### PR TITLE
API get current user roles and get user role, fix assign logic

### DIFF
--- a/App.BLL/Implementations/AccountService.cs
+++ b/App.BLL/Implementations/AccountService.cs
@@ -1,0 +1,47 @@
+﻿using System;
+using App.BLL.Interfaces;
+using App.Commons.ResponseModel;
+using App.DAL.Interfaces;
+using App.Entities.DTOs.Accounts;
+using Microsoft.AspNetCore.Http;
+
+namespace App.BLL.Implementations;
+
+public class AccountService : IAccountService
+{
+    private readonly IIdentityRepository _identityRepository;
+
+    public AccountService(IIdentityRepository identityRepository)
+    {
+        _identityRepository = identityRepository;
+    }
+
+    public async Task<BaseResponseModel<List<RoleOverviewDTO>>> GetAllUserRoles(long userId)
+    {
+        try
+        {
+            var roles = await _identityRepository.GetUserRolesAsync(userId);
+            if (roles != null)
+            {
+                return new BaseResponseModel<List<RoleOverviewDTO>>
+                {
+                    IsSuccess = true,
+                    StatusCode = StatusCodes.Status200OK,
+                    Message = "Lấy danh sách quyền thành công",
+                    Data = roles.Select(r => new RoleOverviewDTO(r)).ToList() ?? new List<RoleOverviewDTO>()
+                };
+            }
+            return new BaseResponseModel<List<RoleOverviewDTO>>
+            {
+                IsSuccess = false,
+                StatusCode = StatusCodes.Status200OK,
+                Message = "Danh sách role rỗng",
+                Data = new List<RoleOverviewDTO>()
+            };
+        }
+        catch (Exception)
+        {
+            throw;
+        }
+    }
+}

--- a/App.BLL/Implementations/PerformanceMatchingService.cs
+++ b/App.BLL/Implementations/PerformanceMatchingService.cs
@@ -1,0 +1,343 @@
+﻿using Microsoft.EntityFrameworkCore;
+using App.BLL.Interfaces;
+using App.DAL.UnitOfWork;
+using App.DAL.Queries;
+using App.Entities.DTOs.ReviewerAssignment;
+using App.Entities.Entities.App;
+using App.Entities.Entities.Core;
+using App.Entities.Enums;
+using App.Entities.Constants;
+using System.Linq.Expressions;
+
+namespace App.BLL.Implementations;
+
+public class PerformanceMatchingService : IPerformanceMatchingService
+{
+    private readonly IUnitOfWork _unitOfWork;
+
+    public PerformanceMatchingService(IUnitOfWork unitOfWork)
+    {
+        _unitOfWork = unitOfWork;
+    }
+
+    public async Task<decimal> CalculateOverallPerformanceScoreAsync(int reviewerId, int? semesterId = null)
+    {
+        var performanceOptions = new QueryOptions<ReviewerPerformance>
+        {
+            Predicate = rp => rp.ReviewerId == reviewerId &&
+                            (!semesterId.HasValue || rp.SemesterId == semesterId.Value)
+        };
+        var performances = await _unitOfWork.GetRepo<ReviewerPerformance>().GetAllAsync(performanceOptions);
+
+        if (!performances.Any())
+            return 2.5m; // Default neutral score for new reviewers
+
+        // Lấy performance gần nhất hoặc của semester cụ thể
+        var latestPerformance = performances.OrderByDescending(p => p.LastUpdated).First();
+
+        // Tính các component scores
+        var reliabilityScore = await CalculateReliabilityScoreAsync(reviewerId, semesterId);
+        var efficiencyScore = await CalculateEfficiencyScoreAsync(reviewerId, semesterId);
+        var consistencyScore = await CalculateConsistencyScoreAsync(reviewerId, semesterId);
+        var qualityScore = (decimal)(latestPerformance.QualityRating ?? 2.5m);
+
+        // Weighted average: Reliability 40%, Quality 30%, Efficiency 20%, Consistency 10%
+        var overallScore = (reliabilityScore * 0.4m) +
+                          (qualityScore * 0.3m) +
+                          (efficiencyScore * 0.2m) +
+                          (consistencyScore * 0.1m);
+
+        return Math.Min(5.0m, Math.Max(0.0m, overallScore));
+    }
+
+    public async Task<decimal> CalculateReliabilityScoreAsync(int reviewerId, int? semesterId = null)
+    {
+        var performanceOptions = new QueryOptions<ReviewerPerformance>
+        {
+            Predicate = rp => rp.ReviewerId == reviewerId &&
+                            (!semesterId.HasValue || rp.SemesterId == semesterId.Value)
+        };
+        var performances = await _unitOfWork.GetRepo<ReviewerPerformance>().GetAllAsync(performanceOptions);
+
+        if (!performances.Any())
+            return 2.5m;
+
+        var latestPerformance = performances.OrderByDescending(p => p.LastUpdated).First();
+
+        decimal reliabilityScore = 0;
+        int factors = 0;
+
+        // On-time completion rate (0-1) -> (0-5)
+        if (latestPerformance.OnTimeRate.HasValue)
+        {
+            reliabilityScore += (decimal)latestPerformance.OnTimeRate.Value * 5;
+            factors++;
+        }
+
+        // Completion rate
+        if (latestPerformance.TotalAssignments > 0)
+        {
+            decimal completionRate = (decimal)latestPerformance.CompletedAssignments / latestPerformance.TotalAssignments;
+            reliabilityScore += completionRate * 5;
+            factors++;
+        }
+
+        // Consistency in assignment acceptance (bonus for experienced reviewers)
+        if (latestPerformance.TotalAssignments >= 10)
+        {
+            reliabilityScore += 0.5m; // Experience bonus
+        }
+
+        return factors > 0 ? Math.Min(5.0m, reliabilityScore / factors) : 2.5m;
+    }
+
+    public async Task<decimal> CalculateEfficiencyScoreAsync(int reviewerId, int? semesterId = null)
+    {
+        var performanceOptions = new QueryOptions<ReviewerPerformance>
+        {
+            Predicate = rp => rp.ReviewerId == reviewerId &&
+                            (!semesterId.HasValue || rp.SemesterId == semesterId.Value)
+        };
+        var performances = await _unitOfWork.GetRepo<ReviewerPerformance>().GetAllAsync(performanceOptions);
+
+        if (!performances.Any())
+            return 2.5m;
+
+        var latestPerformance = performances.OrderByDescending(p => p.LastUpdated).First();
+
+        // Average time efficiency (lower time = higher score)
+        // Assume ideal review time is 90 minutes, max acceptable is 180 minutes
+        var averageTime = latestPerformance.AverageTimeMinutes;
+        if (averageTime <= 0)
+            return 2.5m;
+
+        decimal efficiencyScore;
+        if (averageTime <= 60) // Very fast
+            efficiencyScore = 5.0m;
+        else if (averageTime <= 90) // Ideal time
+            efficiencyScore = 4.5m;
+        else if (averageTime <= 120) // Good time
+            efficiencyScore = 4.0m;
+        else if (averageTime <= 150) // Acceptable time
+            efficiencyScore = 3.0m;
+        else if (averageTime <= 180) // Slow but acceptable
+            efficiencyScore = 2.0m;
+        else // Too slow
+            efficiencyScore = 1.0m;
+
+        return efficiencyScore;
+    }
+
+    public async Task<decimal> CalculateConsistencyScoreAsync(int reviewerId, int? semesterId = null)
+    {
+        var performanceOptions = new QueryOptions<ReviewerPerformance>
+        {
+            Predicate = rp => rp.ReviewerId == reviewerId &&
+                            (!semesterId.HasValue || rp.SemesterId == semesterId.Value)
+        };
+        var performances = await _unitOfWork.GetRepo<ReviewerPerformance>().GetAllAsync(performanceOptions);
+
+        if (!performances.Any())
+            return 2.5m;
+
+        var latestPerformance = performances.OrderByDescending(p => p.LastUpdated).First();
+
+        // Consistency based on average score given (not too high, not too low)
+        // Ideal range is 7.0 - 8.5
+        var avgScore = latestPerformance.AverageScoreGiven;
+        if (!avgScore.HasValue)
+            return 2.5m;
+
+        decimal consistencyScore;
+        var score = (decimal)avgScore.Value;
+
+        if (score >= 7.0m && score <= 8.5m) // Ideal range
+            consistencyScore = 5.0m;
+        else if (score >= 6.5m && score <= 9.0m) // Good range
+            consistencyScore = 4.0m;
+        else if (score >= 6.0m && score <= 9.5m) // Acceptable range
+            consistencyScore = 3.0m;
+        else if (score >= 5.5m && score <= 10.0m) // Wide range but acceptable
+            consistencyScore = 2.0m;
+        else // Too extreme (too harsh or too lenient)
+            consistencyScore = 1.0m;
+
+        return consistencyScore;
+    }
+
+    public async Task<List<ReviewerMatchingResult>> FindBestPerformingReviewersAsync(
+        int submissionId, AutoAssignReviewerDTO criteria)
+    {
+        // Get all reviewers with their performance data
+        var userRoleOptions = new QueryOptions<UserRole>
+        {
+            IncludeProperties = new List<Expression<Func<UserRole, object>>>
+            {
+                ur => ur.User,
+                ur => ur.User.ReviewerPerformances,
+                ur => ur.Role
+            },
+            Predicate = ur => ur.Role.Name == SystemRoleConstants.Reviewer
+        };
+        var userRoles = await _unitOfWork.GetRepo<UserRole>().GetAllAsync(userRoleOptions);
+        var reviewers = userRoles.Select(ur => ur.User).Distinct().ToList();
+
+        // Get already assigned reviewers for this submission
+        var assignedReviewerOptions = new QueryOptions<ReviewerAssignment>
+        {
+            Predicate = ra => ra.SubmissionId == submissionId
+        };
+        var assignedReviewers = await _unitOfWork.GetRepo<ReviewerAssignment>().GetAllAsync(assignedReviewerOptions);
+        var assignedReviewerIds = assignedReviewers.Select(ra => ra.ReviewerId).ToHashSet();
+
+        var matchingResults = new List<ReviewerMatchingResult>();
+
+        foreach (var reviewer in reviewers)
+        {
+            // Skip if already assigned
+            if (assignedReviewerIds.Contains(reviewer.Id))
+                continue;
+
+            var matchingResult = new ReviewerMatchingResult
+            {
+                ReviewerId = reviewer.Id,
+                ReviewerName = reviewer.UserName,
+                ReviewerEmail = reviewer.Email
+            };
+
+            // Calculate performance-based scores
+            matchingResult.PerformanceScore = await CalculateOverallPerformanceScoreAsync(reviewer.Id);
+            matchingResult.WorkloadScore = await CalculateWorkloadScoreAsync(reviewer.Id);
+
+            // Get performance details
+            var performance = reviewer.ReviewerPerformances.FirstOrDefault();
+            if (performance != null)
+            {
+                matchingResult.CompletedAssignments = performance.CompletedAssignments;
+                matchingResult.AverageScoreGiven = performance.AverageScoreGiven;
+                matchingResult.OnTimeRate = performance.OnTimeRate;
+                matchingResult.QualityRating = performance.QualityRating;
+
+                // Set skill match score based on performance (higher performance = better "match")
+                matchingResult.SkillMatchScore = matchingResult.PerformanceScore;
+            }
+            else
+            {
+                // New reviewer - neutral scores
+                matchingResult.SkillMatchScore = 2.5m;
+                matchingResult.CompletedAssignments = 0;
+            }
+
+            // Get current workload
+            var activeAssignmentOptions = new QueryOptions<ReviewerAssignment>
+            {
+                Predicate = ra => ra.ReviewerId == reviewer.Id &&
+                               (ra.Status == AssignmentStatus.Assigned || ra.Status == AssignmentStatus.InProgress)
+            };
+            var activeAssignments = await _unitOfWork.GetRepo<ReviewerAssignment>().GetAllAsync(activeAssignmentOptions);
+            matchingResult.CurrentActiveAssignments = activeAssignments.Count();
+
+            // Check eligibility based on performance criteria
+            matchingResult.IsEligible = IsReviewerEligibleByPerformance(matchingResult, criteria);
+            if (!matchingResult.IsEligible)
+            {
+                matchingResult.IneligibilityReasons = GetPerformanceIneligibilityReasons(matchingResult, criteria);
+            }
+
+            // Calculate overall score (performance-focused)
+            matchingResult.OverallScore = CalculatePerformanceBasedOverallScore(matchingResult, criteria);
+
+            matchingResults.Add(matchingResult);
+        }
+
+        return matchingResults.OrderByDescending(r => r.OverallScore).ToList();
+    }
+
+    #region Private Helper Methods
+
+    private async Task<decimal> CalculateWorkloadScoreAsync(int reviewerId)
+    {
+        var activeAssignmentOptions = new QueryOptions<ReviewerAssignment>
+        {
+            Predicate = ra => ra.ReviewerId == reviewerId &&
+                           (ra.Status == AssignmentStatus.Assigned || ra.Status == AssignmentStatus.InProgress)
+        };
+        var activeAssignments = await _unitOfWork.GetRepo<ReviewerAssignment>().GetAllAsync(activeAssignmentOptions);
+
+        int activeCount = activeAssignments.Count();
+
+        // Workload score: lower load = higher score
+        // 0 assignments = 5.0, 10+ assignments = 0.0
+        return Math.Max(0, 5.0m - (activeCount * 0.5m));
+    }
+
+    private bool IsReviewerEligibleByPerformance(ReviewerMatchingResult result, AutoAssignReviewerDTO criteria)
+    {
+        // Check performance threshold instead of skill match
+        if (result.PerformanceScore < criteria.MinimumSkillMatchScore)
+            return false;
+
+        // Check maximum workload
+        if (result.CurrentActiveAssignments >= criteria.MaxWorkload)
+            return false;
+
+        // Additional performance criteria
+        if (criteria.PrioritizeHighPerformance)
+        {
+            // Require minimum quality rating for high-performance mode
+            if (result.QualityRating.HasValue && result.QualityRating < 3.0m)
+                return false;
+
+            // Require reasonable on-time rate
+            if (result.OnTimeRate.HasValue && result.OnTimeRate < 0.7m)
+                return false;
+        }
+
+        return true;
+    }
+
+    private List<string> GetPerformanceIneligibilityReasons(ReviewerMatchingResult result, AutoAssignReviewerDTO criteria)
+    {
+        var reasons = new List<string>();
+
+        if (result.PerformanceScore < criteria.MinimumSkillMatchScore)
+            reasons.Add($"Performance score ({result.PerformanceScore:F2}) dưới mức yêu cầu ({criteria.MinimumSkillMatchScore:F2})");
+
+        if (result.CurrentActiveAssignments >= criteria.MaxWorkload)
+            reasons.Add($"Quá tải assignment ({result.CurrentActiveAssignments}/{criteria.MaxWorkload})");
+
+        if (criteria.PrioritizeHighPerformance)
+        {
+            if (result.QualityRating.HasValue && result.QualityRating < 3.0m)
+                reasons.Add($"Quality rating thấp ({result.QualityRating:F2})");
+
+            if (result.OnTimeRate.HasValue && result.OnTimeRate < 0.7m)
+                reasons.Add($"On-time rate thấp ({result.OnTimeRate:F2})");
+        }
+
+        return reasons;
+    }
+
+    private decimal CalculatePerformanceBasedOverallScore(ReviewerMatchingResult result, AutoAssignReviewerDTO criteria)
+    {
+        if (!result.IsEligible)
+            return 0;
+
+        // Weight factors for performance-based scoring
+        decimal performanceWeight = criteria.PrioritizeHighPerformance ? 0.6m : 0.4m;
+        decimal workloadWeight = 0.3m;
+        decimal experienceWeight = 0.1m;
+
+        // Experience bonus based on completed assignments
+        decimal experienceScore = Math.Min(5.0m, result.CompletedAssignments * 0.1m);
+
+        decimal overallScore =
+            (result.PerformanceScore * performanceWeight) +
+            (result.WorkloadScore * workloadWeight) +
+            (experienceScore * experienceWeight);
+
+        return Math.Min(5.0m, overallScore);
+    }
+
+    #endregion
+}

--- a/App.BLL/Interfaces/IAccountService.cs
+++ b/App.BLL/Interfaces/IAccountService.cs
@@ -1,0 +1,10 @@
+﻿using System;
+using App.Commons.ResponseModel;
+using App.Entities.DTOs.Accounts;
+
+namespace App.BLL.Interfaces;
+
+public interface IAccountService
+{
+    Task<BaseResponseModel<List<RoleOverviewDTO>>> GetAllUserRoles(long userId);
+}

--- a/App.BLL/Interfaces/IPerformanceMatchingService.cs
+++ b/App.BLL/Interfaces/IPerformanceMatchingService.cs
@@ -1,0 +1,33 @@
+﻿using App.Entities.DTOs.ReviewerAssignment;
+
+namespace App.BLL.Interfaces;
+
+public interface IPerformanceMatchingService
+{
+    /// <summary>
+    /// Tính performance score tổng hợp của reviewer
+    /// </summary>
+    Task<decimal> CalculateOverallPerformanceScoreAsync(int reviewerId, int? semesterId = null);
+
+    /// <summary>
+    /// Tìm reviewer tốt nhất dựa trên performance
+    /// </summary>
+    Task<List<ReviewerMatchingResult>> FindBestPerformingReviewersAsync(
+        int submissionId,
+        AutoAssignReviewerDTO criteria);
+
+    /// <summary>
+    /// Tính reliability score (độ tin cậy) của reviewer
+    /// </summary>
+    Task<decimal> CalculateReliabilityScoreAsync(int reviewerId, int? semesterId = null);
+
+    /// <summary>
+    /// Tính efficiency score (hiệu quả) của reviewer
+    /// </summary>
+    Task<decimal> CalculateEfficiencyScoreAsync(int reviewerId, int? semesterId = null);
+
+    /// <summary>
+    /// Tính consistency score (tính nhất quán) của reviewer
+    /// </summary>
+    Task<decimal> CalculateConsistencyScoreAsync(int reviewerId, int? semesterId = null);
+}

--- a/App.DAL/Implementations/IdentityRepository.cs
+++ b/App.DAL/Implementations/IdentityRepository.cs
@@ -298,6 +298,23 @@ public class IdentityRepository : IIdentityRepository
         }
     }
 
+    public async Task<List<Role>> GetUserRolesAsync(long userId)
+    {
+        var user = await _userManager.FindByIdAsync(userId.ToString());
+        if (user == null)
+            return null;
+
+        var roleNames = await _userManager.GetRolesAsync(user);
+        if (roleNames == null || roleNames.Count == 0)
+            return new List<Role>();
+
+        var roles = await _roleManager.Roles
+            .Where(r => roleNames.Contains(r.Name))
+            .ToListAsync();
+
+        return roles;
+    }
+
     public Task<bool> VerifyPermission(long userId, string claim)
     {
         throw new NotImplementedException();

--- a/App.DAL/Interfaces/IIdentityRepository.cs
+++ b/App.DAL/Interfaces/IIdentityRepository.cs
@@ -111,6 +111,13 @@ public interface IIdentityRepository
     Task<string[]> GetRolesAsync(long userId);
 
     /// <summary>
+    /// Get list roles by userId
+    /// </summary>
+    /// <param name="userId">The user identified.</param>
+    /// <returns></returns>
+    Task<List<Role>> GetUserRolesAsync(long userId);
+
+    /// <summary>
     /// Verified user can be access to the function.
     /// </summary>
     Task<bool> VerifyPermission(long userId, string claim);

--- a/App.Entities/DTOs/Accounts/RoleOverviewDTO.cs
+++ b/App.Entities/DTOs/Accounts/RoleOverviewDTO.cs
@@ -1,0 +1,16 @@
+﻿using System;
+using App.Entities.Entities.Core;
+
+namespace App.Entities.DTOs.Accounts;
+
+public class RoleOverviewDTO
+{
+    public int Id { get; set; }
+    public string RoleName { get; set; } = null!;
+
+    public RoleOverviewDTO(Role role)
+    {
+        Id = role.Id;
+        RoleName = role.Name!;
+    }
+}

--- a/App.Entities/DTOs/ReviewerAssignment/AutoAssignReviewerDTO.cs
+++ b/App.Entities/DTOs/ReviewerAssignment/AutoAssignReviewerDTO.cs
@@ -29,10 +29,10 @@ public class AutoAssignReviewerDTO
     public DateTime? Deadline { get; set; }
 
     /// <summary>
-    /// Minimum skill match score yêu cầu (0-5)
+    /// Minimum performance score yêu cầu (0-5) - thay thế cho skill match score
     /// </summary>
-    [Range(0, 5, ErrorMessage = "Minimum skill match score phải từ 0 đến 5")]
-    public decimal MinimumSkillMatchScore { get; set; } = 2.0m;
+    [Range(0, 5, ErrorMessage = "Minimum performance score phải từ 0 đến 5")]
+    public decimal MinimumSkillMatchScore { get; set; } = 2.5m; // Rename property later to MinimumPerformanceScore
 
     /// <summary>
     /// Maximum workload cho reviewer (số assignment đang active)
@@ -46,7 +46,19 @@ public class AutoAssignReviewerDTO
     public bool PrioritizeHighPerformance { get; set; } = true;
 
     /// <summary>
-    /// Skill tags của đề tài (tùy chọn, để override auto detect)
+    /// Minimum quality rating yêu cầu (chỉ áp dụng khi PrioritizeHighPerformance = true)
     /// </summary>
-    public List<string> TopicSkillTags { get; set; } = new();
+    [Range(0, 5, ErrorMessage = "Minimum quality rating phải từ 0 đến 5")]
+    public decimal MinimumQualityRating { get; set; } = 3.0m;
+
+    /// <summary>
+    /// Minimum on-time rate yêu cầu (0-1, chỉ áp dụng khi PrioritizeHighPerformance = true)
+    /// </summary>
+    [Range(0, 1, ErrorMessage = "Minimum on-time rate phải từ 0 đến 1")]
+    public decimal MinimumOnTimeRate { get; set; } = 0.7m;
+
+    /// <summary>
+    /// Có ưu tiên reviewer có kinh nghiệm không (nhiều assignment đã hoàn thành)
+    /// </summary>
+    public bool PrioritizeExperience { get; set; } = false;
 }

--- a/CapBot.api/Controllers/AccountController.cs
+++ b/CapBot.api/Controllers/AccountController.cs
@@ -1,0 +1,105 @@
+﻿using App.BLL.Interfaces;
+using App.Commons;
+using App.Commons.BaseAPI;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Swashbuckle.AspNetCore.Annotations;
+
+namespace CapBot.api.Controllers
+{
+    [Route("api/[controller]")]
+    [ApiController]
+    public class AccountController : BaseAPIController
+    {
+        private readonly IAccountService _accountService;
+        private readonly ILogger<AccountController> _logger;
+        public AccountController(IAccountService accountService, ILogger<AccountController> logger)
+        {
+            _accountService = accountService;
+            _logger = logger;
+        }
+
+        /// <summary>
+        /// Lấy danh sách chủ đề
+        /// </summary>
+        /// <param name="query">Thông tin lọc</param>
+        /// <returns>Danh sách chủ đề</returns>
+        /// <remarks>
+        /// Lấy danh sách chủ đề với bộ lọc tùy chọn
+        ///
+        /// Sample request:
+        ///
+        ///     GET /api/topic/list
+        ///     GET /api/topic/list?semesterId=1
+        ///     GET /api/topic/list?categoryId=1
+        ///     GET /api/topic/list?semesterId=1&categoryId=1
+        ///
+        /// </remarks>
+        [Authorize]
+        [HttpGet("user-roles/{userId}")]
+        [SwaggerOperation(
+            Summary = "Lấy danh sách quyền của user",
+            Description = "Lấy danh sách quyền của user"
+        )]
+        [SwaggerResponse(200, "Lấy danh sách quyền thành công")]
+        [SwaggerResponse(401, "Lỗi xác thực")]
+        [SwaggerResponse(500, "Lỗi máy chủ nội bộ")]
+        [Consumes("application/json")]
+        [Produces("application/json")]
+        public async Task<IActionResult> GetUserRoles([FromRoute] long userId)
+        {
+            try
+            {
+                var result = await _accountService.GetAllUserRoles(userId);
+                return ProcessServiceResponse(result);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Error occurred while getting all user roles");
+                return Error(ConstantModel.ErrorMessage);
+            }
+        }
+
+        /// <summary>
+        /// Lấy danh sách chủ đề
+        /// </summary>
+        /// <param name="query">Thông tin lọc</param>
+        /// <returns>Danh sách chủ đề</returns>
+        /// <remarks>
+        /// Lấy danh sách chủ đề với bộ lọc tùy chọn
+        ///
+        /// Sample request:
+        ///
+        ///     GET /api/topic/list
+        ///     GET /api/topic/list?semesterId=1
+        ///     GET /api/topic/list?categoryId=1
+        ///     GET /api/topic/list?semesterId=1&categoryId=1
+        ///
+        /// </remarks>
+        [Authorize]
+        [HttpGet("my-user-roles")]
+        [SwaggerOperation(
+            Summary = "Lấy danh sách quyền của user hiện tại",
+            Description = "Lấy danh sách quyền của user hiện tại"
+        )]
+        [SwaggerResponse(200, "Lấy danh sách quyền thành công")]
+        [SwaggerResponse(401, "Lỗi xác thực")]
+        [SwaggerResponse(500, "Lỗi máy chủ nội bộ")]
+        [Consumes("application/json")]
+        [Produces("application/json")]
+        public async Task<IActionResult> GetMyUserRoles()
+        {
+            try
+            {
+                var result = await _accountService.GetAllUserRoles(UserId);
+                return ProcessServiceResponse(result);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Error occurred while getting all user roles");
+                return Error(ConstantModel.ErrorMessage);
+            }
+        }
+    }
+}

--- a/CapBot.api/Logs/log20250811.txt
+++ b/CapBot.api/Logs/log20250811.txt
@@ -2181,3 +2181,942 @@ System.IO.IOException: Received an unexpected EOF or 0 bytes from the transport 
 2025-08-11 12:49:58.350 +07:00 [DBG] The connection queue processing loop for 0HNEOJBFBE7Q0 completed.
 2025-08-11 12:49:58.352 +07:00 [DBG] Connection id "0HNEOJBFBE7Q0" stopped.
 2025-08-11 12:49:58.357 +07:00 [DBG] Hosting stopped
+2025-08-11 14:37:59.869 +07:00 [DBG] An 'IServiceProvider' was created for internal use by Entity Framework.
+2025-08-11 14:37:59.943 +07:00 [INF] User profile is available. Using 'C:\Users\Admin\AppData\Local\ASP.NET\DataProtection-Keys' as key repository and Windows DPAPI to encrypt keys at rest.
+2025-08-11 14:38:00.120 +07:00 [DBG] No relationship from 'ReviewerAssignment' to 'User' has been configured by convention because there are multiple properties on one entity type - {'AssignedByUser', 'Reviewer'} that could be matched with the properties on the other entity type - {'ReviewerAssignments'}. This message can be disregarded if explicit configuration has been specified in 'OnModelCreating'.
+2025-08-11 14:38:00.133 +07:00 [DBG] No relationship from 'SubmissionWorkflowLog' to 'WorkflowState' has been configured by convention because there are multiple properties on one entity type - {'FromState', 'ToState'} that could be matched with the properties on the other entity type - {'FromStateLogs', 'ToStateLogs'}. This message can be disregarded if explicit configuration has been specified in 'OnModelCreating'.
+2025-08-11 14:38:00.141 +07:00 [DBG] No relationship from 'User' to 'ReviewerAssignment' has been configured by convention because there are multiple properties on one entity type - {'ReviewerAssignments'} that could be matched with the properties on the other entity type - {'AssignedByUser', 'Reviewer'}. This message can be disregarded if explicit configuration has been specified in 'OnModelCreating'.
+2025-08-11 14:38:00.143 +07:00 [DBG] No relationship from 'WorkflowState' to 'SubmissionWorkflowLog' has been configured by convention because there are multiple properties on one entity type - {'FromStateLogs', 'ToStateLogs'} that could be matched with the properties on the other entity type - {'FromState', 'ToState'}. This message can be disregarded if explicit configuration has been specified in 'OnModelCreating'.
+2025-08-11 14:38:00.143 +07:00 [DBG] No relationship from 'WorkflowState' to 'WorkflowTransition' has been configured by convention because there are multiple properties on one entity type - {'FromTransitions', 'ToTransitions'} that could be matched with the properties on the other entity type - {'FromState', 'ToState'}. This message can be disregarded if explicit configuration has been specified in 'OnModelCreating'.
+2025-08-11 14:38:00.144 +07:00 [DBG] No relationship from 'WorkflowTransition' to 'WorkflowState' has been configured by convention because there are multiple properties on one entity type - {'FromState', 'ToState'} that could be matched with the properties on the other entity type - {'FromTransitions', 'ToTransitions'}. This message can be disregarded if explicit configuration has been specified in 'OnModelCreating'.
+2025-08-11 14:38:00.269 +07:00 [DBG] No relationship from 'ReviewerAssignment' to 'User' has been configured by convention because there are multiple properties on one entity type - {'AssignedByUser', 'Reviewer'} that could be matched with the properties on the other entity type - {'ReviewerAssignments'}. This message can be disregarded if explicit configuration has been specified in 'OnModelCreating'.
+2025-08-11 14:38:00.272 +07:00 [DBG] No relationship from 'User' to 'ReviewerAssignment' has been configured by convention because there are multiple properties on one entity type - {'ReviewerAssignments'} that could be matched with the properties on the other entity type - {'AssignedByUser', 'Reviewer'}. This message can be disregarded if explicit configuration has been specified in 'OnModelCreating'.
+2025-08-11 14:38:00.287 +07:00 [DBG] No relationship from 'WorkflowTransition' to 'WorkflowState' has been configured by convention because there are multiple properties on one entity type - {'FromState', 'ToState'} that could be matched with the properties on the other entity type - {'FromTransitions', 'ToTransitions'}. This message can be disregarded if explicit configuration has been specified in 'OnModelCreating'.
+2025-08-11 14:38:00.287 +07:00 [DBG] No relationship from 'WorkflowState' to 'SubmissionWorkflowLog' has been configured by convention because there are multiple properties on one entity type - {'FromStateLogs', 'ToStateLogs'} that could be matched with the properties on the other entity type - {'FromState', 'ToState'}. This message can be disregarded if explicit configuration has been specified in 'OnModelCreating'.
+2025-08-11 14:38:00.287 +07:00 [DBG] No relationship from 'WorkflowState' to 'WorkflowTransition' has been configured by convention because there are multiple properties on one entity type - {'FromTransitions', 'ToTransitions'} that could be matched with the properties on the other entity type - {'FromState', 'ToState'}. This message can be disregarded if explicit configuration has been specified in 'OnModelCreating'.
+2025-08-11 14:38:00.288 +07:00 [DBG] No relationship from 'WorkflowState' to 'SubmissionWorkflowLog' has been configured by convention because there are multiple properties on one entity type - {'FromStateLogs', 'ToStateLogs'} that could be matched with the properties on the other entity type - {'FromState', 'ToState'}. This message can be disregarded if explicit configuration has been specified in 'OnModelCreating'.
+2025-08-11 14:38:00.292 +07:00 [DBG] No relationship from 'SubmissionWorkflowLog' to 'WorkflowState' has been configured by convention because there are multiple properties on one entity type - {'FromState', 'ToState'} that could be matched with the properties on the other entity type - {'FromStateLogs', 'ToStateLogs'}. This message can be disregarded if explicit configuration has been specified in 'OnModelCreating'.
+2025-08-11 14:38:00.292 +07:00 [DBG] No relationship from 'WorkflowState' to 'SubmissionWorkflowLog' has been configured by convention because there are multiple properties on one entity type - {'FromStateLogs', 'ToStateLogs'} that could be matched with the properties on the other entity type - {'FromState', 'ToState'}. This message can be disregarded if explicit configuration has been specified in 'OnModelCreating'.
+2025-08-11 14:38:00.312 +07:00 [DBG] The index {'LecturerId'} was not created on entity type 'LecturerSkill' as the properties are already covered by the index {'LecturerId', 'SkillTag'}.
+2025-08-11 14:38:00.313 +07:00 [DBG] The index {'SemesterId'} was not created on entity type 'Phase' as the properties are already covered by the index {'SemesterId', 'PhaseTypeId'}.
+2025-08-11 14:38:00.313 +07:00 [DBG] The index {'AssignmentId'} was not created on entity type 'Review' as the properties are already covered by the index {'AssignmentId', 'Status'}.
+2025-08-11 14:38:00.314 +07:00 [DBG] The index {'ReviewId'} was not created on entity type 'ReviewComment' as the properties are already covered by the index {'ReviewId', 'SectionName'}.
+2025-08-11 14:38:00.314 +07:00 [DBG] The index {'ReviewId'} was not created on entity type 'ReviewCriteriaScore' as the properties are already covered by the index {'ReviewId', 'CriteriaId'}.
+2025-08-11 14:38:00.314 +07:00 [DBG] The index {'ReviewerId'} was not created on entity type 'ReviewerAssignment' as the properties are already covered by the index {'ReviewerId', 'Status'}.
+2025-08-11 14:38:00.314 +07:00 [DBG] The index {'SubmissionId'} was not created on entity type 'ReviewerAssignment' as the properties are already covered by the index {'SubmissionId', 'ReviewerId'}.
+2025-08-11 14:38:00.315 +07:00 [DBG] The index {'ReviewerId'} was not created on entity type 'ReviewerPerformance' as the properties are already covered by the index {'ReviewerId', 'SemesterId'}.
+2025-08-11 14:38:00.315 +07:00 [DBG] The index {'PhaseId'} was not created on entity type 'Submission' as the properties are already covered by the index {'PhaseId', 'Status'}.
+2025-08-11 14:38:00.315 +07:00 [DBG] The index {'PhaseId'} was not created on entity type 'Submission' as the properties are already covered by the index {'PhaseId', 'Status', 'SubmittedAt'}.
+2025-08-11 14:38:00.315 +07:00 [DBG] The index {'TopicVersionId'} was not created on entity type 'Submission' as the properties are already covered by the index {'TopicVersionId', 'PhaseId', 'SubmissionRound'}.
+2025-08-11 14:38:00.315 +07:00 [DBG] The index {'SubmissionId'} was not created on entity type 'SubmissionWorkflowLog' as the properties are already covered by the index {'SubmissionId', 'CreatedAt'}.
+2025-08-11 14:38:00.315 +07:00 [DBG] The index {'UserId'} was not created on entity type 'SystemNotification' as the properties are already covered by the index {'UserId', 'IsRead', 'CreatedAt'}.
+2025-08-11 14:38:00.315 +07:00 [DBG] The index {'SemesterId'} was not created on entity type 'Topic' as the properties are already covered by the index {'SemesterId', 'IsApproved'}.
+2025-08-11 14:38:00.316 +07:00 [DBG] The index {'SupervisorId'} was not created on entity type 'Topic' as the properties are already covered by the index {'SupervisorId', 'SemesterId'}.
+2025-08-11 14:38:00.316 +07:00 [DBG] The index {'TopicId'} was not created on entity type 'TopicVersion' as the properties are already covered by the index {'TopicId', 'Status'}.
+2025-08-11 14:38:00.316 +07:00 [DBG] The index {'TopicId'} was not created on entity type 'TopicVersion' as the properties are already covered by the index {'TopicId', 'VersionNumber'}.
+2025-08-11 14:38:00.316 +07:00 [DBG] The index {'UserId'} was not created on entity type 'UserRole' as the properties are already covered by the index {'UserId', 'RoleId'}.
+2025-08-11 14:38:00.316 +07:00 [DBG] The index {'UserId'} was not created on entity type 'UserToken' as the properties are already covered by the index {'UserId', 'LoginProvider', 'Name'}.
+2025-08-11 14:38:00.420 +07:00 [WRN] The 'ProficiencyLevels' property 'ProficiencyLevel' on entity type 'LecturerSkill' is configured with a database-generated default, but has no configured sentinel value. The database-generated default will always be used for inserts when the property has the value '0', since this is the CLR default for the 'ProficiencyLevels' type. Consider using a nullable type, using a nullable backing field, or setting the sentinel value for the property to ensure the database default is used when, and only when, appropriate. See https://aka.ms/efcore-docs-default-values for more information.
+2025-08-11 14:38:00.421 +07:00 [WRN] The 'ReviewRecommendations' property 'Recommendation' on entity type 'Review' is configured with a database-generated default, but has no configured sentinel value. The database-generated default will always be used for inserts when the property has the value '0', since this is the CLR default for the 'ReviewRecommendations' type. Consider using a nullable type, using a nullable backing field, or setting the sentinel value for the property to ensure the database default is used when, and only when, appropriate. See https://aka.ms/efcore-docs-default-values for more information.
+2025-08-11 14:38:00.421 +07:00 [WRN] The 'ReviewStatus' property 'Status' on entity type 'Review' is configured with a database-generated default, but has no configured sentinel value. The database-generated default will always be used for inserts when the property has the value '0', since this is the CLR default for the 'ReviewStatus' type. Consider using a nullable type, using a nullable backing field, or setting the sentinel value for the property to ensure the database default is used when, and only when, appropriate. See https://aka.ms/efcore-docs-default-values for more information.
+2025-08-11 14:38:00.422 +07:00 [WRN] The 'CommentTypes' property 'CommentType' on entity type 'ReviewComment' is configured with a database-generated default, but has no configured sentinel value. The database-generated default will always be used for inserts when the property has the value '0', since this is the CLR default for the 'CommentTypes' type. Consider using a nullable type, using a nullable backing field, or setting the sentinel value for the property to ensure the database default is used when, and only when, appropriate. See https://aka.ms/efcore-docs-default-values for more information.
+2025-08-11 14:38:00.423 +07:00 [WRN] The 'PriorityLevels' property 'Priority' on entity type 'ReviewComment' is configured with a database-generated default, but has no configured sentinel value. The database-generated default will always be used for inserts when the property has the value '0', since this is the CLR default for the 'PriorityLevels' type. Consider using a nullable type, using a nullable backing field, or setting the sentinel value for the property to ensure the database default is used when, and only when, appropriate. See https://aka.ms/efcore-docs-default-values for more information.
+2025-08-11 14:38:00.423 +07:00 [WRN] The 'AssignmentTypes' property 'AssignmentType' on entity type 'ReviewerAssignment' is configured with a database-generated default, but has no configured sentinel value. The database-generated default will always be used for inserts when the property has the value '0', since this is the CLR default for the 'AssignmentTypes' type. Consider using a nullable type, using a nullable backing field, or setting the sentinel value for the property to ensure the database default is used when, and only when, appropriate. See https://aka.ms/efcore-docs-default-values for more information.
+2025-08-11 14:38:00.423 +07:00 [WRN] The 'AssignmentStatus' property 'Status' on entity type 'ReviewerAssignment' is configured with a database-generated default, but has no configured sentinel value. The database-generated default will always be used for inserts when the property has the value '0', since this is the CLR default for the 'AssignmentStatus' type. Consider using a nullable type, using a nullable backing field, or setting the sentinel value for the property to ensure the database default is used when, and only when, appropriate. See https://aka.ms/efcore-docs-default-values for more information.
+2025-08-11 14:38:00.424 +07:00 [WRN] The 'AiCheckStatus' property 'AiCheckStatus' on entity type 'Submission' is configured with a database-generated default, but has no configured sentinel value. The database-generated default will always be used for inserts when the property has the value '0', since this is the CLR default for the 'AiCheckStatus' type. Consider using a nullable type, using a nullable backing field, or setting the sentinel value for the property to ensure the database default is used when, and only when, appropriate. See https://aka.ms/efcore-docs-default-values for more information.
+2025-08-11 14:38:00.424 +07:00 [WRN] The 'SubmissionStatus' property 'Status' on entity type 'Submission' is configured with a database-generated default, but has no configured sentinel value. The database-generated default will always be used for inserts when the property has the value '0', since this is the CLR default for the 'SubmissionStatus' type. Consider using a nullable type, using a nullable backing field, or setting the sentinel value for the property to ensure the database default is used when, and only when, appropriate. See https://aka.ms/efcore-docs-default-values for more information.
+2025-08-11 14:38:00.424 +07:00 [WRN] The 'NotificationTypes' property 'Type' on entity type 'SystemNotification' is configured with a database-generated default, but has no configured sentinel value. The database-generated default will always be used for inserts when the property has the value '0', since this is the CLR default for the 'NotificationTypes' type. Consider using a nullable type, using a nullable backing field, or setting the sentinel value for the property to ensure the database default is used when, and only when, appropriate. See https://aka.ms/efcore-docs-default-values for more information.
+2025-08-11 14:38:00.424 +07:00 [WRN] The 'TopicStatus' property 'Status' on entity type 'TopicVersion' is configured with a database-generated default, but has no configured sentinel value. The database-generated default will always be used for inserts when the property has the value '0', since this is the CLR default for the 'TopicStatus' type. Consider using a nullable type, using a nullable backing field, or setting the sentinel value for the property to ensure the database default is used when, and only when, appropriate. See https://aka.ms/efcore-docs-default-values for more information.
+2025-08-11 14:38:00.522 +07:00 [DBG] Entity Framework Core 8.0.16 initialized 'MyDbContext' using provider 'Microsoft.EntityFrameworkCore.SqlServer:8.0.13' with options: MigrationsAssembly=App.DAL 
+2025-08-11 14:38:00.612 +07:00 [DBG] Compiling query expression: 
+'DbSet<Role>()
+    .FirstOrDefault(r => r.NormalizedName == __normalizedName_0)'
+2025-08-11 14:38:00.740 +07:00 [DBG] Generated query execution expression: 
+'queryContext => ShapedQueryCompilingExpressionVisitor.SingleOrDefaultAsync<Role>(
+    asyncEnumerable: new SingleQueryingEnumerable<Role>(
+        (RelationalQueryContext)queryContext, 
+        RelationalCommandCache.QueryExpression(
+            Projection Mapping:
+                EmptyProjectionMember -> Dictionary<IProperty, int> { [Property: Role.Id (int) Required PK AfterSave:Throw ValueGenerated.OnAdd, 0], [Property: Role.ConcurrencyStamp (string), 1], [Property: Role.IsAdmin (bool) Required, 2], [Property: Role.Name (string), 3], [Property: Role.NormalizedName (string), 4] }
+            SELECT TOP(1) r.Id, r.ConcurrencyStamp, r.IsAdmin, r.Name, r.NormalizedName
+            FROM roles AS r
+            WHERE r.NormalizedName == @__normalizedName_0), 
+        null, 
+        Func<QueryContext, DbDataReader, ResultContext, SingleQueryResultCoordinator, Role>, 
+        App.DAL.Context.MyDbContext, 
+        False, 
+        False, 
+        True
+    ), 
+    cancellationToken: queryContext.CancellationToken)'
+2025-08-11 14:38:00.769 +07:00 [DBG] Creating DbConnection.
+2025-08-11 14:38:00.782 +07:00 [DBG] Created DbConnection. (11ms).
+2025-08-11 14:38:00.785 +07:00 [DBG] Opening connection to database 'capbot_db' on server 'localhost'.
+2025-08-11 14:38:01.003 +07:00 [DBG] Opened connection to database 'capbot_db' on server 'localhost'.
+2025-08-11 14:38:01.005 +07:00 [DBG] Creating DbCommand for 'ExecuteReader'.
+2025-08-11 14:38:01.010 +07:00 [DBG] Created DbCommand for 'ExecuteReader' (2ms).
+2025-08-11 14:38:01.015 +07:00 [DBG] Initialized DbCommand for 'ExecuteReader' (9ms).
+2025-08-11 14:38:01.023 +07:00 [DBG] Executing DbCommand [Parameters=[@__normalizedName_0='?' (Size = 4000)], CommandType='"Text"', CommandTimeout='30']
+SELECT TOP(1) [r].[Id], [r].[ConcurrencyStamp], [r].[IsAdmin], [r].[Name], [r].[NormalizedName]
+FROM [roles] AS [r]
+WHERE [r].[NormalizedName] = @__normalizedName_0
+2025-08-11 14:38:01.076 +07:00 [INF] Executed DbCommand (56ms) [Parameters=[@__normalizedName_0='?' (Size = 4000)], CommandType='"Text"', CommandTimeout='30']
+SELECT TOP(1) [r].[Id], [r].[ConcurrencyStamp], [r].[IsAdmin], [r].[Name], [r].[NormalizedName]
+FROM [roles] AS [r]
+WHERE [r].[NormalizedName] = @__normalizedName_0
+2025-08-11 14:38:01.103 +07:00 [DBG] Context 'MyDbContext' started tracking 'Role' entity. Consider using 'DbContextOptionsBuilder.EnableSensitiveDataLogging' to see key values.
+2025-08-11 14:38:01.118 +07:00 [DBG] Closing data reader to 'capbot_db' on server 'localhost'.
+2025-08-11 14:38:01.123 +07:00 [DBG] A data reader for 'capbot_db' on server 'localhost' is being disposed after spending 43ms reading results.
+2025-08-11 14:38:01.125 +07:00 [DBG] Closing connection to database 'capbot_db' on server 'localhost'.
+2025-08-11 14:38:01.129 +07:00 [DBG] Closed connection to database 'capbot_db' on server 'localhost' (3ms).
+2025-08-11 14:38:01.132 +07:00 [DBG] Opening connection to database 'capbot_db' on server 'localhost'.
+2025-08-11 14:38:01.133 +07:00 [DBG] Opened connection to database 'capbot_db' on server 'localhost'.
+2025-08-11 14:38:01.133 +07:00 [DBG] Creating DbCommand for 'ExecuteReader'.
+2025-08-11 14:38:01.133 +07:00 [DBG] Created DbCommand for 'ExecuteReader' (0ms).
+2025-08-11 14:38:01.134 +07:00 [DBG] Initialized DbCommand for 'ExecuteReader' (0ms).
+2025-08-11 14:38:01.134 +07:00 [DBG] Executing DbCommand [Parameters=[@__normalizedName_0='?' (Size = 4000)], CommandType='"Text"', CommandTimeout='30']
+SELECT TOP(1) [r].[Id], [r].[ConcurrencyStamp], [r].[IsAdmin], [r].[Name], [r].[NormalizedName]
+FROM [roles] AS [r]
+WHERE [r].[NormalizedName] = @__normalizedName_0
+2025-08-11 14:38:01.140 +07:00 [INF] Executed DbCommand (6ms) [Parameters=[@__normalizedName_0='?' (Size = 4000)], CommandType='"Text"', CommandTimeout='30']
+SELECT TOP(1) [r].[Id], [r].[ConcurrencyStamp], [r].[IsAdmin], [r].[Name], [r].[NormalizedName]
+FROM [roles] AS [r]
+WHERE [r].[NormalizedName] = @__normalizedName_0
+2025-08-11 14:38:01.140 +07:00 [DBG] Context 'MyDbContext' started tracking 'Role' entity. Consider using 'DbContextOptionsBuilder.EnableSensitiveDataLogging' to see key values.
+2025-08-11 14:38:01.141 +07:00 [DBG] Closing data reader to 'capbot_db' on server 'localhost'.
+2025-08-11 14:38:01.141 +07:00 [DBG] A data reader for 'capbot_db' on server 'localhost' is being disposed after spending 0ms reading results.
+2025-08-11 14:38:01.141 +07:00 [DBG] Closing connection to database 'capbot_db' on server 'localhost'.
+2025-08-11 14:38:01.141 +07:00 [DBG] Closed connection to database 'capbot_db' on server 'localhost' (0ms).
+2025-08-11 14:38:01.142 +07:00 [DBG] Opening connection to database 'capbot_db' on server 'localhost'.
+2025-08-11 14:38:01.142 +07:00 [DBG] Opened connection to database 'capbot_db' on server 'localhost'.
+2025-08-11 14:38:01.142 +07:00 [DBG] Creating DbCommand for 'ExecuteReader'.
+2025-08-11 14:38:01.142 +07:00 [DBG] Created DbCommand for 'ExecuteReader' (0ms).
+2025-08-11 14:38:01.142 +07:00 [DBG] Initialized DbCommand for 'ExecuteReader' (0ms).
+2025-08-11 14:38:01.143 +07:00 [DBG] Executing DbCommand [Parameters=[@__normalizedName_0='?' (Size = 4000)], CommandType='"Text"', CommandTimeout='30']
+SELECT TOP(1) [r].[Id], [r].[ConcurrencyStamp], [r].[IsAdmin], [r].[Name], [r].[NormalizedName]
+FROM [roles] AS [r]
+WHERE [r].[NormalizedName] = @__normalizedName_0
+2025-08-11 14:38:01.147 +07:00 [INF] Executed DbCommand (4ms) [Parameters=[@__normalizedName_0='?' (Size = 4000)], CommandType='"Text"', CommandTimeout='30']
+SELECT TOP(1) [r].[Id], [r].[ConcurrencyStamp], [r].[IsAdmin], [r].[Name], [r].[NormalizedName]
+FROM [roles] AS [r]
+WHERE [r].[NormalizedName] = @__normalizedName_0
+2025-08-11 14:38:01.147 +07:00 [DBG] Context 'MyDbContext' started tracking 'Role' entity. Consider using 'DbContextOptionsBuilder.EnableSensitiveDataLogging' to see key values.
+2025-08-11 14:38:01.148 +07:00 [DBG] Closing data reader to 'capbot_db' on server 'localhost'.
+2025-08-11 14:38:01.148 +07:00 [DBG] A data reader for 'capbot_db' on server 'localhost' is being disposed after spending 0ms reading results.
+2025-08-11 14:38:01.148 +07:00 [DBG] Closing connection to database 'capbot_db' on server 'localhost'.
+2025-08-11 14:38:01.148 +07:00 [DBG] Closed connection to database 'capbot_db' on server 'localhost' (0ms).
+2025-08-11 14:38:01.149 +07:00 [DBG] Opening connection to database 'capbot_db' on server 'localhost'.
+2025-08-11 14:38:01.149 +07:00 [DBG] Opened connection to database 'capbot_db' on server 'localhost'.
+2025-08-11 14:38:01.149 +07:00 [DBG] Creating DbCommand for 'ExecuteReader'.
+2025-08-11 14:38:01.150 +07:00 [DBG] Created DbCommand for 'ExecuteReader' (0ms).
+2025-08-11 14:38:01.150 +07:00 [DBG] Initialized DbCommand for 'ExecuteReader' (0ms).
+2025-08-11 14:38:01.150 +07:00 [DBG] Executing DbCommand [Parameters=[@__normalizedName_0='?' (Size = 4000)], CommandType='"Text"', CommandTimeout='30']
+SELECT TOP(1) [r].[Id], [r].[ConcurrencyStamp], [r].[IsAdmin], [r].[Name], [r].[NormalizedName]
+FROM [roles] AS [r]
+WHERE [r].[NormalizedName] = @__normalizedName_0
+2025-08-11 14:38:01.155 +07:00 [INF] Executed DbCommand (5ms) [Parameters=[@__normalizedName_0='?' (Size = 4000)], CommandType='"Text"', CommandTimeout='30']
+SELECT TOP(1) [r].[Id], [r].[ConcurrencyStamp], [r].[IsAdmin], [r].[Name], [r].[NormalizedName]
+FROM [roles] AS [r]
+WHERE [r].[NormalizedName] = @__normalizedName_0
+2025-08-11 14:38:01.155 +07:00 [DBG] Context 'MyDbContext' started tracking 'Role' entity. Consider using 'DbContextOptionsBuilder.EnableSensitiveDataLogging' to see key values.
+2025-08-11 14:38:01.156 +07:00 [DBG] Closing data reader to 'capbot_db' on server 'localhost'.
+2025-08-11 14:38:01.156 +07:00 [DBG] A data reader for 'capbot_db' on server 'localhost' is being disposed after spending 0ms reading results.
+2025-08-11 14:38:01.156 +07:00 [DBG] Closing connection to database 'capbot_db' on server 'localhost'.
+2025-08-11 14:38:01.156 +07:00 [DBG] Closed connection to database 'capbot_db' on server 'localhost' (0ms).
+2025-08-11 14:38:01.161 +07:00 [DBG] Compiling query expression: 
+'DbSet<User>()
+    .SingleOrDefault(u => u.NormalizedEmail == __normalizedEmail_0)'
+2025-08-11 14:38:01.166 +07:00 [DBG] Generated query execution expression: 
+'queryContext => ShapedQueryCompilingExpressionVisitor.SingleOrDefaultAsync<User>(
+    asyncEnumerable: new SingleQueryingEnumerable<User>(
+        (RelationalQueryContext)queryContext, 
+        RelationalCommandCache.QueryExpression(
+            Projection Mapping:
+                EmptyProjectionMember -> Dictionary<IProperty, int> { [Property: User.Id (int) Required PK AfterSave:Throw ValueGenerated.OnAdd, 0], [Property: User.AccessFailedCount (int) Required, 1], [Property: User.ConcurrencyStamp (string), 2], [Property: User.CreatedAt (DateTime) Required, 3], [Property: User.DeletedAt (DateTime?), 4], [Property: User.Email (string), 5], [Property: User.EmailConfirmed (bool) Required, 6], [Property: User.LastModifiedAt (DateTime) Required, 7], [Property: User.LastModifiedBy (string), 8], [Property: User.LockoutEnabled (bool) Required, 9], [Property: User.LockoutEnd (DateTimeOffset?), 10], [Property: User.NormalizedEmail (string), 11], [Property: User.NormalizedUserName (string), 12], [Property: User.PasswordHash (string), 13], [Property: User.PhoneNumber (string), 14], [Property: User.PhoneNumberConfirmed (bool) Required, 15], [Property: User.SecurityStamp (string), 16], [Property: User.TwoFactorEnabled (bool) Required, 17], [Property: User.UserName (string), 18] }
+            SELECT TOP(2) u.Id, u.AccessFailedCount, u.ConcurrencyStamp, u.CreatedAt, u.DeletedAt, u.Email, u.EmailConfirmed, u.LastModifiedAt, u.LastModifiedBy, u.LockoutEnabled, u.LockoutEnd, u.NormalizedEmail, u.NormalizedUserName, u.PasswordHash, u.PhoneNumber, u.PhoneNumberConfirmed, u.SecurityStamp, u.TwoFactorEnabled, u.UserName
+            FROM users AS u
+            WHERE u.NormalizedEmail == @__normalizedEmail_0), 
+        null, 
+        Func<QueryContext, DbDataReader, ResultContext, SingleQueryResultCoordinator, User>, 
+        App.DAL.Context.MyDbContext, 
+        False, 
+        False, 
+        True
+    ), 
+    cancellationToken: queryContext.CancellationToken)'
+2025-08-11 14:38:01.168 +07:00 [DBG] Opening connection to database 'capbot_db' on server 'localhost'.
+2025-08-11 14:38:01.168 +07:00 [DBG] Opened connection to database 'capbot_db' on server 'localhost'.
+2025-08-11 14:38:01.169 +07:00 [DBG] Creating DbCommand for 'ExecuteReader'.
+2025-08-11 14:38:01.169 +07:00 [DBG] Created DbCommand for 'ExecuteReader' (0ms).
+2025-08-11 14:38:01.169 +07:00 [DBG] Initialized DbCommand for 'ExecuteReader' (0ms).
+2025-08-11 14:38:01.169 +07:00 [DBG] Executing DbCommand [Parameters=[@__normalizedEmail_0='?' (Size = 4000)], CommandType='"Text"', CommandTimeout='30']
+SELECT TOP(2) [u].[Id], [u].[AccessFailedCount], [u].[ConcurrencyStamp], [u].[CreatedAt], [u].[DeletedAt], [u].[Email], [u].[EmailConfirmed], [u].[LastModifiedAt], [u].[LastModifiedBy], [u].[LockoutEnabled], [u].[LockoutEnd], [u].[NormalizedEmail], [u].[NormalizedUserName], [u].[PasswordHash], [u].[PhoneNumber], [u].[PhoneNumberConfirmed], [u].[SecurityStamp], [u].[TwoFactorEnabled], [u].[UserName]
+FROM [users] AS [u]
+WHERE [u].[NormalizedEmail] = @__normalizedEmail_0
+2025-08-11 14:38:01.176 +07:00 [INF] Executed DbCommand (7ms) [Parameters=[@__normalizedEmail_0='?' (Size = 4000)], CommandType='"Text"', CommandTimeout='30']
+SELECT TOP(2) [u].[Id], [u].[AccessFailedCount], [u].[ConcurrencyStamp], [u].[CreatedAt], [u].[DeletedAt], [u].[Email], [u].[EmailConfirmed], [u].[LastModifiedAt], [u].[LastModifiedBy], [u].[LockoutEnabled], [u].[LockoutEnd], [u].[NormalizedEmail], [u].[NormalizedUserName], [u].[PasswordHash], [u].[PhoneNumber], [u].[PhoneNumberConfirmed], [u].[SecurityStamp], [u].[TwoFactorEnabled], [u].[UserName]
+FROM [users] AS [u]
+WHERE [u].[NormalizedEmail] = @__normalizedEmail_0
+2025-08-11 14:38:01.211 +07:00 [DBG] Context 'MyDbContext' started tracking 'User' entity. Consider using 'DbContextOptionsBuilder.EnableSensitiveDataLogging' to see key values.
+2025-08-11 14:38:01.232 +07:00 [DBG] Closing data reader to 'capbot_db' on server 'localhost'.
+2025-08-11 14:38:01.232 +07:00 [DBG] A data reader for 'capbot_db' on server 'localhost' is being disposed after spending 54ms reading results.
+2025-08-11 14:38:01.233 +07:00 [DBG] Closing connection to database 'capbot_db' on server 'localhost'.
+2025-08-11 14:38:01.233 +07:00 [DBG] Closed connection to database 'capbot_db' on server 'localhost' (0ms).
+2025-08-11 14:38:01.235 +07:00 [INF] Admin user 'fptslayer@gmail.com' already exists
+2025-08-11 14:38:01.237 +07:00 [DBG] Opening connection to database 'capbot_db' on server 'localhost'.
+2025-08-11 14:38:01.237 +07:00 [DBG] Opened connection to database 'capbot_db' on server 'localhost'.
+2025-08-11 14:38:01.238 +07:00 [DBG] Creating DbCommand for 'ExecuteReader'.
+2025-08-11 14:38:01.238 +07:00 [DBG] Created DbCommand for 'ExecuteReader' (0ms).
+2025-08-11 14:38:01.238 +07:00 [DBG] Initialized DbCommand for 'ExecuteReader' (0ms).
+2025-08-11 14:38:01.239 +07:00 [DBG] Executing DbCommand [Parameters=[@__normalizedEmail_0='?' (Size = 4000)], CommandType='"Text"', CommandTimeout='30']
+SELECT TOP(2) [u].[Id], [u].[AccessFailedCount], [u].[ConcurrencyStamp], [u].[CreatedAt], [u].[DeletedAt], [u].[Email], [u].[EmailConfirmed], [u].[LastModifiedAt], [u].[LastModifiedBy], [u].[LockoutEnabled], [u].[LockoutEnd], [u].[NormalizedEmail], [u].[NormalizedUserName], [u].[PasswordHash], [u].[PhoneNumber], [u].[PhoneNumberConfirmed], [u].[SecurityStamp], [u].[TwoFactorEnabled], [u].[UserName]
+FROM [users] AS [u]
+WHERE [u].[NormalizedEmail] = @__normalizedEmail_0
+2025-08-11 14:38:01.242 +07:00 [INF] Executed DbCommand (3ms) [Parameters=[@__normalizedEmail_0='?' (Size = 4000)], CommandType='"Text"', CommandTimeout='30']
+SELECT TOP(2) [u].[Id], [u].[AccessFailedCount], [u].[ConcurrencyStamp], [u].[CreatedAt], [u].[DeletedAt], [u].[Email], [u].[EmailConfirmed], [u].[LastModifiedAt], [u].[LastModifiedBy], [u].[LockoutEnabled], [u].[LockoutEnd], [u].[NormalizedEmail], [u].[NormalizedUserName], [u].[PasswordHash], [u].[PhoneNumber], [u].[PhoneNumberConfirmed], [u].[SecurityStamp], [u].[TwoFactorEnabled], [u].[UserName]
+FROM [users] AS [u]
+WHERE [u].[NormalizedEmail] = @__normalizedEmail_0
+2025-08-11 14:38:01.243 +07:00 [DBG] Context 'MyDbContext' started tracking 'User' entity. Consider using 'DbContextOptionsBuilder.EnableSensitiveDataLogging' to see key values.
+2025-08-11 14:38:01.243 +07:00 [DBG] Closing data reader to 'capbot_db' on server 'localhost'.
+2025-08-11 14:38:01.243 +07:00 [DBG] A data reader for 'capbot_db' on server 'localhost' is being disposed after spending 0ms reading results.
+2025-08-11 14:38:01.244 +07:00 [DBG] Closing connection to database 'capbot_db' on server 'localhost'.
+2025-08-11 14:38:01.244 +07:00 [DBG] Closed connection to database 'capbot_db' on server 'localhost' (0ms).
+2025-08-11 14:38:01.244 +07:00 [INF] Sample moderator 'moderator@example.com' already exists
+2025-08-11 14:38:01.245 +07:00 [DBG] Opening connection to database 'capbot_db' on server 'localhost'.
+2025-08-11 14:38:01.245 +07:00 [DBG] Opened connection to database 'capbot_db' on server 'localhost'.
+2025-08-11 14:38:01.245 +07:00 [DBG] Creating DbCommand for 'ExecuteReader'.
+2025-08-11 14:38:01.245 +07:00 [DBG] Created DbCommand for 'ExecuteReader' (0ms).
+2025-08-11 14:38:01.245 +07:00 [DBG] Initialized DbCommand for 'ExecuteReader' (0ms).
+2025-08-11 14:38:01.246 +07:00 [DBG] Executing DbCommand [Parameters=[@__normalizedEmail_0='?' (Size = 4000)], CommandType='"Text"', CommandTimeout='30']
+SELECT TOP(2) [u].[Id], [u].[AccessFailedCount], [u].[ConcurrencyStamp], [u].[CreatedAt], [u].[DeletedAt], [u].[Email], [u].[EmailConfirmed], [u].[LastModifiedAt], [u].[LastModifiedBy], [u].[LockoutEnabled], [u].[LockoutEnd], [u].[NormalizedEmail], [u].[NormalizedUserName], [u].[PasswordHash], [u].[PhoneNumber], [u].[PhoneNumberConfirmed], [u].[SecurityStamp], [u].[TwoFactorEnabled], [u].[UserName]
+FROM [users] AS [u]
+WHERE [u].[NormalizedEmail] = @__normalizedEmail_0
+2025-08-11 14:38:01.250 +07:00 [INF] Executed DbCommand (4ms) [Parameters=[@__normalizedEmail_0='?' (Size = 4000)], CommandType='"Text"', CommandTimeout='30']
+SELECT TOP(2) [u].[Id], [u].[AccessFailedCount], [u].[ConcurrencyStamp], [u].[CreatedAt], [u].[DeletedAt], [u].[Email], [u].[EmailConfirmed], [u].[LastModifiedAt], [u].[LastModifiedBy], [u].[LockoutEnabled], [u].[LockoutEnd], [u].[NormalizedEmail], [u].[NormalizedUserName], [u].[PasswordHash], [u].[PhoneNumber], [u].[PhoneNumberConfirmed], [u].[SecurityStamp], [u].[TwoFactorEnabled], [u].[UserName]
+FROM [users] AS [u]
+WHERE [u].[NormalizedEmail] = @__normalizedEmail_0
+2025-08-11 14:38:01.251 +07:00 [DBG] Context 'MyDbContext' started tracking 'User' entity. Consider using 'DbContextOptionsBuilder.EnableSensitiveDataLogging' to see key values.
+2025-08-11 14:38:01.251 +07:00 [DBG] Closing data reader to 'capbot_db' on server 'localhost'.
+2025-08-11 14:38:01.251 +07:00 [DBG] A data reader for 'capbot_db' on server 'localhost' is being disposed after spending 0ms reading results.
+2025-08-11 14:38:01.252 +07:00 [DBG] Closing connection to database 'capbot_db' on server 'localhost'.
+2025-08-11 14:38:01.252 +07:00 [DBG] Closed connection to database 'capbot_db' on server 'localhost' (0ms).
+2025-08-11 14:38:01.252 +07:00 [DBG] Opening connection to database 'capbot_db' on server 'localhost'.
+2025-08-11 14:38:01.252 +07:00 [DBG] Opened connection to database 'capbot_db' on server 'localhost'.
+2025-08-11 14:38:01.252 +07:00 [DBG] Creating DbCommand for 'ExecuteReader'.
+2025-08-11 14:38:01.253 +07:00 [DBG] Created DbCommand for 'ExecuteReader' (0ms).
+2025-08-11 14:38:01.253 +07:00 [DBG] Initialized DbCommand for 'ExecuteReader' (0ms).
+2025-08-11 14:38:01.253 +07:00 [DBG] Executing DbCommand [Parameters=[@__normalizedEmail_0='?' (Size = 4000)], CommandType='"Text"', CommandTimeout='30']
+SELECT TOP(2) [u].[Id], [u].[AccessFailedCount], [u].[ConcurrencyStamp], [u].[CreatedAt], [u].[DeletedAt], [u].[Email], [u].[EmailConfirmed], [u].[LastModifiedAt], [u].[LastModifiedBy], [u].[LockoutEnabled], [u].[LockoutEnd], [u].[NormalizedEmail], [u].[NormalizedUserName], [u].[PasswordHash], [u].[PhoneNumber], [u].[PhoneNumberConfirmed], [u].[SecurityStamp], [u].[TwoFactorEnabled], [u].[UserName]
+FROM [users] AS [u]
+WHERE [u].[NormalizedEmail] = @__normalizedEmail_0
+2025-08-11 14:38:01.258 +07:00 [INF] Executed DbCommand (5ms) [Parameters=[@__normalizedEmail_0='?' (Size = 4000)], CommandType='"Text"', CommandTimeout='30']
+SELECT TOP(2) [u].[Id], [u].[AccessFailedCount], [u].[ConcurrencyStamp], [u].[CreatedAt], [u].[DeletedAt], [u].[Email], [u].[EmailConfirmed], [u].[LastModifiedAt], [u].[LastModifiedBy], [u].[LockoutEnabled], [u].[LockoutEnd], [u].[NormalizedEmail], [u].[NormalizedUserName], [u].[PasswordHash], [u].[PhoneNumber], [u].[PhoneNumberConfirmed], [u].[SecurityStamp], [u].[TwoFactorEnabled], [u].[UserName]
+FROM [users] AS [u]
+WHERE [u].[NormalizedEmail] = @__normalizedEmail_0
+2025-08-11 14:38:01.260 +07:00 [DBG] Context 'MyDbContext' started tracking 'User' entity. Consider using 'DbContextOptionsBuilder.EnableSensitiveDataLogging' to see key values.
+2025-08-11 14:38:01.260 +07:00 [DBG] Closing data reader to 'capbot_db' on server 'localhost'.
+2025-08-11 14:38:01.260 +07:00 [DBG] A data reader for 'capbot_db' on server 'localhost' is being disposed after spending 0ms reading results.
+2025-08-11 14:38:01.261 +07:00 [DBG] Closing connection to database 'capbot_db' on server 'localhost'.
+2025-08-11 14:38:01.261 +07:00 [DBG] Closed connection to database 'capbot_db' on server 'localhost' (0ms).
+2025-08-11 14:38:01.261 +07:00 [INF] Data seeding completed successfully
+2025-08-11 14:38:01.263 +07:00 [DBG] 'MyDbContext' disposed.
+2025-08-11 14:38:01.264 +07:00 [DBG] Disposing connection to database 'capbot_db' on server 'localhost'.
+2025-08-11 14:38:01.265 +07:00 [DBG] Disposed connection to database '' on server '' (0ms).
+2025-08-11 14:38:01.409 +07:00 [DBG] Registered model binder providers, in the following order: ["Microsoft.AspNetCore.Mvc.ModelBinding.Binders.BinderTypeModelBinderProvider","Microsoft.AspNetCore.Mvc.ModelBinding.Binders.ServicesModelBinderProvider","Microsoft.AspNetCore.Mvc.ModelBinding.Binders.BodyModelBinderProvider","Microsoft.AspNetCore.Mvc.ModelBinding.Binders.HeaderModelBinderProvider","Microsoft.AspNetCore.Mvc.ModelBinding.Binders.FloatingPointTypeModelBinderProvider","Microsoft.AspNetCore.Mvc.ModelBinding.Binders.EnumTypeModelBinderProvider","Microsoft.AspNetCore.Mvc.ModelBinding.Binders.DateTimeModelBinderProvider","Microsoft.AspNetCore.Mvc.ModelBinding.Binders.SimpleTypeModelBinderProvider","Microsoft.AspNetCore.Mvc.ModelBinding.Binders.TryParseModelBinderProvider","Microsoft.AspNetCore.Mvc.ModelBinding.Binders.CancellationTokenModelBinderProvider"]
+2025-08-11 14:38:01.482 +07:00 [DBG] Hosting starting
+2025-08-11 14:38:01.487 +07:00 [DBG] Reading data from file 'C:\Users\Admin\AppData\Local\ASP.NET\DataProtection-Keys\key-1d6bcff1-a155-4167-8a22-de35a5f05047.xml'.
+2025-08-11 14:38:01.489 +07:00 [DBG] Reading data from file 'C:\Users\Admin\AppData\Local\ASP.NET\DataProtection-Keys\key-2459dd29-32d5-4c49-ac9d-33896047bb78.xml'.
+2025-08-11 14:38:01.490 +07:00 [DBG] Reading data from file 'C:\Users\Admin\AppData\Local\ASP.NET\DataProtection-Keys\key-374624f1-e856-4617-8ae6-fe6a81ce6346.xml'.
+2025-08-11 14:38:01.493 +07:00 [DBG] Found key {1d6bcff1-a155-4167-8a22-de35a5f05047}.
+2025-08-11 14:38:01.496 +07:00 [DBG] Found key {2459dd29-32d5-4c49-ac9d-33896047bb78}.
+2025-08-11 14:38:01.497 +07:00 [DBG] Found key {374624f1-e856-4617-8ae6-fe6a81ce6346}.
+2025-08-11 14:38:01.501 +07:00 [DBG] Considering key {2459dd29-32d5-4c49-ac9d-33896047bb78} with expiration date 2025-11-03 12:40:53Z as default key.
+2025-08-11 14:38:01.503 +07:00 [DBG] Forwarded activator type request from Microsoft.AspNetCore.DataProtection.XmlEncryption.DpapiXmlDecryptor, Microsoft.AspNetCore.DataProtection, Version=8.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60 to Microsoft.AspNetCore.DataProtection.XmlEncryption.DpapiXmlDecryptor, Microsoft.AspNetCore.DataProtection, Culture=neutral, PublicKeyToken=adb9793829ddae60
+2025-08-11 14:38:01.504 +07:00 [DBG] Decrypting secret element using Windows DPAPI.
+2025-08-11 14:38:01.506 +07:00 [DBG] Forwarded activator type request from Microsoft.AspNetCore.DataProtection.AuthenticatedEncryption.ConfigurationModel.AuthenticatedEncryptorDescriptorDeserializer, Microsoft.AspNetCore.DataProtection, Version=8.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60 to Microsoft.AspNetCore.DataProtection.AuthenticatedEncryption.ConfigurationModel.AuthenticatedEncryptorDescriptorDeserializer, Microsoft.AspNetCore.DataProtection, Culture=neutral, PublicKeyToken=adb9793829ddae60
+2025-08-11 14:38:01.507 +07:00 [DBG] Opening CNG algorithm 'AES' from provider 'null' with chaining mode CBC.
+2025-08-11 14:38:01.508 +07:00 [DBG] Opening CNG algorithm 'SHA256' from provider 'null' with HMAC.
+2025-08-11 14:38:01.509 +07:00 [DBG] Using key {2459dd29-32d5-4c49-ac9d-33896047bb78} as the default key.
+2025-08-11 14:38:01.510 +07:00 [DBG] Key ring with default key {2459dd29-32d5-4c49-ac9d-33896047bb78} was loaded during application startup.
+2025-08-11 14:38:01.622 +07:00 [INF] Now listening on: https://localhost:7190
+2025-08-11 14:38:01.623 +07:00 [DBG] Loaded hosting startup assembly CapBot.api
+2025-08-11 14:38:01.623 +07:00 [DBG] Loaded hosting startup assembly Microsoft.WebTools.ApiEndpointDiscovery
+2025-08-11 14:38:01.623 +07:00 [DBG] Loaded hosting startup assembly Microsoft.AspNetCore.Watch.BrowserRefresh
+2025-08-11 14:38:01.624 +07:00 [DBG] Loaded hosting startup assembly Microsoft.WebTools.BrowserLink.Net
+2025-08-11 14:38:01.706 +07:00 [INF] Application started. Press Ctrl+C to shut down.
+2025-08-11 14:38:01.707 +07:00 [INF] Hosting environment: Development
+2025-08-11 14:38:01.707 +07:00 [INF] Content root path: C:\Users\Admin\Downloads\CBAI_API\CapBot.api
+2025-08-11 14:38:01.707 +07:00 [DBG] Hosting started
+2025-08-11 14:38:01.829 +07:00 [DBG] Connection id "0HNEOL805G3U9" received FIN.
+2025-08-11 14:38:01.829 +07:00 [DBG] Connection id "0HNEOL805G3U8" received FIN.
+2025-08-11 14:38:01.841 +07:00 [DBG] Connection id "0HNEOL805G3U9" accepted.
+2025-08-11 14:38:01.841 +07:00 [DBG] Connection id "0HNEOL805G3U8" accepted.
+2025-08-11 14:38:01.842 +07:00 [DBG] Connection id "0HNEOL805G3U9" started.
+2025-08-11 14:38:01.842 +07:00 [DBG] Connection id "0HNEOL805G3U8" started.
+2025-08-11 14:38:01.860 +07:00 [DBG] Failed to authenticate HTTPS connection.
+System.IO.IOException: Received an unexpected EOF or 0 bytes from the transport stream.
+   at System.Net.Security.SslStream.ReceiveHandshakeFrameAsync[TIOAdapter](CancellationToken cancellationToken)
+   at System.Net.Security.SslStream.ForceAuthenticationAsync[TIOAdapter](Boolean receiveFirst, Byte[] reAuthenticationData, CancellationToken cancellationToken)
+   at System.Net.Security.SslStream.ProcessAuthenticationWithTelemetryAsync(Boolean isAsync, CancellationToken cancellationToken)
+   at Microsoft.AspNetCore.Server.Kestrel.Https.Internal.HttpsConnectionMiddleware.OnConnectionAsync(ConnectionContext context)
+2025-08-11 14:38:01.860 +07:00 [DBG] Failed to authenticate HTTPS connection.
+System.IO.IOException: Received an unexpected EOF or 0 bytes from the transport stream.
+   at System.Net.Security.SslStream.ReceiveHandshakeFrameAsync[TIOAdapter](CancellationToken cancellationToken)
+   at System.Net.Security.SslStream.ForceAuthenticationAsync[TIOAdapter](Boolean receiveFirst, Byte[] reAuthenticationData, CancellationToken cancellationToken)
+   at System.Net.Security.SslStream.ProcessAuthenticationWithTelemetryAsync(Boolean isAsync, CancellationToken cancellationToken)
+   at Microsoft.AspNetCore.Server.Kestrel.Https.Internal.HttpsConnectionMiddleware.OnConnectionAsync(ConnectionContext context)
+2025-08-11 14:38:01.872 +07:00 [DBG] Connection id "0HNEOL805G3U8" stopped.
+2025-08-11 14:38:01.872 +07:00 [DBG] Connection id "0HNEOL805G3U9" stopped.
+2025-08-11 14:38:01.877 +07:00 [DBG] Connection id "0HNEOL805G3U8" sending FIN because: "The Socket transport's send loop completed gracefully."
+2025-08-11 14:38:01.877 +07:00 [DBG] Connection id "0HNEOL805G3U9" sending FIN because: "The Socket transport's send loop completed gracefully."
+2025-08-11 14:38:01.916 +07:00 [DBG] Connection id "0HNEOL805G3UA" accepted.
+2025-08-11 14:38:01.917 +07:00 [DBG] Connection id "0HNEOL805G3UA" started.
+2025-08-11 14:38:01.996 +07:00 [DBG] Connection 0HNEOL805G3UA established using the following protocol: "Tls13"
+2025-08-11 14:38:02.055 +07:00 [INF] Request starting HTTP/2 GET https://localhost:7190/index.html - null null
+2025-08-11 14:38:02.093 +07:00 [DBG] Wildcard detected, all requests with hosts will be allowed.
+2025-08-11 14:38:02.124 +07:00 [DBG] Response markup is scheduled to include Browser Link script injection.
+2025-08-11 14:38:02.125 +07:00 [DBG] Response markup is scheduled to include browser refresh script injection.
+2025-08-11 14:38:02.142 +07:00 [DBG] Response markup was updated to include Browser Link script injection.
+2025-08-11 14:38:02.143 +07:00 [DBG] Response markup was updated to include browser refresh script injection.
+2025-08-11 14:38:02.146 +07:00 [INF] Request finished HTTP/2 GET https://localhost:7190/index.html - 200 null text/html;charset=utf-8 96.7813ms
+2025-08-11 14:38:02.154 +07:00 [INF] Request starting HTTP/2 GET https://localhost:7190/_framework/aspnetcore-browser-refresh.js - null null
+2025-08-11 14:38:02.154 +07:00 [INF] Request starting HTTP/2 GET https://localhost:7190/_vs/browserLink - null null
+2025-08-11 14:38:02.161 +07:00 [INF] Request finished HTTP/2 GET https://localhost:7190/_framework/aspnetcore-browser-refresh.js - 200 13756 application/javascript; charset=utf-8 7.6146ms
+2025-08-11 14:38:02.200 +07:00 [INF] Request finished HTTP/2 GET https://localhost:7190/_vs/browserLink - 200 null text/javascript; charset=UTF-8 46.5686ms
+2025-08-11 14:38:02.221 +07:00 [INF] Request starting HTTP/2 GET https://localhost:7190/swagger/v1/swagger.json - null null
+2025-08-11 14:38:02.255 +07:00 [INF] Request finished HTTP/2 GET https://localhost:7190/swagger/v1/swagger.json - 200 null application/json;charset=utf-8 33.8988ms
+2025-08-11 14:38:22.063 +07:00 [INF] Application is shutting down...
+2025-08-11 14:38:22.068 +07:00 [DBG] Hosting stopping
+2025-08-11 14:38:22.087 +07:00 [DBG] Connection id "0HNEOL805G3UA" is closing.
+2025-08-11 14:38:22.087 +07:00 [DBG] Connection id "0HNEOL805G3UA" is closed. The last processed stream ID was 7.
+2025-08-11 14:38:22.089 +07:00 [DBG] Connection id "0HNEOL805G3UA" received FIN.
+2025-08-11 14:38:22.092 +07:00 [DBG] Connection id "0HNEOL805G3UA" sending FIN because: "The Socket transport's send loop completed gracefully."
+2025-08-11 14:38:22.093 +07:00 [DBG] The connection queue processing loop for 0HNEOL805G3UA completed.
+2025-08-11 14:38:22.094 +07:00 [DBG] Connection id "0HNEOL805G3UA" stopped.
+2025-08-11 14:38:22.098 +07:00 [DBG] Hosting stopped
+2025-08-11 14:46:06.989 +07:00 [DBG] An 'IServiceProvider' was created for internal use by Entity Framework.
+2025-08-11 14:46:07.073 +07:00 [INF] User profile is available. Using 'C:\Users\Admin\AppData\Local\ASP.NET\DataProtection-Keys' as key repository and Windows DPAPI to encrypt keys at rest.
+2025-08-11 14:46:07.227 +07:00 [DBG] No relationship from 'ReviewerAssignment' to 'User' has been configured by convention because there are multiple properties on one entity type - {'AssignedByUser', 'Reviewer'} that could be matched with the properties on the other entity type - {'ReviewerAssignments'}. This message can be disregarded if explicit configuration has been specified in 'OnModelCreating'.
+2025-08-11 14:46:07.240 +07:00 [DBG] No relationship from 'SubmissionWorkflowLog' to 'WorkflowState' has been configured by convention because there are multiple properties on one entity type - {'FromState', 'ToState'} that could be matched with the properties on the other entity type - {'FromStateLogs', 'ToStateLogs'}. This message can be disregarded if explicit configuration has been specified in 'OnModelCreating'.
+2025-08-11 14:46:07.248 +07:00 [DBG] No relationship from 'User' to 'ReviewerAssignment' has been configured by convention because there are multiple properties on one entity type - {'ReviewerAssignments'} that could be matched with the properties on the other entity type - {'AssignedByUser', 'Reviewer'}. This message can be disregarded if explicit configuration has been specified in 'OnModelCreating'.
+2025-08-11 14:46:07.249 +07:00 [DBG] No relationship from 'WorkflowState' to 'SubmissionWorkflowLog' has been configured by convention because there are multiple properties on one entity type - {'FromStateLogs', 'ToStateLogs'} that could be matched with the properties on the other entity type - {'FromState', 'ToState'}. This message can be disregarded if explicit configuration has been specified in 'OnModelCreating'.
+2025-08-11 14:46:07.250 +07:00 [DBG] No relationship from 'WorkflowState' to 'WorkflowTransition' has been configured by convention because there are multiple properties on one entity type - {'FromTransitions', 'ToTransitions'} that could be matched with the properties on the other entity type - {'FromState', 'ToState'}. This message can be disregarded if explicit configuration has been specified in 'OnModelCreating'.
+2025-08-11 14:46:07.251 +07:00 [DBG] No relationship from 'WorkflowTransition' to 'WorkflowState' has been configured by convention because there are multiple properties on one entity type - {'FromState', 'ToState'} that could be matched with the properties on the other entity type - {'FromTransitions', 'ToTransitions'}. This message can be disregarded if explicit configuration has been specified in 'OnModelCreating'.
+2025-08-11 14:46:07.371 +07:00 [DBG] No relationship from 'ReviewerAssignment' to 'User' has been configured by convention because there are multiple properties on one entity type - {'AssignedByUser', 'Reviewer'} that could be matched with the properties on the other entity type - {'ReviewerAssignments'}. This message can be disregarded if explicit configuration has been specified in 'OnModelCreating'.
+2025-08-11 14:46:07.372 +07:00 [DBG] No relationship from 'User' to 'ReviewerAssignment' has been configured by convention because there are multiple properties on one entity type - {'ReviewerAssignments'} that could be matched with the properties on the other entity type - {'AssignedByUser', 'Reviewer'}. This message can be disregarded if explicit configuration has been specified in 'OnModelCreating'.
+2025-08-11 14:46:07.385 +07:00 [DBG] No relationship from 'WorkflowTransition' to 'WorkflowState' has been configured by convention because there are multiple properties on one entity type - {'FromState', 'ToState'} that could be matched with the properties on the other entity type - {'FromTransitions', 'ToTransitions'}. This message can be disregarded if explicit configuration has been specified in 'OnModelCreating'.
+2025-08-11 14:46:07.386 +07:00 [DBG] No relationship from 'WorkflowState' to 'SubmissionWorkflowLog' has been configured by convention because there are multiple properties on one entity type - {'FromStateLogs', 'ToStateLogs'} that could be matched with the properties on the other entity type - {'FromState', 'ToState'}. This message can be disregarded if explicit configuration has been specified in 'OnModelCreating'.
+2025-08-11 14:46:07.386 +07:00 [DBG] No relationship from 'WorkflowState' to 'WorkflowTransition' has been configured by convention because there are multiple properties on one entity type - {'FromTransitions', 'ToTransitions'} that could be matched with the properties on the other entity type - {'FromState', 'ToState'}. This message can be disregarded if explicit configuration has been specified in 'OnModelCreating'.
+2025-08-11 14:46:07.387 +07:00 [DBG] No relationship from 'WorkflowState' to 'SubmissionWorkflowLog' has been configured by convention because there are multiple properties on one entity type - {'FromStateLogs', 'ToStateLogs'} that could be matched with the properties on the other entity type - {'FromState', 'ToState'}. This message can be disregarded if explicit configuration has been specified in 'OnModelCreating'.
+2025-08-11 14:46:07.391 +07:00 [DBG] No relationship from 'SubmissionWorkflowLog' to 'WorkflowState' has been configured by convention because there are multiple properties on one entity type - {'FromState', 'ToState'} that could be matched with the properties on the other entity type - {'FromStateLogs', 'ToStateLogs'}. This message can be disregarded if explicit configuration has been specified in 'OnModelCreating'.
+2025-08-11 14:46:07.391 +07:00 [DBG] No relationship from 'WorkflowState' to 'SubmissionWorkflowLog' has been configured by convention because there are multiple properties on one entity type - {'FromStateLogs', 'ToStateLogs'} that could be matched with the properties on the other entity type - {'FromState', 'ToState'}. This message can be disregarded if explicit configuration has been specified in 'OnModelCreating'.
+2025-08-11 14:46:07.420 +07:00 [DBG] The index {'LecturerId'} was not created on entity type 'LecturerSkill' as the properties are already covered by the index {'LecturerId', 'SkillTag'}.
+2025-08-11 14:46:07.421 +07:00 [DBG] The index {'SemesterId'} was not created on entity type 'Phase' as the properties are already covered by the index {'SemesterId', 'PhaseTypeId'}.
+2025-08-11 14:46:07.422 +07:00 [DBG] The index {'AssignmentId'} was not created on entity type 'Review' as the properties are already covered by the index {'AssignmentId', 'Status'}.
+2025-08-11 14:46:07.422 +07:00 [DBG] The index {'ReviewId'} was not created on entity type 'ReviewComment' as the properties are already covered by the index {'ReviewId', 'SectionName'}.
+2025-08-11 14:46:07.422 +07:00 [DBG] The index {'ReviewId'} was not created on entity type 'ReviewCriteriaScore' as the properties are already covered by the index {'ReviewId', 'CriteriaId'}.
+2025-08-11 14:46:07.423 +07:00 [DBG] The index {'ReviewerId'} was not created on entity type 'ReviewerAssignment' as the properties are already covered by the index {'ReviewerId', 'Status'}.
+2025-08-11 14:46:07.423 +07:00 [DBG] The index {'SubmissionId'} was not created on entity type 'ReviewerAssignment' as the properties are already covered by the index {'SubmissionId', 'ReviewerId'}.
+2025-08-11 14:46:07.423 +07:00 [DBG] The index {'ReviewerId'} was not created on entity type 'ReviewerPerformance' as the properties are already covered by the index {'ReviewerId', 'SemesterId'}.
+2025-08-11 14:46:07.423 +07:00 [DBG] The index {'PhaseId'} was not created on entity type 'Submission' as the properties are already covered by the index {'PhaseId', 'Status'}.
+2025-08-11 14:46:07.424 +07:00 [DBG] The index {'PhaseId'} was not created on entity type 'Submission' as the properties are already covered by the index {'PhaseId', 'Status', 'SubmittedAt'}.
+2025-08-11 14:46:07.424 +07:00 [DBG] The index {'TopicVersionId'} was not created on entity type 'Submission' as the properties are already covered by the index {'TopicVersionId', 'PhaseId', 'SubmissionRound'}.
+2025-08-11 14:46:07.424 +07:00 [DBG] The index {'SubmissionId'} was not created on entity type 'SubmissionWorkflowLog' as the properties are already covered by the index {'SubmissionId', 'CreatedAt'}.
+2025-08-11 14:46:07.424 +07:00 [DBG] The index {'UserId'} was not created on entity type 'SystemNotification' as the properties are already covered by the index {'UserId', 'IsRead', 'CreatedAt'}.
+2025-08-11 14:46:07.424 +07:00 [DBG] The index {'SemesterId'} was not created on entity type 'Topic' as the properties are already covered by the index {'SemesterId', 'IsApproved'}.
+2025-08-11 14:46:07.424 +07:00 [DBG] The index {'SupervisorId'} was not created on entity type 'Topic' as the properties are already covered by the index {'SupervisorId', 'SemesterId'}.
+2025-08-11 14:46:07.424 +07:00 [DBG] The index {'TopicId'} was not created on entity type 'TopicVersion' as the properties are already covered by the index {'TopicId', 'Status'}.
+2025-08-11 14:46:07.425 +07:00 [DBG] The index {'TopicId'} was not created on entity type 'TopicVersion' as the properties are already covered by the index {'TopicId', 'VersionNumber'}.
+2025-08-11 14:46:07.425 +07:00 [DBG] The index {'UserId'} was not created on entity type 'UserRole' as the properties are already covered by the index {'UserId', 'RoleId'}.
+2025-08-11 14:46:07.425 +07:00 [DBG] The index {'UserId'} was not created on entity type 'UserToken' as the properties are already covered by the index {'UserId', 'LoginProvider', 'Name'}.
+2025-08-11 14:46:07.517 +07:00 [WRN] The 'ProficiencyLevels' property 'ProficiencyLevel' on entity type 'LecturerSkill' is configured with a database-generated default, but has no configured sentinel value. The database-generated default will always be used for inserts when the property has the value '0', since this is the CLR default for the 'ProficiencyLevels' type. Consider using a nullable type, using a nullable backing field, or setting the sentinel value for the property to ensure the database default is used when, and only when, appropriate. See https://aka.ms/efcore-docs-default-values for more information.
+2025-08-11 14:46:07.518 +07:00 [WRN] The 'ReviewRecommendations' property 'Recommendation' on entity type 'Review' is configured with a database-generated default, but has no configured sentinel value. The database-generated default will always be used for inserts when the property has the value '0', since this is the CLR default for the 'ReviewRecommendations' type. Consider using a nullable type, using a nullable backing field, or setting the sentinel value for the property to ensure the database default is used when, and only when, appropriate. See https://aka.ms/efcore-docs-default-values for more information.
+2025-08-11 14:46:07.518 +07:00 [WRN] The 'ReviewStatus' property 'Status' on entity type 'Review' is configured with a database-generated default, but has no configured sentinel value. The database-generated default will always be used for inserts when the property has the value '0', since this is the CLR default for the 'ReviewStatus' type. Consider using a nullable type, using a nullable backing field, or setting the sentinel value for the property to ensure the database default is used when, and only when, appropriate. See https://aka.ms/efcore-docs-default-values for more information.
+2025-08-11 14:46:07.518 +07:00 [WRN] The 'CommentTypes' property 'CommentType' on entity type 'ReviewComment' is configured with a database-generated default, but has no configured sentinel value. The database-generated default will always be used for inserts when the property has the value '0', since this is the CLR default for the 'CommentTypes' type. Consider using a nullable type, using a nullable backing field, or setting the sentinel value for the property to ensure the database default is used when, and only when, appropriate. See https://aka.ms/efcore-docs-default-values for more information.
+2025-08-11 14:46:07.519 +07:00 [WRN] The 'PriorityLevels' property 'Priority' on entity type 'ReviewComment' is configured with a database-generated default, but has no configured sentinel value. The database-generated default will always be used for inserts when the property has the value '0', since this is the CLR default for the 'PriorityLevels' type. Consider using a nullable type, using a nullable backing field, or setting the sentinel value for the property to ensure the database default is used when, and only when, appropriate. See https://aka.ms/efcore-docs-default-values for more information.
+2025-08-11 14:46:07.519 +07:00 [WRN] The 'AssignmentTypes' property 'AssignmentType' on entity type 'ReviewerAssignment' is configured with a database-generated default, but has no configured sentinel value. The database-generated default will always be used for inserts when the property has the value '0', since this is the CLR default for the 'AssignmentTypes' type. Consider using a nullable type, using a nullable backing field, or setting the sentinel value for the property to ensure the database default is used when, and only when, appropriate. See https://aka.ms/efcore-docs-default-values for more information.
+2025-08-11 14:46:07.519 +07:00 [WRN] The 'AssignmentStatus' property 'Status' on entity type 'ReviewerAssignment' is configured with a database-generated default, but has no configured sentinel value. The database-generated default will always be used for inserts when the property has the value '0', since this is the CLR default for the 'AssignmentStatus' type. Consider using a nullable type, using a nullable backing field, or setting the sentinel value for the property to ensure the database default is used when, and only when, appropriate. See https://aka.ms/efcore-docs-default-values for more information.
+2025-08-11 14:46:07.520 +07:00 [WRN] The 'AiCheckStatus' property 'AiCheckStatus' on entity type 'Submission' is configured with a database-generated default, but has no configured sentinel value. The database-generated default will always be used for inserts when the property has the value '0', since this is the CLR default for the 'AiCheckStatus' type. Consider using a nullable type, using a nullable backing field, or setting the sentinel value for the property to ensure the database default is used when, and only when, appropriate. See https://aka.ms/efcore-docs-default-values for more information.
+2025-08-11 14:46:07.520 +07:00 [WRN] The 'SubmissionStatus' property 'Status' on entity type 'Submission' is configured with a database-generated default, but has no configured sentinel value. The database-generated default will always be used for inserts when the property has the value '0', since this is the CLR default for the 'SubmissionStatus' type. Consider using a nullable type, using a nullable backing field, or setting the sentinel value for the property to ensure the database default is used when, and only when, appropriate. See https://aka.ms/efcore-docs-default-values for more information.
+2025-08-11 14:46:07.520 +07:00 [WRN] The 'NotificationTypes' property 'Type' on entity type 'SystemNotification' is configured with a database-generated default, but has no configured sentinel value. The database-generated default will always be used for inserts when the property has the value '0', since this is the CLR default for the 'NotificationTypes' type. Consider using a nullable type, using a nullable backing field, or setting the sentinel value for the property to ensure the database default is used when, and only when, appropriate. See https://aka.ms/efcore-docs-default-values for more information.
+2025-08-11 14:46:07.520 +07:00 [WRN] The 'TopicStatus' property 'Status' on entity type 'TopicVersion' is configured with a database-generated default, but has no configured sentinel value. The database-generated default will always be used for inserts when the property has the value '0', since this is the CLR default for the 'TopicStatus' type. Consider using a nullable type, using a nullable backing field, or setting the sentinel value for the property to ensure the database default is used when, and only when, appropriate. See https://aka.ms/efcore-docs-default-values for more information.
+2025-08-11 14:46:07.623 +07:00 [DBG] Entity Framework Core 8.0.16 initialized 'MyDbContext' using provider 'Microsoft.EntityFrameworkCore.SqlServer:8.0.13' with options: MigrationsAssembly=App.DAL 
+2025-08-11 14:46:07.704 +07:00 [DBG] Compiling query expression: 
+'DbSet<Role>()
+    .FirstOrDefault(r => r.NormalizedName == __normalizedName_0)'
+2025-08-11 14:46:07.805 +07:00 [DBG] Generated query execution expression: 
+'queryContext => ShapedQueryCompilingExpressionVisitor.SingleOrDefaultAsync<Role>(
+    asyncEnumerable: new SingleQueryingEnumerable<Role>(
+        (RelationalQueryContext)queryContext, 
+        RelationalCommandCache.QueryExpression(
+            Projection Mapping:
+                EmptyProjectionMember -> Dictionary<IProperty, int> { [Property: Role.Id (int) Required PK AfterSave:Throw ValueGenerated.OnAdd, 0], [Property: Role.ConcurrencyStamp (string), 1], [Property: Role.IsAdmin (bool) Required, 2], [Property: Role.Name (string), 3], [Property: Role.NormalizedName (string), 4] }
+            SELECT TOP(1) r.Id, r.ConcurrencyStamp, r.IsAdmin, r.Name, r.NormalizedName
+            FROM roles AS r
+            WHERE r.NormalizedName == @__normalizedName_0), 
+        null, 
+        Func<QueryContext, DbDataReader, ResultContext, SingleQueryResultCoordinator, Role>, 
+        App.DAL.Context.MyDbContext, 
+        False, 
+        False, 
+        True
+    ), 
+    cancellationToken: queryContext.CancellationToken)'
+2025-08-11 14:46:07.832 +07:00 [DBG] Creating DbConnection.
+2025-08-11 14:46:07.846 +07:00 [DBG] Created DbConnection. (12ms).
+2025-08-11 14:46:07.849 +07:00 [DBG] Opening connection to database 'capbot_db' on server 'localhost'.
+2025-08-11 14:46:08.063 +07:00 [DBG] Opened connection to database 'capbot_db' on server 'localhost'.
+2025-08-11 14:46:08.068 +07:00 [DBG] Creating DbCommand for 'ExecuteReader'.
+2025-08-11 14:46:08.077 +07:00 [DBG] Created DbCommand for 'ExecuteReader' (4ms).
+2025-08-11 14:46:08.085 +07:00 [DBG] Initialized DbCommand for 'ExecuteReader' (17ms).
+2025-08-11 14:46:08.091 +07:00 [DBG] Executing DbCommand [Parameters=[@__normalizedName_0='?' (Size = 4000)], CommandType='"Text"', CommandTimeout='30']
+SELECT TOP(1) [r].[Id], [r].[ConcurrencyStamp], [r].[IsAdmin], [r].[Name], [r].[NormalizedName]
+FROM [roles] AS [r]
+WHERE [r].[NormalizedName] = @__normalizedName_0
+2025-08-11 14:46:08.147 +07:00 [INF] Executed DbCommand (50ms) [Parameters=[@__normalizedName_0='?' (Size = 4000)], CommandType='"Text"', CommandTimeout='30']
+SELECT TOP(1) [r].[Id], [r].[ConcurrencyStamp], [r].[IsAdmin], [r].[Name], [r].[NormalizedName]
+FROM [roles] AS [r]
+WHERE [r].[NormalizedName] = @__normalizedName_0
+2025-08-11 14:46:08.185 +07:00 [DBG] Context 'MyDbContext' started tracking 'Role' entity. Consider using 'DbContextOptionsBuilder.EnableSensitiveDataLogging' to see key values.
+2025-08-11 14:46:08.201 +07:00 [DBG] Closing data reader to 'capbot_db' on server 'localhost'.
+2025-08-11 14:46:08.206 +07:00 [DBG] A data reader for 'capbot_db' on server 'localhost' is being disposed after spending 54ms reading results.
+2025-08-11 14:46:08.209 +07:00 [DBG] Closing connection to database 'capbot_db' on server 'localhost'.
+2025-08-11 14:46:08.212 +07:00 [DBG] Closed connection to database 'capbot_db' on server 'localhost' (3ms).
+2025-08-11 14:46:08.215 +07:00 [DBG] Opening connection to database 'capbot_db' on server 'localhost'.
+2025-08-11 14:46:08.215 +07:00 [DBG] Opened connection to database 'capbot_db' on server 'localhost'.
+2025-08-11 14:46:08.216 +07:00 [DBG] Creating DbCommand for 'ExecuteReader'.
+2025-08-11 14:46:08.216 +07:00 [DBG] Created DbCommand for 'ExecuteReader' (0ms).
+2025-08-11 14:46:08.216 +07:00 [DBG] Initialized DbCommand for 'ExecuteReader' (0ms).
+2025-08-11 14:46:08.217 +07:00 [DBG] Executing DbCommand [Parameters=[@__normalizedName_0='?' (Size = 4000)], CommandType='"Text"', CommandTimeout='30']
+SELECT TOP(1) [r].[Id], [r].[ConcurrencyStamp], [r].[IsAdmin], [r].[Name], [r].[NormalizedName]
+FROM [roles] AS [r]
+WHERE [r].[NormalizedName] = @__normalizedName_0
+2025-08-11 14:46:08.219 +07:00 [INF] Executed DbCommand (3ms) [Parameters=[@__normalizedName_0='?' (Size = 4000)], CommandType='"Text"', CommandTimeout='30']
+SELECT TOP(1) [r].[Id], [r].[ConcurrencyStamp], [r].[IsAdmin], [r].[Name], [r].[NormalizedName]
+FROM [roles] AS [r]
+WHERE [r].[NormalizedName] = @__normalizedName_0
+2025-08-11 14:46:08.220 +07:00 [DBG] Context 'MyDbContext' started tracking 'Role' entity. Consider using 'DbContextOptionsBuilder.EnableSensitiveDataLogging' to see key values.
+2025-08-11 14:46:08.221 +07:00 [DBG] Closing data reader to 'capbot_db' on server 'localhost'.
+2025-08-11 14:46:08.221 +07:00 [DBG] A data reader for 'capbot_db' on server 'localhost' is being disposed after spending 1ms reading results.
+2025-08-11 14:46:08.222 +07:00 [DBG] Closing connection to database 'capbot_db' on server 'localhost'.
+2025-08-11 14:46:08.222 +07:00 [DBG] Closed connection to database 'capbot_db' on server 'localhost' (0ms).
+2025-08-11 14:46:08.222 +07:00 [DBG] Opening connection to database 'capbot_db' on server 'localhost'.
+2025-08-11 14:46:08.223 +07:00 [DBG] Opened connection to database 'capbot_db' on server 'localhost'.
+2025-08-11 14:46:08.223 +07:00 [DBG] Creating DbCommand for 'ExecuteReader'.
+2025-08-11 14:46:08.223 +07:00 [DBG] Created DbCommand for 'ExecuteReader' (0ms).
+2025-08-11 14:46:08.223 +07:00 [DBG] Initialized DbCommand for 'ExecuteReader' (0ms).
+2025-08-11 14:46:08.224 +07:00 [DBG] Executing DbCommand [Parameters=[@__normalizedName_0='?' (Size = 4000)], CommandType='"Text"', CommandTimeout='30']
+SELECT TOP(1) [r].[Id], [r].[ConcurrencyStamp], [r].[IsAdmin], [r].[Name], [r].[NormalizedName]
+FROM [roles] AS [r]
+WHERE [r].[NormalizedName] = @__normalizedName_0
+2025-08-11 14:46:08.225 +07:00 [INF] Executed DbCommand (1ms) [Parameters=[@__normalizedName_0='?' (Size = 4000)], CommandType='"Text"', CommandTimeout='30']
+SELECT TOP(1) [r].[Id], [r].[ConcurrencyStamp], [r].[IsAdmin], [r].[Name], [r].[NormalizedName]
+FROM [roles] AS [r]
+WHERE [r].[NormalizedName] = @__normalizedName_0
+2025-08-11 14:46:08.225 +07:00 [DBG] Context 'MyDbContext' started tracking 'Role' entity. Consider using 'DbContextOptionsBuilder.EnableSensitiveDataLogging' to see key values.
+2025-08-11 14:46:08.226 +07:00 [DBG] Closing data reader to 'capbot_db' on server 'localhost'.
+2025-08-11 14:46:08.226 +07:00 [DBG] A data reader for 'capbot_db' on server 'localhost' is being disposed after spending 0ms reading results.
+2025-08-11 14:46:08.226 +07:00 [DBG] Closing connection to database 'capbot_db' on server 'localhost'.
+2025-08-11 14:46:08.226 +07:00 [DBG] Closed connection to database 'capbot_db' on server 'localhost' (0ms).
+2025-08-11 14:46:08.226 +07:00 [DBG] Opening connection to database 'capbot_db' on server 'localhost'.
+2025-08-11 14:46:08.227 +07:00 [DBG] Opened connection to database 'capbot_db' on server 'localhost'.
+2025-08-11 14:46:08.227 +07:00 [DBG] Creating DbCommand for 'ExecuteReader'.
+2025-08-11 14:46:08.227 +07:00 [DBG] Created DbCommand for 'ExecuteReader' (0ms).
+2025-08-11 14:46:08.227 +07:00 [DBG] Initialized DbCommand for 'ExecuteReader' (0ms).
+2025-08-11 14:46:08.227 +07:00 [DBG] Executing DbCommand [Parameters=[@__normalizedName_0='?' (Size = 4000)], CommandType='"Text"', CommandTimeout='30']
+SELECT TOP(1) [r].[Id], [r].[ConcurrencyStamp], [r].[IsAdmin], [r].[Name], [r].[NormalizedName]
+FROM [roles] AS [r]
+WHERE [r].[NormalizedName] = @__normalizedName_0
+2025-08-11 14:46:08.228 +07:00 [INF] Executed DbCommand (1ms) [Parameters=[@__normalizedName_0='?' (Size = 4000)], CommandType='"Text"', CommandTimeout='30']
+SELECT TOP(1) [r].[Id], [r].[ConcurrencyStamp], [r].[IsAdmin], [r].[Name], [r].[NormalizedName]
+FROM [roles] AS [r]
+WHERE [r].[NormalizedName] = @__normalizedName_0
+2025-08-11 14:46:08.229 +07:00 [DBG] Context 'MyDbContext' started tracking 'Role' entity. Consider using 'DbContextOptionsBuilder.EnableSensitiveDataLogging' to see key values.
+2025-08-11 14:46:08.229 +07:00 [DBG] Closing data reader to 'capbot_db' on server 'localhost'.
+2025-08-11 14:46:08.229 +07:00 [DBG] A data reader for 'capbot_db' on server 'localhost' is being disposed after spending 0ms reading results.
+2025-08-11 14:46:08.229 +07:00 [DBG] Closing connection to database 'capbot_db' on server 'localhost'.
+2025-08-11 14:46:08.230 +07:00 [DBG] Closed connection to database 'capbot_db' on server 'localhost' (0ms).
+2025-08-11 14:46:08.233 +07:00 [DBG] Compiling query expression: 
+'DbSet<User>()
+    .SingleOrDefault(u => u.NormalizedEmail == __normalizedEmail_0)'
+2025-08-11 14:46:08.238 +07:00 [DBG] Generated query execution expression: 
+'queryContext => ShapedQueryCompilingExpressionVisitor.SingleOrDefaultAsync<User>(
+    asyncEnumerable: new SingleQueryingEnumerable<User>(
+        (RelationalQueryContext)queryContext, 
+        RelationalCommandCache.QueryExpression(
+            Projection Mapping:
+                EmptyProjectionMember -> Dictionary<IProperty, int> { [Property: User.Id (int) Required PK AfterSave:Throw ValueGenerated.OnAdd, 0], [Property: User.AccessFailedCount (int) Required, 1], [Property: User.ConcurrencyStamp (string), 2], [Property: User.CreatedAt (DateTime) Required, 3], [Property: User.DeletedAt (DateTime?), 4], [Property: User.Email (string), 5], [Property: User.EmailConfirmed (bool) Required, 6], [Property: User.LastModifiedAt (DateTime) Required, 7], [Property: User.LastModifiedBy (string), 8], [Property: User.LockoutEnabled (bool) Required, 9], [Property: User.LockoutEnd (DateTimeOffset?), 10], [Property: User.NormalizedEmail (string), 11], [Property: User.NormalizedUserName (string), 12], [Property: User.PasswordHash (string), 13], [Property: User.PhoneNumber (string), 14], [Property: User.PhoneNumberConfirmed (bool) Required, 15], [Property: User.SecurityStamp (string), 16], [Property: User.TwoFactorEnabled (bool) Required, 17], [Property: User.UserName (string), 18] }
+            SELECT TOP(2) u.Id, u.AccessFailedCount, u.ConcurrencyStamp, u.CreatedAt, u.DeletedAt, u.Email, u.EmailConfirmed, u.LastModifiedAt, u.LastModifiedBy, u.LockoutEnabled, u.LockoutEnd, u.NormalizedEmail, u.NormalizedUserName, u.PasswordHash, u.PhoneNumber, u.PhoneNumberConfirmed, u.SecurityStamp, u.TwoFactorEnabled, u.UserName
+            FROM users AS u
+            WHERE u.NormalizedEmail == @__normalizedEmail_0), 
+        null, 
+        Func<QueryContext, DbDataReader, ResultContext, SingleQueryResultCoordinator, User>, 
+        App.DAL.Context.MyDbContext, 
+        False, 
+        False, 
+        True
+    ), 
+    cancellationToken: queryContext.CancellationToken)'
+2025-08-11 14:46:08.240 +07:00 [DBG] Opening connection to database 'capbot_db' on server 'localhost'.
+2025-08-11 14:46:08.241 +07:00 [DBG] Opened connection to database 'capbot_db' on server 'localhost'.
+2025-08-11 14:46:08.241 +07:00 [DBG] Creating DbCommand for 'ExecuteReader'.
+2025-08-11 14:46:08.241 +07:00 [DBG] Created DbCommand for 'ExecuteReader' (0ms).
+2025-08-11 14:46:08.241 +07:00 [DBG] Initialized DbCommand for 'ExecuteReader' (0ms).
+2025-08-11 14:46:08.242 +07:00 [DBG] Executing DbCommand [Parameters=[@__normalizedEmail_0='?' (Size = 4000)], CommandType='"Text"', CommandTimeout='30']
+SELECT TOP(2) [u].[Id], [u].[AccessFailedCount], [u].[ConcurrencyStamp], [u].[CreatedAt], [u].[DeletedAt], [u].[Email], [u].[EmailConfirmed], [u].[LastModifiedAt], [u].[LastModifiedBy], [u].[LockoutEnabled], [u].[LockoutEnd], [u].[NormalizedEmail], [u].[NormalizedUserName], [u].[PasswordHash], [u].[PhoneNumber], [u].[PhoneNumberConfirmed], [u].[SecurityStamp], [u].[TwoFactorEnabled], [u].[UserName]
+FROM [users] AS [u]
+WHERE [u].[NormalizedEmail] = @__normalizedEmail_0
+2025-08-11 14:46:08.245 +07:00 [INF] Executed DbCommand (4ms) [Parameters=[@__normalizedEmail_0='?' (Size = 4000)], CommandType='"Text"', CommandTimeout='30']
+SELECT TOP(2) [u].[Id], [u].[AccessFailedCount], [u].[ConcurrencyStamp], [u].[CreatedAt], [u].[DeletedAt], [u].[Email], [u].[EmailConfirmed], [u].[LastModifiedAt], [u].[LastModifiedBy], [u].[LockoutEnabled], [u].[LockoutEnd], [u].[NormalizedEmail], [u].[NormalizedUserName], [u].[PasswordHash], [u].[PhoneNumber], [u].[PhoneNumberConfirmed], [u].[SecurityStamp], [u].[TwoFactorEnabled], [u].[UserName]
+FROM [users] AS [u]
+WHERE [u].[NormalizedEmail] = @__normalizedEmail_0
+2025-08-11 14:46:08.262 +07:00 [DBG] Context 'MyDbContext' started tracking 'User' entity. Consider using 'DbContextOptionsBuilder.EnableSensitiveDataLogging' to see key values.
+2025-08-11 14:46:08.285 +07:00 [DBG] Closing data reader to 'capbot_db' on server 'localhost'.
+2025-08-11 14:46:08.285 +07:00 [DBG] A data reader for 'capbot_db' on server 'localhost' is being disposed after spending 39ms reading results.
+2025-08-11 14:46:08.286 +07:00 [DBG] Closing connection to database 'capbot_db' on server 'localhost'.
+2025-08-11 14:46:08.286 +07:00 [DBG] Closed connection to database 'capbot_db' on server 'localhost' (0ms).
+2025-08-11 14:46:08.288 +07:00 [INF] Admin user 'fptslayer@gmail.com' already exists
+2025-08-11 14:46:08.290 +07:00 [DBG] Opening connection to database 'capbot_db' on server 'localhost'.
+2025-08-11 14:46:08.291 +07:00 [DBG] Opened connection to database 'capbot_db' on server 'localhost'.
+2025-08-11 14:46:08.291 +07:00 [DBG] Creating DbCommand for 'ExecuteReader'.
+2025-08-11 14:46:08.291 +07:00 [DBG] Created DbCommand for 'ExecuteReader' (0ms).
+2025-08-11 14:46:08.292 +07:00 [DBG] Initialized DbCommand for 'ExecuteReader' (0ms).
+2025-08-11 14:46:08.292 +07:00 [DBG] Executing DbCommand [Parameters=[@__normalizedEmail_0='?' (Size = 4000)], CommandType='"Text"', CommandTimeout='30']
+SELECT TOP(2) [u].[Id], [u].[AccessFailedCount], [u].[ConcurrencyStamp], [u].[CreatedAt], [u].[DeletedAt], [u].[Email], [u].[EmailConfirmed], [u].[LastModifiedAt], [u].[LastModifiedBy], [u].[LockoutEnabled], [u].[LockoutEnd], [u].[NormalizedEmail], [u].[NormalizedUserName], [u].[PasswordHash], [u].[PhoneNumber], [u].[PhoneNumberConfirmed], [u].[SecurityStamp], [u].[TwoFactorEnabled], [u].[UserName]
+FROM [users] AS [u]
+WHERE [u].[NormalizedEmail] = @__normalizedEmail_0
+2025-08-11 14:46:08.293 +07:00 [INF] Executed DbCommand (1ms) [Parameters=[@__normalizedEmail_0='?' (Size = 4000)], CommandType='"Text"', CommandTimeout='30']
+SELECT TOP(2) [u].[Id], [u].[AccessFailedCount], [u].[ConcurrencyStamp], [u].[CreatedAt], [u].[DeletedAt], [u].[Email], [u].[EmailConfirmed], [u].[LastModifiedAt], [u].[LastModifiedBy], [u].[LockoutEnabled], [u].[LockoutEnd], [u].[NormalizedEmail], [u].[NormalizedUserName], [u].[PasswordHash], [u].[PhoneNumber], [u].[PhoneNumberConfirmed], [u].[SecurityStamp], [u].[TwoFactorEnabled], [u].[UserName]
+FROM [users] AS [u]
+WHERE [u].[NormalizedEmail] = @__normalizedEmail_0
+2025-08-11 14:46:08.294 +07:00 [DBG] Context 'MyDbContext' started tracking 'User' entity. Consider using 'DbContextOptionsBuilder.EnableSensitiveDataLogging' to see key values.
+2025-08-11 14:46:08.294 +07:00 [DBG] Closing data reader to 'capbot_db' on server 'localhost'.
+2025-08-11 14:46:08.294 +07:00 [DBG] A data reader for 'capbot_db' on server 'localhost' is being disposed after spending 0ms reading results.
+2025-08-11 14:46:08.294 +07:00 [DBG] Closing connection to database 'capbot_db' on server 'localhost'.
+2025-08-11 14:46:08.295 +07:00 [DBG] Closed connection to database 'capbot_db' on server 'localhost' (0ms).
+2025-08-11 14:46:08.295 +07:00 [INF] Sample moderator 'moderator@example.com' already exists
+2025-08-11 14:46:08.295 +07:00 [DBG] Opening connection to database 'capbot_db' on server 'localhost'.
+2025-08-11 14:46:08.295 +07:00 [DBG] Opened connection to database 'capbot_db' on server 'localhost'.
+2025-08-11 14:46:08.295 +07:00 [DBG] Creating DbCommand for 'ExecuteReader'.
+2025-08-11 14:46:08.296 +07:00 [DBG] Created DbCommand for 'ExecuteReader' (0ms).
+2025-08-11 14:46:08.296 +07:00 [DBG] Initialized DbCommand for 'ExecuteReader' (0ms).
+2025-08-11 14:46:08.296 +07:00 [DBG] Executing DbCommand [Parameters=[@__normalizedEmail_0='?' (Size = 4000)], CommandType='"Text"', CommandTimeout='30']
+SELECT TOP(2) [u].[Id], [u].[AccessFailedCount], [u].[ConcurrencyStamp], [u].[CreatedAt], [u].[DeletedAt], [u].[Email], [u].[EmailConfirmed], [u].[LastModifiedAt], [u].[LastModifiedBy], [u].[LockoutEnabled], [u].[LockoutEnd], [u].[NormalizedEmail], [u].[NormalizedUserName], [u].[PasswordHash], [u].[PhoneNumber], [u].[PhoneNumberConfirmed], [u].[SecurityStamp], [u].[TwoFactorEnabled], [u].[UserName]
+FROM [users] AS [u]
+WHERE [u].[NormalizedEmail] = @__normalizedEmail_0
+2025-08-11 14:46:08.297 +07:00 [INF] Executed DbCommand (1ms) [Parameters=[@__normalizedEmail_0='?' (Size = 4000)], CommandType='"Text"', CommandTimeout='30']
+SELECT TOP(2) [u].[Id], [u].[AccessFailedCount], [u].[ConcurrencyStamp], [u].[CreatedAt], [u].[DeletedAt], [u].[Email], [u].[EmailConfirmed], [u].[LastModifiedAt], [u].[LastModifiedBy], [u].[LockoutEnabled], [u].[LockoutEnd], [u].[NormalizedEmail], [u].[NormalizedUserName], [u].[PasswordHash], [u].[PhoneNumber], [u].[PhoneNumberConfirmed], [u].[SecurityStamp], [u].[TwoFactorEnabled], [u].[UserName]
+FROM [users] AS [u]
+WHERE [u].[NormalizedEmail] = @__normalizedEmail_0
+2025-08-11 14:46:08.297 +07:00 [DBG] Context 'MyDbContext' started tracking 'User' entity. Consider using 'DbContextOptionsBuilder.EnableSensitiveDataLogging' to see key values.
+2025-08-11 14:46:08.298 +07:00 [DBG] Closing data reader to 'capbot_db' on server 'localhost'.
+2025-08-11 14:46:08.298 +07:00 [DBG] A data reader for 'capbot_db' on server 'localhost' is being disposed after spending 0ms reading results.
+2025-08-11 14:46:08.298 +07:00 [DBG] Closing connection to database 'capbot_db' on server 'localhost'.
+2025-08-11 14:46:08.298 +07:00 [DBG] Closed connection to database 'capbot_db' on server 'localhost' (0ms).
+2025-08-11 14:46:08.298 +07:00 [DBG] Opening connection to database 'capbot_db' on server 'localhost'.
+2025-08-11 14:46:08.299 +07:00 [DBG] Opened connection to database 'capbot_db' on server 'localhost'.
+2025-08-11 14:46:08.299 +07:00 [DBG] Creating DbCommand for 'ExecuteReader'.
+2025-08-11 14:46:08.299 +07:00 [DBG] Created DbCommand for 'ExecuteReader' (0ms).
+2025-08-11 14:46:08.299 +07:00 [DBG] Initialized DbCommand for 'ExecuteReader' (0ms).
+2025-08-11 14:46:08.299 +07:00 [DBG] Executing DbCommand [Parameters=[@__normalizedEmail_0='?' (Size = 4000)], CommandType='"Text"', CommandTimeout='30']
+SELECT TOP(2) [u].[Id], [u].[AccessFailedCount], [u].[ConcurrencyStamp], [u].[CreatedAt], [u].[DeletedAt], [u].[Email], [u].[EmailConfirmed], [u].[LastModifiedAt], [u].[LastModifiedBy], [u].[LockoutEnabled], [u].[LockoutEnd], [u].[NormalizedEmail], [u].[NormalizedUserName], [u].[PasswordHash], [u].[PhoneNumber], [u].[PhoneNumberConfirmed], [u].[SecurityStamp], [u].[TwoFactorEnabled], [u].[UserName]
+FROM [users] AS [u]
+WHERE [u].[NormalizedEmail] = @__normalizedEmail_0
+2025-08-11 14:46:08.300 +07:00 [INF] Executed DbCommand (1ms) [Parameters=[@__normalizedEmail_0='?' (Size = 4000)], CommandType='"Text"', CommandTimeout='30']
+SELECT TOP(2) [u].[Id], [u].[AccessFailedCount], [u].[ConcurrencyStamp], [u].[CreatedAt], [u].[DeletedAt], [u].[Email], [u].[EmailConfirmed], [u].[LastModifiedAt], [u].[LastModifiedBy], [u].[LockoutEnabled], [u].[LockoutEnd], [u].[NormalizedEmail], [u].[NormalizedUserName], [u].[PasswordHash], [u].[PhoneNumber], [u].[PhoneNumberConfirmed], [u].[SecurityStamp], [u].[TwoFactorEnabled], [u].[UserName]
+FROM [users] AS [u]
+WHERE [u].[NormalizedEmail] = @__normalizedEmail_0
+2025-08-11 14:46:08.301 +07:00 [DBG] Context 'MyDbContext' started tracking 'User' entity. Consider using 'DbContextOptionsBuilder.EnableSensitiveDataLogging' to see key values.
+2025-08-11 14:46:08.301 +07:00 [DBG] Closing data reader to 'capbot_db' on server 'localhost'.
+2025-08-11 14:46:08.301 +07:00 [DBG] A data reader for 'capbot_db' on server 'localhost' is being disposed after spending 0ms reading results.
+2025-08-11 14:46:08.302 +07:00 [DBG] Closing connection to database 'capbot_db' on server 'localhost'.
+2025-08-11 14:46:08.302 +07:00 [DBG] Closed connection to database 'capbot_db' on server 'localhost' (0ms).
+2025-08-11 14:46:08.302 +07:00 [INF] Data seeding completed successfully
+2025-08-11 14:46:08.303 +07:00 [DBG] 'MyDbContext' disposed.
+2025-08-11 14:46:08.305 +07:00 [DBG] Disposing connection to database 'capbot_db' on server 'localhost'.
+2025-08-11 14:46:08.305 +07:00 [DBG] Disposed connection to database '' on server '' (0ms).
+2025-08-11 14:46:08.443 +07:00 [DBG] Registered model binder providers, in the following order: ["Microsoft.AspNetCore.Mvc.ModelBinding.Binders.BinderTypeModelBinderProvider","Microsoft.AspNetCore.Mvc.ModelBinding.Binders.ServicesModelBinderProvider","Microsoft.AspNetCore.Mvc.ModelBinding.Binders.BodyModelBinderProvider","Microsoft.AspNetCore.Mvc.ModelBinding.Binders.HeaderModelBinderProvider","Microsoft.AspNetCore.Mvc.ModelBinding.Binders.FloatingPointTypeModelBinderProvider","Microsoft.AspNetCore.Mvc.ModelBinding.Binders.EnumTypeModelBinderProvider","Microsoft.AspNetCore.Mvc.ModelBinding.Binders.DateTimeModelBinderProvider","Microsoft.AspNetCore.Mvc.ModelBinding.Binders.SimpleTypeModelBinderProvider","Microsoft.AspNetCore.Mvc.ModelBinding.Binders.TryParseModelBinderProvider","Microsoft.AspNetCore.Mvc.ModelBinding.Binders.CancellationTokenModelBinderProvider"]
+2025-08-11 14:46:08.515 +07:00 [DBG] Hosting starting
+2025-08-11 14:46:08.520 +07:00 [DBG] Reading data from file 'C:\Users\Admin\AppData\Local\ASP.NET\DataProtection-Keys\key-1d6bcff1-a155-4167-8a22-de35a5f05047.xml'.
+2025-08-11 14:46:08.522 +07:00 [DBG] Reading data from file 'C:\Users\Admin\AppData\Local\ASP.NET\DataProtection-Keys\key-2459dd29-32d5-4c49-ac9d-33896047bb78.xml'.
+2025-08-11 14:46:08.523 +07:00 [DBG] Reading data from file 'C:\Users\Admin\AppData\Local\ASP.NET\DataProtection-Keys\key-374624f1-e856-4617-8ae6-fe6a81ce6346.xml'.
+2025-08-11 14:46:08.525 +07:00 [DBG] Found key {1d6bcff1-a155-4167-8a22-de35a5f05047}.
+2025-08-11 14:46:08.529 +07:00 [DBG] Found key {2459dd29-32d5-4c49-ac9d-33896047bb78}.
+2025-08-11 14:46:08.529 +07:00 [DBG] Found key {374624f1-e856-4617-8ae6-fe6a81ce6346}.
+2025-08-11 14:46:08.533 +07:00 [DBG] Considering key {2459dd29-32d5-4c49-ac9d-33896047bb78} with expiration date 2025-11-03 12:40:53Z as default key.
+2025-08-11 14:46:08.535 +07:00 [DBG] Forwarded activator type request from Microsoft.AspNetCore.DataProtection.XmlEncryption.DpapiXmlDecryptor, Microsoft.AspNetCore.DataProtection, Version=8.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60 to Microsoft.AspNetCore.DataProtection.XmlEncryption.DpapiXmlDecryptor, Microsoft.AspNetCore.DataProtection, Culture=neutral, PublicKeyToken=adb9793829ddae60
+2025-08-11 14:46:08.536 +07:00 [DBG] Decrypting secret element using Windows DPAPI.
+2025-08-11 14:46:08.538 +07:00 [DBG] Forwarded activator type request from Microsoft.AspNetCore.DataProtection.AuthenticatedEncryption.ConfigurationModel.AuthenticatedEncryptorDescriptorDeserializer, Microsoft.AspNetCore.DataProtection, Version=8.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60 to Microsoft.AspNetCore.DataProtection.AuthenticatedEncryption.ConfigurationModel.AuthenticatedEncryptorDescriptorDeserializer, Microsoft.AspNetCore.DataProtection, Culture=neutral, PublicKeyToken=adb9793829ddae60
+2025-08-11 14:46:08.539 +07:00 [DBG] Opening CNG algorithm 'AES' from provider 'null' with chaining mode CBC.
+2025-08-11 14:46:08.540 +07:00 [DBG] Opening CNG algorithm 'SHA256' from provider 'null' with HMAC.
+2025-08-11 14:46:08.542 +07:00 [DBG] Using key {2459dd29-32d5-4c49-ac9d-33896047bb78} as the default key.
+2025-08-11 14:46:08.543 +07:00 [DBG] Key ring with default key {2459dd29-32d5-4c49-ac9d-33896047bb78} was loaded during application startup.
+2025-08-11 14:46:08.648 +07:00 [INF] Now listening on: https://localhost:7190
+2025-08-11 14:46:08.649 +07:00 [DBG] Loaded hosting startup assembly CapBot.api
+2025-08-11 14:46:08.649 +07:00 [DBG] Loaded hosting startup assembly Microsoft.WebTools.ApiEndpointDiscovery
+2025-08-11 14:46:08.649 +07:00 [DBG] Loaded hosting startup assembly Microsoft.AspNetCore.Watch.BrowserRefresh
+2025-08-11 14:46:08.650 +07:00 [DBG] Loaded hosting startup assembly Microsoft.WebTools.BrowserLink.Net
+2025-08-11 14:46:08.702 +07:00 [INF] Application started. Press Ctrl+C to shut down.
+2025-08-11 14:46:08.703 +07:00 [INF] Hosting environment: Development
+2025-08-11 14:46:08.704 +07:00 [INF] Content root path: C:\Users\Admin\Downloads\CBAI_API\CapBot.api
+2025-08-11 14:46:08.704 +07:00 [DBG] Hosting started
+2025-08-11 14:46:08.761 +07:00 [DBG] Connection id "0HNEOLCH97SLG" accepted.
+2025-08-11 14:46:08.761 +07:00 [DBG] Connection id "0HNEOLCH97SLF" accepted.
+2025-08-11 14:46:08.762 +07:00 [DBG] Connection id "0HNEOLCH97SLG" started.
+2025-08-11 14:46:08.762 +07:00 [DBG] Connection id "0HNEOLCH97SLF" started.
+2025-08-11 14:46:08.778 +07:00 [DBG] Connection id "0HNEOLCH97SLF" received FIN.
+2025-08-11 14:46:08.778 +07:00 [DBG] Connection id "0HNEOLCH97SLG" received FIN.
+2025-08-11 14:46:08.792 +07:00 [DBG] Failed to authenticate HTTPS connection.
+System.IO.IOException: Received an unexpected EOF or 0 bytes from the transport stream.
+   at System.Net.Security.SslStream.ReceiveHandshakeFrameAsync[TIOAdapter](CancellationToken cancellationToken)
+   at System.Net.Security.SslStream.ForceAuthenticationAsync[TIOAdapter](Boolean receiveFirst, Byte[] reAuthenticationData, CancellationToken cancellationToken)
+   at System.Net.Security.SslStream.ProcessAuthenticationWithTelemetryAsync(Boolean isAsync, CancellationToken cancellationToken)
+   at Microsoft.AspNetCore.Server.Kestrel.Https.Internal.HttpsConnectionMiddleware.OnConnectionAsync(ConnectionContext context)
+2025-08-11 14:46:08.792 +07:00 [DBG] Failed to authenticate HTTPS connection.
+System.IO.IOException: Received an unexpected EOF or 0 bytes from the transport stream.
+   at System.Net.Security.SslStream.ReceiveHandshakeFrameAsync[TIOAdapter](CancellationToken cancellationToken)
+   at System.Net.Security.SslStream.ForceAuthenticationAsync[TIOAdapter](Boolean receiveFirst, Byte[] reAuthenticationData, CancellationToken cancellationToken)
+   at System.Net.Security.SslStream.ProcessAuthenticationWithTelemetryAsync(Boolean isAsync, CancellationToken cancellationToken)
+   at Microsoft.AspNetCore.Server.Kestrel.Https.Internal.HttpsConnectionMiddleware.OnConnectionAsync(ConnectionContext context)
+2025-08-11 14:46:08.802 +07:00 [DBG] Connection id "0HNEOLCH97SLG" stopped.
+2025-08-11 14:46:08.802 +07:00 [DBG] Connection id "0HNEOLCH97SLF" stopped.
+2025-08-11 14:46:08.805 +07:00 [DBG] Connection id "0HNEOLCH97SLG" sending FIN because: "The Socket transport's send loop completed gracefully."
+2025-08-11 14:46:08.805 +07:00 [DBG] Connection id "0HNEOLCH97SLF" sending FIN because: "The Socket transport's send loop completed gracefully."
+2025-08-11 14:46:08.869 +07:00 [DBG] Connection id "0HNEOLCH97SLH" accepted.
+2025-08-11 14:46:08.870 +07:00 [DBG] Connection id "0HNEOLCH97SLH" started.
+2025-08-11 14:46:08.961 +07:00 [DBG] Connection 0HNEOLCH97SLH established using the following protocol: "Tls13"
+2025-08-11 14:46:09.023 +07:00 [INF] Request starting HTTP/2 GET https://localhost:7190/index.html - null null
+2025-08-11 14:46:09.054 +07:00 [DBG] Wildcard detected, all requests with hosts will be allowed.
+2025-08-11 14:46:09.085 +07:00 [DBG] Response markup is scheduled to include Browser Link script injection.
+2025-08-11 14:46:09.087 +07:00 [DBG] Response markup is scheduled to include browser refresh script injection.
+2025-08-11 14:46:09.102 +07:00 [DBG] Response markup was updated to include Browser Link script injection.
+2025-08-11 14:46:09.103 +07:00 [DBG] Response markup was updated to include browser refresh script injection.
+2025-08-11 14:46:09.106 +07:00 [INF] Request finished HTTP/2 GET https://localhost:7190/index.html - 200 null text/html;charset=utf-8 88.7454ms
+2025-08-11 14:46:09.111 +07:00 [INF] Request starting HTTP/2 GET https://localhost:7190/_framework/aspnetcore-browser-refresh.js - null null
+2025-08-11 14:46:09.111 +07:00 [INF] Request starting HTTP/2 GET https://localhost:7190/_vs/browserLink - null null
+2025-08-11 14:46:09.117 +07:00 [INF] Request finished HTTP/2 GET https://localhost:7190/_framework/aspnetcore-browser-refresh.js - 200 13756 application/javascript; charset=utf-8 6.307ms
+2025-08-11 14:46:09.172 +07:00 [INF] Request finished HTTP/2 GET https://localhost:7190/_vs/browserLink - 200 null text/javascript; charset=UTF-8 60.7643ms
+2025-08-11 14:46:09.193 +07:00 [INF] Request starting HTTP/2 GET https://localhost:7190/swagger/v1/swagger.json - null null
+2025-08-11 14:46:09.220 +07:00 [INF] Request finished HTTP/2 GET https://localhost:7190/swagger/v1/swagger.json - 200 null application/json;charset=utf-8 26.6902ms
+2025-08-11 14:46:12.343 +07:00 [INF] Application is shutting down...
+2025-08-11 14:46:12.347 +07:00 [DBG] Hosting stopping
+2025-08-11 14:46:12.360 +07:00 [DBG] Connection id "0HNEOLCH97SLH" is closing.
+2025-08-11 14:46:12.361 +07:00 [DBG] Connection id "0HNEOLCH97SLH" is closed. The last processed stream ID was 7.
+2025-08-11 14:46:12.362 +07:00 [DBG] Connection id "0HNEOLCH97SLH" received FIN.
+2025-08-11 14:46:12.362 +07:00 [DBG] Connection id "0HNEOLCH97SLH" sending FIN because: "The Socket transport's send loop completed gracefully."
+2025-08-11 14:46:12.365 +07:00 [DBG] The connection queue processing loop for 0HNEOLCH97SLH completed.
+2025-08-11 14:46:12.367 +07:00 [DBG] Connection id "0HNEOLCH97SLH" stopped.
+2025-08-11 14:46:12.369 +07:00 [DBG] Hosting stopped
+2025-08-11 14:46:20.084 +07:00 [DBG] An 'IServiceProvider' was created for internal use by Entity Framework.
+2025-08-11 14:46:20.178 +07:00 [INF] User profile is available. Using 'C:\Users\Admin\AppData\Local\ASP.NET\DataProtection-Keys' as key repository and Windows DPAPI to encrypt keys at rest.
+2025-08-11 14:46:20.342 +07:00 [DBG] No relationship from 'ReviewerAssignment' to 'User' has been configured by convention because there are multiple properties on one entity type - {'AssignedByUser', 'Reviewer'} that could be matched with the properties on the other entity type - {'ReviewerAssignments'}. This message can be disregarded if explicit configuration has been specified in 'OnModelCreating'.
+2025-08-11 14:46:20.355 +07:00 [DBG] No relationship from 'SubmissionWorkflowLog' to 'WorkflowState' has been configured by convention because there are multiple properties on one entity type - {'FromState', 'ToState'} that could be matched with the properties on the other entity type - {'FromStateLogs', 'ToStateLogs'}. This message can be disregarded if explicit configuration has been specified in 'OnModelCreating'.
+2025-08-11 14:46:20.364 +07:00 [DBG] No relationship from 'User' to 'ReviewerAssignment' has been configured by convention because there are multiple properties on one entity type - {'ReviewerAssignments'} that could be matched with the properties on the other entity type - {'AssignedByUser', 'Reviewer'}. This message can be disregarded if explicit configuration has been specified in 'OnModelCreating'.
+2025-08-11 14:46:20.365 +07:00 [DBG] No relationship from 'WorkflowState' to 'SubmissionWorkflowLog' has been configured by convention because there are multiple properties on one entity type - {'FromStateLogs', 'ToStateLogs'} that could be matched with the properties on the other entity type - {'FromState', 'ToState'}. This message can be disregarded if explicit configuration has been specified in 'OnModelCreating'.
+2025-08-11 14:46:20.366 +07:00 [DBG] No relationship from 'WorkflowState' to 'WorkflowTransition' has been configured by convention because there are multiple properties on one entity type - {'FromTransitions', 'ToTransitions'} that could be matched with the properties on the other entity type - {'FromState', 'ToState'}. This message can be disregarded if explicit configuration has been specified in 'OnModelCreating'.
+2025-08-11 14:46:20.367 +07:00 [DBG] No relationship from 'WorkflowTransition' to 'WorkflowState' has been configured by convention because there are multiple properties on one entity type - {'FromState', 'ToState'} that could be matched with the properties on the other entity type - {'FromTransitions', 'ToTransitions'}. This message can be disregarded if explicit configuration has been specified in 'OnModelCreating'.
+2025-08-11 14:46:20.494 +07:00 [DBG] No relationship from 'ReviewerAssignment' to 'User' has been configured by convention because there are multiple properties on one entity type - {'AssignedByUser', 'Reviewer'} that could be matched with the properties on the other entity type - {'ReviewerAssignments'}. This message can be disregarded if explicit configuration has been specified in 'OnModelCreating'.
+2025-08-11 14:46:20.495 +07:00 [DBG] No relationship from 'User' to 'ReviewerAssignment' has been configured by convention because there are multiple properties on one entity type - {'ReviewerAssignments'} that could be matched with the properties on the other entity type - {'AssignedByUser', 'Reviewer'}. This message can be disregarded if explicit configuration has been specified in 'OnModelCreating'.
+2025-08-11 14:46:20.510 +07:00 [DBG] No relationship from 'WorkflowTransition' to 'WorkflowState' has been configured by convention because there are multiple properties on one entity type - {'FromState', 'ToState'} that could be matched with the properties on the other entity type - {'FromTransitions', 'ToTransitions'}. This message can be disregarded if explicit configuration has been specified in 'OnModelCreating'.
+2025-08-11 14:46:20.511 +07:00 [DBG] No relationship from 'WorkflowState' to 'SubmissionWorkflowLog' has been configured by convention because there are multiple properties on one entity type - {'FromStateLogs', 'ToStateLogs'} that could be matched with the properties on the other entity type - {'FromState', 'ToState'}. This message can be disregarded if explicit configuration has been specified in 'OnModelCreating'.
+2025-08-11 14:46:20.511 +07:00 [DBG] No relationship from 'WorkflowState' to 'WorkflowTransition' has been configured by convention because there are multiple properties on one entity type - {'FromTransitions', 'ToTransitions'} that could be matched with the properties on the other entity type - {'FromState', 'ToState'}. This message can be disregarded if explicit configuration has been specified in 'OnModelCreating'.
+2025-08-11 14:46:20.512 +07:00 [DBG] No relationship from 'WorkflowState' to 'SubmissionWorkflowLog' has been configured by convention because there are multiple properties on one entity type - {'FromStateLogs', 'ToStateLogs'} that could be matched with the properties on the other entity type - {'FromState', 'ToState'}. This message can be disregarded if explicit configuration has been specified in 'OnModelCreating'.
+2025-08-11 14:46:20.516 +07:00 [DBG] No relationship from 'SubmissionWorkflowLog' to 'WorkflowState' has been configured by convention because there are multiple properties on one entity type - {'FromState', 'ToState'} that could be matched with the properties on the other entity type - {'FromStateLogs', 'ToStateLogs'}. This message can be disregarded if explicit configuration has been specified in 'OnModelCreating'.
+2025-08-11 14:46:20.516 +07:00 [DBG] No relationship from 'WorkflowState' to 'SubmissionWorkflowLog' has been configured by convention because there are multiple properties on one entity type - {'FromStateLogs', 'ToStateLogs'} that could be matched with the properties on the other entity type - {'FromState', 'ToState'}. This message can be disregarded if explicit configuration has been specified in 'OnModelCreating'.
+2025-08-11 14:46:20.537 +07:00 [DBG] The index {'LecturerId'} was not created on entity type 'LecturerSkill' as the properties are already covered by the index {'LecturerId', 'SkillTag'}.
+2025-08-11 14:46:20.537 +07:00 [DBG] The index {'SemesterId'} was not created on entity type 'Phase' as the properties are already covered by the index {'SemesterId', 'PhaseTypeId'}.
+2025-08-11 14:46:20.537 +07:00 [DBG] The index {'AssignmentId'} was not created on entity type 'Review' as the properties are already covered by the index {'AssignmentId', 'Status'}.
+2025-08-11 14:46:20.538 +07:00 [DBG] The index {'ReviewId'} was not created on entity type 'ReviewComment' as the properties are already covered by the index {'ReviewId', 'SectionName'}.
+2025-08-11 14:46:20.539 +07:00 [DBG] The index {'ReviewId'} was not created on entity type 'ReviewCriteriaScore' as the properties are already covered by the index {'ReviewId', 'CriteriaId'}.
+2025-08-11 14:46:20.539 +07:00 [DBG] The index {'ReviewerId'} was not created on entity type 'ReviewerAssignment' as the properties are already covered by the index {'ReviewerId', 'Status'}.
+2025-08-11 14:46:20.539 +07:00 [DBG] The index {'SubmissionId'} was not created on entity type 'ReviewerAssignment' as the properties are already covered by the index {'SubmissionId', 'ReviewerId'}.
+2025-08-11 14:46:20.539 +07:00 [DBG] The index {'ReviewerId'} was not created on entity type 'ReviewerPerformance' as the properties are already covered by the index {'ReviewerId', 'SemesterId'}.
+2025-08-11 14:46:20.540 +07:00 [DBG] The index {'PhaseId'} was not created on entity type 'Submission' as the properties are already covered by the index {'PhaseId', 'Status'}.
+2025-08-11 14:46:20.540 +07:00 [DBG] The index {'PhaseId'} was not created on entity type 'Submission' as the properties are already covered by the index {'PhaseId', 'Status', 'SubmittedAt'}.
+2025-08-11 14:46:20.540 +07:00 [DBG] The index {'TopicVersionId'} was not created on entity type 'Submission' as the properties are already covered by the index {'TopicVersionId', 'PhaseId', 'SubmissionRound'}.
+2025-08-11 14:46:20.540 +07:00 [DBG] The index {'SubmissionId'} was not created on entity type 'SubmissionWorkflowLog' as the properties are already covered by the index {'SubmissionId', 'CreatedAt'}.
+2025-08-11 14:46:20.540 +07:00 [DBG] The index {'UserId'} was not created on entity type 'SystemNotification' as the properties are already covered by the index {'UserId', 'IsRead', 'CreatedAt'}.
+2025-08-11 14:46:20.541 +07:00 [DBG] The index {'SemesterId'} was not created on entity type 'Topic' as the properties are already covered by the index {'SemesterId', 'IsApproved'}.
+2025-08-11 14:46:20.541 +07:00 [DBG] The index {'SupervisorId'} was not created on entity type 'Topic' as the properties are already covered by the index {'SupervisorId', 'SemesterId'}.
+2025-08-11 14:46:20.541 +07:00 [DBG] The index {'TopicId'} was not created on entity type 'TopicVersion' as the properties are already covered by the index {'TopicId', 'Status'}.
+2025-08-11 14:46:20.541 +07:00 [DBG] The index {'TopicId'} was not created on entity type 'TopicVersion' as the properties are already covered by the index {'TopicId', 'VersionNumber'}.
+2025-08-11 14:46:20.541 +07:00 [DBG] The index {'UserId'} was not created on entity type 'UserRole' as the properties are already covered by the index {'UserId', 'RoleId'}.
+2025-08-11 14:46:20.542 +07:00 [DBG] The index {'UserId'} was not created on entity type 'UserToken' as the properties are already covered by the index {'UserId', 'LoginProvider', 'Name'}.
+2025-08-11 14:46:20.639 +07:00 [WRN] The 'ProficiencyLevels' property 'ProficiencyLevel' on entity type 'LecturerSkill' is configured with a database-generated default, but has no configured sentinel value. The database-generated default will always be used for inserts when the property has the value '0', since this is the CLR default for the 'ProficiencyLevels' type. Consider using a nullable type, using a nullable backing field, or setting the sentinel value for the property to ensure the database default is used when, and only when, appropriate. See https://aka.ms/efcore-docs-default-values for more information.
+2025-08-11 14:46:20.640 +07:00 [WRN] The 'ReviewRecommendations' property 'Recommendation' on entity type 'Review' is configured with a database-generated default, but has no configured sentinel value. The database-generated default will always be used for inserts when the property has the value '0', since this is the CLR default for the 'ReviewRecommendations' type. Consider using a nullable type, using a nullable backing field, or setting the sentinel value for the property to ensure the database default is used when, and only when, appropriate. See https://aka.ms/efcore-docs-default-values for more information.
+2025-08-11 14:46:20.640 +07:00 [WRN] The 'ReviewStatus' property 'Status' on entity type 'Review' is configured with a database-generated default, but has no configured sentinel value. The database-generated default will always be used for inserts when the property has the value '0', since this is the CLR default for the 'ReviewStatus' type. Consider using a nullable type, using a nullable backing field, or setting the sentinel value for the property to ensure the database default is used when, and only when, appropriate. See https://aka.ms/efcore-docs-default-values for more information.
+2025-08-11 14:46:20.641 +07:00 [WRN] The 'CommentTypes' property 'CommentType' on entity type 'ReviewComment' is configured with a database-generated default, but has no configured sentinel value. The database-generated default will always be used for inserts when the property has the value '0', since this is the CLR default for the 'CommentTypes' type. Consider using a nullable type, using a nullable backing field, or setting the sentinel value for the property to ensure the database default is used when, and only when, appropriate. See https://aka.ms/efcore-docs-default-values for more information.
+2025-08-11 14:46:20.641 +07:00 [WRN] The 'PriorityLevels' property 'Priority' on entity type 'ReviewComment' is configured with a database-generated default, but has no configured sentinel value. The database-generated default will always be used for inserts when the property has the value '0', since this is the CLR default for the 'PriorityLevels' type. Consider using a nullable type, using a nullable backing field, or setting the sentinel value for the property to ensure the database default is used when, and only when, appropriate. See https://aka.ms/efcore-docs-default-values for more information.
+2025-08-11 14:46:20.641 +07:00 [WRN] The 'AssignmentTypes' property 'AssignmentType' on entity type 'ReviewerAssignment' is configured with a database-generated default, but has no configured sentinel value. The database-generated default will always be used for inserts when the property has the value '0', since this is the CLR default for the 'AssignmentTypes' type. Consider using a nullable type, using a nullable backing field, or setting the sentinel value for the property to ensure the database default is used when, and only when, appropriate. See https://aka.ms/efcore-docs-default-values for more information.
+2025-08-11 14:46:20.641 +07:00 [WRN] The 'AssignmentStatus' property 'Status' on entity type 'ReviewerAssignment' is configured with a database-generated default, but has no configured sentinel value. The database-generated default will always be used for inserts when the property has the value '0', since this is the CLR default for the 'AssignmentStatus' type. Consider using a nullable type, using a nullable backing field, or setting the sentinel value for the property to ensure the database default is used when, and only when, appropriate. See https://aka.ms/efcore-docs-default-values for more information.
+2025-08-11 14:46:20.641 +07:00 [WRN] The 'AiCheckStatus' property 'AiCheckStatus' on entity type 'Submission' is configured with a database-generated default, but has no configured sentinel value. The database-generated default will always be used for inserts when the property has the value '0', since this is the CLR default for the 'AiCheckStatus' type. Consider using a nullable type, using a nullable backing field, or setting the sentinel value for the property to ensure the database default is used when, and only when, appropriate. See https://aka.ms/efcore-docs-default-values for more information.
+2025-08-11 14:46:20.642 +07:00 [WRN] The 'SubmissionStatus' property 'Status' on entity type 'Submission' is configured with a database-generated default, but has no configured sentinel value. The database-generated default will always be used for inserts when the property has the value '0', since this is the CLR default for the 'SubmissionStatus' type. Consider using a nullable type, using a nullable backing field, or setting the sentinel value for the property to ensure the database default is used when, and only when, appropriate. See https://aka.ms/efcore-docs-default-values for more information.
+2025-08-11 14:46:20.642 +07:00 [WRN] The 'NotificationTypes' property 'Type' on entity type 'SystemNotification' is configured with a database-generated default, but has no configured sentinel value. The database-generated default will always be used for inserts when the property has the value '0', since this is the CLR default for the 'NotificationTypes' type. Consider using a nullable type, using a nullable backing field, or setting the sentinel value for the property to ensure the database default is used when, and only when, appropriate. See https://aka.ms/efcore-docs-default-values for more information.
+2025-08-11 14:46:20.642 +07:00 [WRN] The 'TopicStatus' property 'Status' on entity type 'TopicVersion' is configured with a database-generated default, but has no configured sentinel value. The database-generated default will always be used for inserts when the property has the value '0', since this is the CLR default for the 'TopicStatus' type. Consider using a nullable type, using a nullable backing field, or setting the sentinel value for the property to ensure the database default is used when, and only when, appropriate. See https://aka.ms/efcore-docs-default-values for more information.
+2025-08-11 14:46:20.736 +07:00 [DBG] Entity Framework Core 8.0.16 initialized 'MyDbContext' using provider 'Microsoft.EntityFrameworkCore.SqlServer:8.0.13' with options: MigrationsAssembly=App.DAL 
+2025-08-11 14:46:20.786 +07:00 [DBG] Compiling query expression: 
+'DbSet<Role>()
+    .FirstOrDefault(r => r.NormalizedName == __normalizedName_0)'
+2025-08-11 14:46:20.885 +07:00 [DBG] Generated query execution expression: 
+'queryContext => ShapedQueryCompilingExpressionVisitor.SingleOrDefaultAsync<Role>(
+    asyncEnumerable: new SingleQueryingEnumerable<Role>(
+        (RelationalQueryContext)queryContext, 
+        RelationalCommandCache.QueryExpression(
+            Projection Mapping:
+                EmptyProjectionMember -> Dictionary<IProperty, int> { [Property: Role.Id (int) Required PK AfterSave:Throw ValueGenerated.OnAdd, 0], [Property: Role.ConcurrencyStamp (string), 1], [Property: Role.IsAdmin (bool) Required, 2], [Property: Role.Name (string), 3], [Property: Role.NormalizedName (string), 4] }
+            SELECT TOP(1) r.Id, r.ConcurrencyStamp, r.IsAdmin, r.Name, r.NormalizedName
+            FROM roles AS r
+            WHERE r.NormalizedName == @__normalizedName_0), 
+        null, 
+        Func<QueryContext, DbDataReader, ResultContext, SingleQueryResultCoordinator, Role>, 
+        App.DAL.Context.MyDbContext, 
+        False, 
+        False, 
+        True
+    ), 
+    cancellationToken: queryContext.CancellationToken)'
+2025-08-11 14:46:20.910 +07:00 [DBG] Creating DbConnection.
+2025-08-11 14:46:20.923 +07:00 [DBG] Created DbConnection. (11ms).
+2025-08-11 14:46:20.926 +07:00 [DBG] Opening connection to database 'capbot_db' on server 'localhost'.
+2025-08-11 14:46:21.126 +07:00 [DBG] Opened connection to database 'capbot_db' on server 'localhost'.
+2025-08-11 14:46:21.128 +07:00 [DBG] Creating DbCommand for 'ExecuteReader'.
+2025-08-11 14:46:21.132 +07:00 [DBG] Created DbCommand for 'ExecuteReader' (2ms).
+2025-08-11 14:46:21.136 +07:00 [DBG] Initialized DbCommand for 'ExecuteReader' (8ms).
+2025-08-11 14:46:21.142 +07:00 [DBG] Executing DbCommand [Parameters=[@__normalizedName_0='?' (Size = 4000)], CommandType='"Text"', CommandTimeout='30']
+SELECT TOP(1) [r].[Id], [r].[ConcurrencyStamp], [r].[IsAdmin], [r].[Name], [r].[NormalizedName]
+FROM [roles] AS [r]
+WHERE [r].[NormalizedName] = @__normalizedName_0
+2025-08-11 14:46:21.187 +07:00 [INF] Executed DbCommand (46ms) [Parameters=[@__normalizedName_0='?' (Size = 4000)], CommandType='"Text"', CommandTimeout='30']
+SELECT TOP(1) [r].[Id], [r].[ConcurrencyStamp], [r].[IsAdmin], [r].[Name], [r].[NormalizedName]
+FROM [roles] AS [r]
+WHERE [r].[NormalizedName] = @__normalizedName_0
+2025-08-11 14:46:21.213 +07:00 [DBG] Context 'MyDbContext' started tracking 'Role' entity. Consider using 'DbContextOptionsBuilder.EnableSensitiveDataLogging' to see key values.
+2025-08-11 14:46:21.233 +07:00 [DBG] Closing data reader to 'capbot_db' on server 'localhost'.
+2025-08-11 14:46:21.238 +07:00 [DBG] A data reader for 'capbot_db' on server 'localhost' is being disposed after spending 47ms reading results.
+2025-08-11 14:46:21.240 +07:00 [DBG] Closing connection to database 'capbot_db' on server 'localhost'.
+2025-08-11 14:46:21.244 +07:00 [DBG] Closed connection to database 'capbot_db' on server 'localhost' (3ms).
+2025-08-11 14:46:21.246 +07:00 [DBG] Opening connection to database 'capbot_db' on server 'localhost'.
+2025-08-11 14:46:21.248 +07:00 [DBG] Opened connection to database 'capbot_db' on server 'localhost'.
+2025-08-11 14:46:21.249 +07:00 [DBG] Creating DbCommand for 'ExecuteReader'.
+2025-08-11 14:46:21.250 +07:00 [DBG] Created DbCommand for 'ExecuteReader' (0ms).
+2025-08-11 14:46:21.250 +07:00 [DBG] Initialized DbCommand for 'ExecuteReader' (0ms).
+2025-08-11 14:46:21.251 +07:00 [DBG] Executing DbCommand [Parameters=[@__normalizedName_0='?' (Size = 4000)], CommandType='"Text"', CommandTimeout='30']
+SELECT TOP(1) [r].[Id], [r].[ConcurrencyStamp], [r].[IsAdmin], [r].[Name], [r].[NormalizedName]
+FROM [roles] AS [r]
+WHERE [r].[NormalizedName] = @__normalizedName_0
+2025-08-11 14:46:21.254 +07:00 [INF] Executed DbCommand (3ms) [Parameters=[@__normalizedName_0='?' (Size = 4000)], CommandType='"Text"', CommandTimeout='30']
+SELECT TOP(1) [r].[Id], [r].[ConcurrencyStamp], [r].[IsAdmin], [r].[Name], [r].[NormalizedName]
+FROM [roles] AS [r]
+WHERE [r].[NormalizedName] = @__normalizedName_0
+2025-08-11 14:46:21.254 +07:00 [DBG] Context 'MyDbContext' started tracking 'Role' entity. Consider using 'DbContextOptionsBuilder.EnableSensitiveDataLogging' to see key values.
+2025-08-11 14:46:21.255 +07:00 [DBG] Closing data reader to 'capbot_db' on server 'localhost'.
+2025-08-11 14:46:21.255 +07:00 [DBG] A data reader for 'capbot_db' on server 'localhost' is being disposed after spending 0ms reading results.
+2025-08-11 14:46:21.255 +07:00 [DBG] Closing connection to database 'capbot_db' on server 'localhost'.
+2025-08-11 14:46:21.255 +07:00 [DBG] Closed connection to database 'capbot_db' on server 'localhost' (0ms).
+2025-08-11 14:46:21.256 +07:00 [DBG] Opening connection to database 'capbot_db' on server 'localhost'.
+2025-08-11 14:46:21.256 +07:00 [DBG] Opened connection to database 'capbot_db' on server 'localhost'.
+2025-08-11 14:46:21.257 +07:00 [DBG] Creating DbCommand for 'ExecuteReader'.
+2025-08-11 14:46:21.257 +07:00 [DBG] Created DbCommand for 'ExecuteReader' (0ms).
+2025-08-11 14:46:21.257 +07:00 [DBG] Initialized DbCommand for 'ExecuteReader' (0ms).
+2025-08-11 14:46:21.257 +07:00 [DBG] Executing DbCommand [Parameters=[@__normalizedName_0='?' (Size = 4000)], CommandType='"Text"', CommandTimeout='30']
+SELECT TOP(1) [r].[Id], [r].[ConcurrencyStamp], [r].[IsAdmin], [r].[Name], [r].[NormalizedName]
+FROM [roles] AS [r]
+WHERE [r].[NormalizedName] = @__normalizedName_0
+2025-08-11 14:46:21.259 +07:00 [INF] Executed DbCommand (1ms) [Parameters=[@__normalizedName_0='?' (Size = 4000)], CommandType='"Text"', CommandTimeout='30']
+SELECT TOP(1) [r].[Id], [r].[ConcurrencyStamp], [r].[IsAdmin], [r].[Name], [r].[NormalizedName]
+FROM [roles] AS [r]
+WHERE [r].[NormalizedName] = @__normalizedName_0
+2025-08-11 14:46:21.259 +07:00 [DBG] Context 'MyDbContext' started tracking 'Role' entity. Consider using 'DbContextOptionsBuilder.EnableSensitiveDataLogging' to see key values.
+2025-08-11 14:46:21.259 +07:00 [DBG] Closing data reader to 'capbot_db' on server 'localhost'.
+2025-08-11 14:46:21.259 +07:00 [DBG] A data reader for 'capbot_db' on server 'localhost' is being disposed after spending 0ms reading results.
+2025-08-11 14:46:21.260 +07:00 [DBG] Closing connection to database 'capbot_db' on server 'localhost'.
+2025-08-11 14:46:21.260 +07:00 [DBG] Closed connection to database 'capbot_db' on server 'localhost' (0ms).
+2025-08-11 14:46:21.260 +07:00 [DBG] Opening connection to database 'capbot_db' on server 'localhost'.
+2025-08-11 14:46:21.260 +07:00 [DBG] Opened connection to database 'capbot_db' on server 'localhost'.
+2025-08-11 14:46:21.260 +07:00 [DBG] Creating DbCommand for 'ExecuteReader'.
+2025-08-11 14:46:21.260 +07:00 [DBG] Created DbCommand for 'ExecuteReader' (0ms).
+2025-08-11 14:46:21.261 +07:00 [DBG] Initialized DbCommand for 'ExecuteReader' (0ms).
+2025-08-11 14:46:21.261 +07:00 [DBG] Executing DbCommand [Parameters=[@__normalizedName_0='?' (Size = 4000)], CommandType='"Text"', CommandTimeout='30']
+SELECT TOP(1) [r].[Id], [r].[ConcurrencyStamp], [r].[IsAdmin], [r].[Name], [r].[NormalizedName]
+FROM [roles] AS [r]
+WHERE [r].[NormalizedName] = @__normalizedName_0
+2025-08-11 14:46:21.262 +07:00 [INF] Executed DbCommand (1ms) [Parameters=[@__normalizedName_0='?' (Size = 4000)], CommandType='"Text"', CommandTimeout='30']
+SELECT TOP(1) [r].[Id], [r].[ConcurrencyStamp], [r].[IsAdmin], [r].[Name], [r].[NormalizedName]
+FROM [roles] AS [r]
+WHERE [r].[NormalizedName] = @__normalizedName_0
+2025-08-11 14:46:21.262 +07:00 [DBG] Context 'MyDbContext' started tracking 'Role' entity. Consider using 'DbContextOptionsBuilder.EnableSensitiveDataLogging' to see key values.
+2025-08-11 14:46:21.262 +07:00 [DBG] Closing data reader to 'capbot_db' on server 'localhost'.
+2025-08-11 14:46:21.262 +07:00 [DBG] A data reader for 'capbot_db' on server 'localhost' is being disposed after spending 0ms reading results.
+2025-08-11 14:46:21.263 +07:00 [DBG] Closing connection to database 'capbot_db' on server 'localhost'.
+2025-08-11 14:46:21.265 +07:00 [DBG] Closed connection to database 'capbot_db' on server 'localhost' (2ms).
+2025-08-11 14:46:21.269 +07:00 [DBG] Compiling query expression: 
+'DbSet<User>()
+    .SingleOrDefault(u => u.NormalizedEmail == __normalizedEmail_0)'
+2025-08-11 14:46:21.274 +07:00 [DBG] Generated query execution expression: 
+'queryContext => ShapedQueryCompilingExpressionVisitor.SingleOrDefaultAsync<User>(
+    asyncEnumerable: new SingleQueryingEnumerable<User>(
+        (RelationalQueryContext)queryContext, 
+        RelationalCommandCache.QueryExpression(
+            Projection Mapping:
+                EmptyProjectionMember -> Dictionary<IProperty, int> { [Property: User.Id (int) Required PK AfterSave:Throw ValueGenerated.OnAdd, 0], [Property: User.AccessFailedCount (int) Required, 1], [Property: User.ConcurrencyStamp (string), 2], [Property: User.CreatedAt (DateTime) Required, 3], [Property: User.DeletedAt (DateTime?), 4], [Property: User.Email (string), 5], [Property: User.EmailConfirmed (bool) Required, 6], [Property: User.LastModifiedAt (DateTime) Required, 7], [Property: User.LastModifiedBy (string), 8], [Property: User.LockoutEnabled (bool) Required, 9], [Property: User.LockoutEnd (DateTimeOffset?), 10], [Property: User.NormalizedEmail (string), 11], [Property: User.NormalizedUserName (string), 12], [Property: User.PasswordHash (string), 13], [Property: User.PhoneNumber (string), 14], [Property: User.PhoneNumberConfirmed (bool) Required, 15], [Property: User.SecurityStamp (string), 16], [Property: User.TwoFactorEnabled (bool) Required, 17], [Property: User.UserName (string), 18] }
+            SELECT TOP(2) u.Id, u.AccessFailedCount, u.ConcurrencyStamp, u.CreatedAt, u.DeletedAt, u.Email, u.EmailConfirmed, u.LastModifiedAt, u.LastModifiedBy, u.LockoutEnabled, u.LockoutEnd, u.NormalizedEmail, u.NormalizedUserName, u.PasswordHash, u.PhoneNumber, u.PhoneNumberConfirmed, u.SecurityStamp, u.TwoFactorEnabled, u.UserName
+            FROM users AS u
+            WHERE u.NormalizedEmail == @__normalizedEmail_0), 
+        null, 
+        Func<QueryContext, DbDataReader, ResultContext, SingleQueryResultCoordinator, User>, 
+        App.DAL.Context.MyDbContext, 
+        False, 
+        False, 
+        True
+    ), 
+    cancellationToken: queryContext.CancellationToken)'
+2025-08-11 14:46:21.277 +07:00 [DBG] Opening connection to database 'capbot_db' on server 'localhost'.
+2025-08-11 14:46:21.277 +07:00 [DBG] Opened connection to database 'capbot_db' on server 'localhost'.
+2025-08-11 14:46:21.277 +07:00 [DBG] Creating DbCommand for 'ExecuteReader'.
+2025-08-11 14:46:21.277 +07:00 [DBG] Created DbCommand for 'ExecuteReader' (0ms).
+2025-08-11 14:46:21.277 +07:00 [DBG] Initialized DbCommand for 'ExecuteReader' (0ms).
+2025-08-11 14:46:21.278 +07:00 [DBG] Executing DbCommand [Parameters=[@__normalizedEmail_0='?' (Size = 4000)], CommandType='"Text"', CommandTimeout='30']
+SELECT TOP(2) [u].[Id], [u].[AccessFailedCount], [u].[ConcurrencyStamp], [u].[CreatedAt], [u].[DeletedAt], [u].[Email], [u].[EmailConfirmed], [u].[LastModifiedAt], [u].[LastModifiedBy], [u].[LockoutEnabled], [u].[LockoutEnd], [u].[NormalizedEmail], [u].[NormalizedUserName], [u].[PasswordHash], [u].[PhoneNumber], [u].[PhoneNumberConfirmed], [u].[SecurityStamp], [u].[TwoFactorEnabled], [u].[UserName]
+FROM [users] AS [u]
+WHERE [u].[NormalizedEmail] = @__normalizedEmail_0
+2025-08-11 14:46:21.283 +07:00 [INF] Executed DbCommand (6ms) [Parameters=[@__normalizedEmail_0='?' (Size = 4000)], CommandType='"Text"', CommandTimeout='30']
+SELECT TOP(2) [u].[Id], [u].[AccessFailedCount], [u].[ConcurrencyStamp], [u].[CreatedAt], [u].[DeletedAt], [u].[Email], [u].[EmailConfirmed], [u].[LastModifiedAt], [u].[LastModifiedBy], [u].[LockoutEnabled], [u].[LockoutEnd], [u].[NormalizedEmail], [u].[NormalizedUserName], [u].[PasswordHash], [u].[PhoneNumber], [u].[PhoneNumberConfirmed], [u].[SecurityStamp], [u].[TwoFactorEnabled], [u].[UserName]
+FROM [users] AS [u]
+WHERE [u].[NormalizedEmail] = @__normalizedEmail_0
+2025-08-11 14:46:21.298 +07:00 [DBG] Context 'MyDbContext' started tracking 'User' entity. Consider using 'DbContextOptionsBuilder.EnableSensitiveDataLogging' to see key values.
+2025-08-11 14:46:21.317 +07:00 [DBG] Closing data reader to 'capbot_db' on server 'localhost'.
+2025-08-11 14:46:21.317 +07:00 [DBG] A data reader for 'capbot_db' on server 'localhost' is being disposed after spending 33ms reading results.
+2025-08-11 14:46:21.318 +07:00 [DBG] Closing connection to database 'capbot_db' on server 'localhost'.
+2025-08-11 14:46:21.318 +07:00 [DBG] Closed connection to database 'capbot_db' on server 'localhost' (0ms).
+2025-08-11 14:46:21.320 +07:00 [INF] Admin user 'fptslayer@gmail.com' already exists
+2025-08-11 14:46:21.322 +07:00 [DBG] Opening connection to database 'capbot_db' on server 'localhost'.
+2025-08-11 14:46:21.322 +07:00 [DBG] Opened connection to database 'capbot_db' on server 'localhost'.
+2025-08-11 14:46:21.323 +07:00 [DBG] Creating DbCommand for 'ExecuteReader'.
+2025-08-11 14:46:21.323 +07:00 [DBG] Created DbCommand for 'ExecuteReader' (0ms).
+2025-08-11 14:46:21.323 +07:00 [DBG] Initialized DbCommand for 'ExecuteReader' (0ms).
+2025-08-11 14:46:21.324 +07:00 [DBG] Executing DbCommand [Parameters=[@__normalizedEmail_0='?' (Size = 4000)], CommandType='"Text"', CommandTimeout='30']
+SELECT TOP(2) [u].[Id], [u].[AccessFailedCount], [u].[ConcurrencyStamp], [u].[CreatedAt], [u].[DeletedAt], [u].[Email], [u].[EmailConfirmed], [u].[LastModifiedAt], [u].[LastModifiedBy], [u].[LockoutEnabled], [u].[LockoutEnd], [u].[NormalizedEmail], [u].[NormalizedUserName], [u].[PasswordHash], [u].[PhoneNumber], [u].[PhoneNumberConfirmed], [u].[SecurityStamp], [u].[TwoFactorEnabled], [u].[UserName]
+FROM [users] AS [u]
+WHERE [u].[NormalizedEmail] = @__normalizedEmail_0
+2025-08-11 14:46:21.326 +07:00 [INF] Executed DbCommand (2ms) [Parameters=[@__normalizedEmail_0='?' (Size = 4000)], CommandType='"Text"', CommandTimeout='30']
+SELECT TOP(2) [u].[Id], [u].[AccessFailedCount], [u].[ConcurrencyStamp], [u].[CreatedAt], [u].[DeletedAt], [u].[Email], [u].[EmailConfirmed], [u].[LastModifiedAt], [u].[LastModifiedBy], [u].[LockoutEnabled], [u].[LockoutEnd], [u].[NormalizedEmail], [u].[NormalizedUserName], [u].[PasswordHash], [u].[PhoneNumber], [u].[PhoneNumberConfirmed], [u].[SecurityStamp], [u].[TwoFactorEnabled], [u].[UserName]
+FROM [users] AS [u]
+WHERE [u].[NormalizedEmail] = @__normalizedEmail_0
+2025-08-11 14:46:21.327 +07:00 [DBG] Context 'MyDbContext' started tracking 'User' entity. Consider using 'DbContextOptionsBuilder.EnableSensitiveDataLogging' to see key values.
+2025-08-11 14:46:21.327 +07:00 [DBG] Closing data reader to 'capbot_db' on server 'localhost'.
+2025-08-11 14:46:21.327 +07:00 [DBG] A data reader for 'capbot_db' on server 'localhost' is being disposed after spending 0ms reading results.
+2025-08-11 14:46:21.328 +07:00 [DBG] Closing connection to database 'capbot_db' on server 'localhost'.
+2025-08-11 14:46:21.328 +07:00 [DBG] Closed connection to database 'capbot_db' on server 'localhost' (0ms).
+2025-08-11 14:46:21.328 +07:00 [INF] Sample moderator 'moderator@example.com' already exists
+2025-08-11 14:46:21.328 +07:00 [DBG] Opening connection to database 'capbot_db' on server 'localhost'.
+2025-08-11 14:46:21.329 +07:00 [DBG] Opened connection to database 'capbot_db' on server 'localhost'.
+2025-08-11 14:46:21.329 +07:00 [DBG] Creating DbCommand for 'ExecuteReader'.
+2025-08-11 14:46:21.329 +07:00 [DBG] Created DbCommand for 'ExecuteReader' (0ms).
+2025-08-11 14:46:21.329 +07:00 [DBG] Initialized DbCommand for 'ExecuteReader' (0ms).
+2025-08-11 14:46:21.329 +07:00 [DBG] Executing DbCommand [Parameters=[@__normalizedEmail_0='?' (Size = 4000)], CommandType='"Text"', CommandTimeout='30']
+SELECT TOP(2) [u].[Id], [u].[AccessFailedCount], [u].[ConcurrencyStamp], [u].[CreatedAt], [u].[DeletedAt], [u].[Email], [u].[EmailConfirmed], [u].[LastModifiedAt], [u].[LastModifiedBy], [u].[LockoutEnabled], [u].[LockoutEnd], [u].[NormalizedEmail], [u].[NormalizedUserName], [u].[PasswordHash], [u].[PhoneNumber], [u].[PhoneNumberConfirmed], [u].[SecurityStamp], [u].[TwoFactorEnabled], [u].[UserName]
+FROM [users] AS [u]
+WHERE [u].[NormalizedEmail] = @__normalizedEmail_0
+2025-08-11 14:46:21.330 +07:00 [INF] Executed DbCommand (1ms) [Parameters=[@__normalizedEmail_0='?' (Size = 4000)], CommandType='"Text"', CommandTimeout='30']
+SELECT TOP(2) [u].[Id], [u].[AccessFailedCount], [u].[ConcurrencyStamp], [u].[CreatedAt], [u].[DeletedAt], [u].[Email], [u].[EmailConfirmed], [u].[LastModifiedAt], [u].[LastModifiedBy], [u].[LockoutEnabled], [u].[LockoutEnd], [u].[NormalizedEmail], [u].[NormalizedUserName], [u].[PasswordHash], [u].[PhoneNumber], [u].[PhoneNumberConfirmed], [u].[SecurityStamp], [u].[TwoFactorEnabled], [u].[UserName]
+FROM [users] AS [u]
+WHERE [u].[NormalizedEmail] = @__normalizedEmail_0
+2025-08-11 14:46:21.330 +07:00 [DBG] Context 'MyDbContext' started tracking 'User' entity. Consider using 'DbContextOptionsBuilder.EnableSensitiveDataLogging' to see key values.
+2025-08-11 14:46:21.330 +07:00 [DBG] Closing data reader to 'capbot_db' on server 'localhost'.
+2025-08-11 14:46:21.330 +07:00 [DBG] A data reader for 'capbot_db' on server 'localhost' is being disposed after spending 0ms reading results.
+2025-08-11 14:46:21.331 +07:00 [DBG] Closing connection to database 'capbot_db' on server 'localhost'.
+2025-08-11 14:46:21.331 +07:00 [DBG] Closed connection to database 'capbot_db' on server 'localhost' (0ms).
+2025-08-11 14:46:21.331 +07:00 [DBG] Opening connection to database 'capbot_db' on server 'localhost'.
+2025-08-11 14:46:21.331 +07:00 [DBG] Opened connection to database 'capbot_db' on server 'localhost'.
+2025-08-11 14:46:21.331 +07:00 [DBG] Creating DbCommand for 'ExecuteReader'.
+2025-08-11 14:46:21.331 +07:00 [DBG] Created DbCommand for 'ExecuteReader' (0ms).
+2025-08-11 14:46:21.331 +07:00 [DBG] Initialized DbCommand for 'ExecuteReader' (0ms).
+2025-08-11 14:46:21.332 +07:00 [DBG] Executing DbCommand [Parameters=[@__normalizedEmail_0='?' (Size = 4000)], CommandType='"Text"', CommandTimeout='30']
+SELECT TOP(2) [u].[Id], [u].[AccessFailedCount], [u].[ConcurrencyStamp], [u].[CreatedAt], [u].[DeletedAt], [u].[Email], [u].[EmailConfirmed], [u].[LastModifiedAt], [u].[LastModifiedBy], [u].[LockoutEnabled], [u].[LockoutEnd], [u].[NormalizedEmail], [u].[NormalizedUserName], [u].[PasswordHash], [u].[PhoneNumber], [u].[PhoneNumberConfirmed], [u].[SecurityStamp], [u].[TwoFactorEnabled], [u].[UserName]
+FROM [users] AS [u]
+WHERE [u].[NormalizedEmail] = @__normalizedEmail_0
+2025-08-11 14:46:21.332 +07:00 [INF] Executed DbCommand (1ms) [Parameters=[@__normalizedEmail_0='?' (Size = 4000)], CommandType='"Text"', CommandTimeout='30']
+SELECT TOP(2) [u].[Id], [u].[AccessFailedCount], [u].[ConcurrencyStamp], [u].[CreatedAt], [u].[DeletedAt], [u].[Email], [u].[EmailConfirmed], [u].[LastModifiedAt], [u].[LastModifiedBy], [u].[LockoutEnabled], [u].[LockoutEnd], [u].[NormalizedEmail], [u].[NormalizedUserName], [u].[PasswordHash], [u].[PhoneNumber], [u].[PhoneNumberConfirmed], [u].[SecurityStamp], [u].[TwoFactorEnabled], [u].[UserName]
+FROM [users] AS [u]
+WHERE [u].[NormalizedEmail] = @__normalizedEmail_0
+2025-08-11 14:46:21.333 +07:00 [DBG] Context 'MyDbContext' started tracking 'User' entity. Consider using 'DbContextOptionsBuilder.EnableSensitiveDataLogging' to see key values.
+2025-08-11 14:46:21.333 +07:00 [DBG] Closing data reader to 'capbot_db' on server 'localhost'.
+2025-08-11 14:46:21.333 +07:00 [DBG] A data reader for 'capbot_db' on server 'localhost' is being disposed after spending 0ms reading results.
+2025-08-11 14:46:21.333 +07:00 [DBG] Closing connection to database 'capbot_db' on server 'localhost'.
+2025-08-11 14:46:21.333 +07:00 [DBG] Closed connection to database 'capbot_db' on server 'localhost' (0ms).
+2025-08-11 14:46:21.334 +07:00 [INF] Data seeding completed successfully
+2025-08-11 14:46:21.335 +07:00 [DBG] 'MyDbContext' disposed.
+2025-08-11 14:46:21.336 +07:00 [DBG] Disposing connection to database 'capbot_db' on server 'localhost'.
+2025-08-11 14:46:21.337 +07:00 [DBG] Disposed connection to database '' on server '' (0ms).
+2025-08-11 14:46:21.524 +07:00 [DBG] Registered model binder providers, in the following order: ["Microsoft.AspNetCore.Mvc.ModelBinding.Binders.BinderTypeModelBinderProvider","Microsoft.AspNetCore.Mvc.ModelBinding.Binders.ServicesModelBinderProvider","Microsoft.AspNetCore.Mvc.ModelBinding.Binders.BodyModelBinderProvider","Microsoft.AspNetCore.Mvc.ModelBinding.Binders.HeaderModelBinderProvider","Microsoft.AspNetCore.Mvc.ModelBinding.Binders.FloatingPointTypeModelBinderProvider","Microsoft.AspNetCore.Mvc.ModelBinding.Binders.EnumTypeModelBinderProvider","Microsoft.AspNetCore.Mvc.ModelBinding.Binders.DateTimeModelBinderProvider","Microsoft.AspNetCore.Mvc.ModelBinding.Binders.SimpleTypeModelBinderProvider","Microsoft.AspNetCore.Mvc.ModelBinding.Binders.TryParseModelBinderProvider","Microsoft.AspNetCore.Mvc.ModelBinding.Binders.CancellationTokenModelBinderProvider"]
+2025-08-11 14:46:21.592 +07:00 [DBG] Hosting starting
+2025-08-11 14:46:21.597 +07:00 [DBG] Reading data from file 'C:\Users\Admin\AppData\Local\ASP.NET\DataProtection-Keys\key-1d6bcff1-a155-4167-8a22-de35a5f05047.xml'.
+2025-08-11 14:46:21.599 +07:00 [DBG] Reading data from file 'C:\Users\Admin\AppData\Local\ASP.NET\DataProtection-Keys\key-2459dd29-32d5-4c49-ac9d-33896047bb78.xml'.
+2025-08-11 14:46:21.600 +07:00 [DBG] Reading data from file 'C:\Users\Admin\AppData\Local\ASP.NET\DataProtection-Keys\key-374624f1-e856-4617-8ae6-fe6a81ce6346.xml'.
+2025-08-11 14:46:21.602 +07:00 [DBG] Found key {1d6bcff1-a155-4167-8a22-de35a5f05047}.
+2025-08-11 14:46:21.606 +07:00 [DBG] Found key {2459dd29-32d5-4c49-ac9d-33896047bb78}.
+2025-08-11 14:46:21.606 +07:00 [DBG] Found key {374624f1-e856-4617-8ae6-fe6a81ce6346}.
+2025-08-11 14:46:21.610 +07:00 [DBG] Considering key {2459dd29-32d5-4c49-ac9d-33896047bb78} with expiration date 2025-11-03 12:40:53Z as default key.
+2025-08-11 14:46:21.613 +07:00 [DBG] Forwarded activator type request from Microsoft.AspNetCore.DataProtection.XmlEncryption.DpapiXmlDecryptor, Microsoft.AspNetCore.DataProtection, Version=8.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60 to Microsoft.AspNetCore.DataProtection.XmlEncryption.DpapiXmlDecryptor, Microsoft.AspNetCore.DataProtection, Culture=neutral, PublicKeyToken=adb9793829ddae60
+2025-08-11 14:46:21.614 +07:00 [DBG] Decrypting secret element using Windows DPAPI.
+2025-08-11 14:46:21.615 +07:00 [DBG] Forwarded activator type request from Microsoft.AspNetCore.DataProtection.AuthenticatedEncryption.ConfigurationModel.AuthenticatedEncryptorDescriptorDeserializer, Microsoft.AspNetCore.DataProtection, Version=8.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60 to Microsoft.AspNetCore.DataProtection.AuthenticatedEncryption.ConfigurationModel.AuthenticatedEncryptorDescriptorDeserializer, Microsoft.AspNetCore.DataProtection, Culture=neutral, PublicKeyToken=adb9793829ddae60
+2025-08-11 14:46:21.617 +07:00 [DBG] Opening CNG algorithm 'AES' from provider 'null' with chaining mode CBC.
+2025-08-11 14:46:21.618 +07:00 [DBG] Opening CNG algorithm 'SHA256' from provider 'null' with HMAC.
+2025-08-11 14:46:21.620 +07:00 [DBG] Using key {2459dd29-32d5-4c49-ac9d-33896047bb78} as the default key.
+2025-08-11 14:46:21.620 +07:00 [DBG] Key ring with default key {2459dd29-32d5-4c49-ac9d-33896047bb78} was loaded during application startup.
+2025-08-11 14:46:21.725 +07:00 [INF] Now listening on: https://localhost:7190
+2025-08-11 14:46:21.726 +07:00 [DBG] Loaded hosting startup assembly CapBot.api
+2025-08-11 14:46:21.726 +07:00 [DBG] Loaded hosting startup assembly Microsoft.WebTools.ApiEndpointDiscovery
+2025-08-11 14:46:21.726 +07:00 [DBG] Loaded hosting startup assembly Microsoft.AspNetCore.Watch.BrowserRefresh
+2025-08-11 14:46:21.726 +07:00 [DBG] Loaded hosting startup assembly Microsoft.WebTools.BrowserLink.Net
+2025-08-11 14:46:21.785 +07:00 [INF] Application started. Press Ctrl+C to shut down.
+2025-08-11 14:46:21.785 +07:00 [INF] Hosting environment: Development
+2025-08-11 14:46:21.787 +07:00 [INF] Content root path: C:\Users\Admin\Downloads\CBAI_API\CapBot.api
+2025-08-11 14:46:21.808 +07:00 [DBG] Hosting started
+2025-08-11 14:46:21.932 +07:00 [DBG] Connection id "0HNEOLCL6RC1S" accepted.
+2025-08-11 14:46:21.932 +07:00 [DBG] Connection id "0HNEOLCL6RC1S" started.
+2025-08-11 14:46:21.941 +07:00 [DBG] Connection id "0HNEOLCL6RC1T" accepted.
+2025-08-11 14:46:21.941 +07:00 [DBG] Connection id "0HNEOLCL6RC1T" started.
+2025-08-11 14:46:21.977 +07:00 [DBG] Connection id "0HNEOLCL6RC1T" received FIN.
+2025-08-11 14:46:21.977 +07:00 [DBG] Connection id "0HNEOLCL6RC1S" received FIN.
+2025-08-11 14:46:21.986 +07:00 [DBG] Failed to authenticate HTTPS connection.
+System.IO.IOException: Received an unexpected EOF or 0 bytes from the transport stream.
+   at System.Net.Security.SslStream.ReceiveHandshakeFrameAsync[TIOAdapter](CancellationToken cancellationToken)
+   at System.Net.Security.SslStream.ForceAuthenticationAsync[TIOAdapter](Boolean receiveFirst, Byte[] reAuthenticationData, CancellationToken cancellationToken)
+   at System.Net.Security.SslStream.ProcessAuthenticationWithTelemetryAsync(Boolean isAsync, CancellationToken cancellationToken)
+   at Microsoft.AspNetCore.Server.Kestrel.Https.Internal.HttpsConnectionMiddleware.OnConnectionAsync(ConnectionContext context)
+2025-08-11 14:46:21.986 +07:00 [DBG] Failed to authenticate HTTPS connection.
+System.IO.IOException: Received an unexpected EOF or 0 bytes from the transport stream.
+   at System.Net.Security.SslStream.ReceiveHandshakeFrameAsync[TIOAdapter](CancellationToken cancellationToken)
+   at System.Net.Security.SslStream.ForceAuthenticationAsync[TIOAdapter](Boolean receiveFirst, Byte[] reAuthenticationData, CancellationToken cancellationToken)
+   at System.Net.Security.SslStream.ProcessAuthenticationWithTelemetryAsync(Boolean isAsync, CancellationToken cancellationToken)
+   at Microsoft.AspNetCore.Server.Kestrel.Https.Internal.HttpsConnectionMiddleware.OnConnectionAsync(ConnectionContext context)
+2025-08-11 14:46:22.001 +07:00 [DBG] Connection id "0HNEOLCL6RC1S" stopped.
+2025-08-11 14:46:22.001 +07:00 [DBG] Connection id "0HNEOLCL6RC1T" stopped.
+2025-08-11 14:46:22.006 +07:00 [DBG] Connection id "0HNEOLCL6RC1T" sending FIN because: "The Socket transport's send loop completed gracefully."
+2025-08-11 14:46:22.006 +07:00 [DBG] Connection id "0HNEOLCL6RC1S" sending FIN because: "The Socket transport's send loop completed gracefully."
+2025-08-11 14:46:22.079 +07:00 [DBG] Connection id "0HNEOLCL6RC1U" accepted.
+2025-08-11 14:46:22.079 +07:00 [DBG] Connection id "0HNEOLCL6RC1U" started.
+2025-08-11 14:46:22.149 +07:00 [DBG] Connection 0HNEOLCL6RC1U established using the following protocol: "Tls13"
+2025-08-11 14:46:22.204 +07:00 [INF] Request starting HTTP/2 GET https://localhost:7190/index.html - null null
+2025-08-11 14:46:22.240 +07:00 [DBG] Wildcard detected, all requests with hosts will be allowed.
+2025-08-11 14:46:22.269 +07:00 [DBG] Response markup is scheduled to include Browser Link script injection.
+2025-08-11 14:46:22.272 +07:00 [DBG] Response markup is scheduled to include browser refresh script injection.
+2025-08-11 14:46:22.293 +07:00 [DBG] Response markup was updated to include Browser Link script injection.
+2025-08-11 14:46:22.293 +07:00 [DBG] Response markup was updated to include browser refresh script injection.
+2025-08-11 14:46:22.298 +07:00 [INF] Request finished HTTP/2 GET https://localhost:7190/index.html - 200 null text/html;charset=utf-8 97.667ms
+2025-08-11 14:46:22.311 +07:00 [INF] Request starting HTTP/2 GET https://localhost:7190/_framework/aspnetcore-browser-refresh.js - null null
+2025-08-11 14:46:22.311 +07:00 [INF] Request starting HTTP/2 GET https://localhost:7190/_vs/browserLink - null null
+2025-08-11 14:46:22.320 +07:00 [INF] Request finished HTTP/2 GET https://localhost:7190/_framework/aspnetcore-browser-refresh.js - 200 13756 application/javascript; charset=utf-8 8.824ms
+2025-08-11 14:46:22.353 +07:00 [INF] Request finished HTTP/2 GET https://localhost:7190/_vs/browserLink - 200 null text/javascript; charset=UTF-8 41.2604ms
+2025-08-11 14:46:22.374 +07:00 [INF] Request starting HTTP/2 GET https://localhost:7190/swagger/v1/swagger.json - null null
+2025-08-11 14:46:22.401 +07:00 [INF] Request finished HTTP/2 GET https://localhost:7190/swagger/v1/swagger.json - 200 null application/json;charset=utf-8 26.4413ms
+2025-08-11 14:46:43.476 +07:00 [INF] Application is shutting down...
+2025-08-11 14:46:43.478 +07:00 [DBG] Hosting stopping
+2025-08-11 14:46:43.507 +07:00 [DBG] Connection id "0HNEOLCL6RC1U" is closing.
+2025-08-11 14:46:43.509 +07:00 [DBG] Connection id "0HNEOLCL6RC1U" is closed. The last processed stream ID was 7.
+2025-08-11 14:46:43.510 +07:00 [DBG] Connection id "0HNEOLCL6RC1U" received FIN.
+2025-08-11 14:46:43.511 +07:00 [DBG] Connection id "0HNEOLCL6RC1U" sending FIN because: "The Socket transport's send loop completed gracefully."
+2025-08-11 14:46:43.515 +07:00 [DBG] The connection queue processing loop for 0HNEOLCL6RC1U completed.
+2025-08-11 14:46:43.516 +07:00 [DBG] Connection id "0HNEOLCL6RC1U" stopped.
+2025-08-11 14:46:43.521 +07:00 [DBG] Hosting stopped

--- a/CapBot.api/Logs/log20250812.txt
+++ b/CapBot.api/Logs/log20250812.txt
@@ -1,0 +1,928 @@
+2025-08-12 10:21:10.101 +07:00 [DBG] An 'IServiceProvider' was created for internal use by Entity Framework.
+2025-08-12 10:21:10.203 +07:00 [INF] User profile is available. Using 'C:\Users\Admin\AppData\Local\ASP.NET\DataProtection-Keys' as key repository and Windows DPAPI to encrypt keys at rest.
+2025-08-12 10:21:10.404 +07:00 [DBG] No relationship from 'ReviewerAssignment' to 'User' has been configured by convention because there are multiple properties on one entity type - {'AssignedByUser', 'Reviewer'} that could be matched with the properties on the other entity type - {'ReviewerAssignments'}. This message can be disregarded if explicit configuration has been specified in 'OnModelCreating'.
+2025-08-12 10:21:10.422 +07:00 [DBG] No relationship from 'SubmissionWorkflowLog' to 'WorkflowState' has been configured by convention because there are multiple properties on one entity type - {'FromState', 'ToState'} that could be matched with the properties on the other entity type - {'FromStateLogs', 'ToStateLogs'}. This message can be disregarded if explicit configuration has been specified in 'OnModelCreating'.
+2025-08-12 10:21:10.433 +07:00 [DBG] No relationship from 'User' to 'ReviewerAssignment' has been configured by convention because there are multiple properties on one entity type - {'ReviewerAssignments'} that could be matched with the properties on the other entity type - {'AssignedByUser', 'Reviewer'}. This message can be disregarded if explicit configuration has been specified in 'OnModelCreating'.
+2025-08-12 10:21:10.434 +07:00 [DBG] No relationship from 'WorkflowState' to 'SubmissionWorkflowLog' has been configured by convention because there are multiple properties on one entity type - {'FromStateLogs', 'ToStateLogs'} that could be matched with the properties on the other entity type - {'FromState', 'ToState'}. This message can be disregarded if explicit configuration has been specified in 'OnModelCreating'.
+2025-08-12 10:21:10.435 +07:00 [DBG] No relationship from 'WorkflowState' to 'WorkflowTransition' has been configured by convention because there are multiple properties on one entity type - {'FromTransitions', 'ToTransitions'} that could be matched with the properties on the other entity type - {'FromState', 'ToState'}. This message can be disregarded if explicit configuration has been specified in 'OnModelCreating'.
+2025-08-12 10:21:10.436 +07:00 [DBG] No relationship from 'WorkflowTransition' to 'WorkflowState' has been configured by convention because there are multiple properties on one entity type - {'FromState', 'ToState'} that could be matched with the properties on the other entity type - {'FromTransitions', 'ToTransitions'}. This message can be disregarded if explicit configuration has been specified in 'OnModelCreating'.
+2025-08-12 10:21:10.585 +07:00 [DBG] No relationship from 'ReviewerAssignment' to 'User' has been configured by convention because there are multiple properties on one entity type - {'AssignedByUser', 'Reviewer'} that could be matched with the properties on the other entity type - {'ReviewerAssignments'}. This message can be disregarded if explicit configuration has been specified in 'OnModelCreating'.
+2025-08-12 10:21:10.587 +07:00 [DBG] No relationship from 'User' to 'ReviewerAssignment' has been configured by convention because there are multiple properties on one entity type - {'ReviewerAssignments'} that could be matched with the properties on the other entity type - {'AssignedByUser', 'Reviewer'}. This message can be disregarded if explicit configuration has been specified in 'OnModelCreating'.
+2025-08-12 10:21:10.602 +07:00 [DBG] No relationship from 'WorkflowTransition' to 'WorkflowState' has been configured by convention because there are multiple properties on one entity type - {'FromState', 'ToState'} that could be matched with the properties on the other entity type - {'FromTransitions', 'ToTransitions'}. This message can be disregarded if explicit configuration has been specified in 'OnModelCreating'.
+2025-08-12 10:21:10.603 +07:00 [DBG] No relationship from 'WorkflowState' to 'SubmissionWorkflowLog' has been configured by convention because there are multiple properties on one entity type - {'FromStateLogs', 'ToStateLogs'} that could be matched with the properties on the other entity type - {'FromState', 'ToState'}. This message can be disregarded if explicit configuration has been specified in 'OnModelCreating'.
+2025-08-12 10:21:10.603 +07:00 [DBG] No relationship from 'WorkflowState' to 'WorkflowTransition' has been configured by convention because there are multiple properties on one entity type - {'FromTransitions', 'ToTransitions'} that could be matched with the properties on the other entity type - {'FromState', 'ToState'}. This message can be disregarded if explicit configuration has been specified in 'OnModelCreating'.
+2025-08-12 10:21:10.605 +07:00 [DBG] No relationship from 'WorkflowState' to 'SubmissionWorkflowLog' has been configured by convention because there are multiple properties on one entity type - {'FromStateLogs', 'ToStateLogs'} that could be matched with the properties on the other entity type - {'FromState', 'ToState'}. This message can be disregarded if explicit configuration has been specified in 'OnModelCreating'.
+2025-08-12 10:21:10.609 +07:00 [DBG] No relationship from 'SubmissionWorkflowLog' to 'WorkflowState' has been configured by convention because there are multiple properties on one entity type - {'FromState', 'ToState'} that could be matched with the properties on the other entity type - {'FromStateLogs', 'ToStateLogs'}. This message can be disregarded if explicit configuration has been specified in 'OnModelCreating'.
+2025-08-12 10:21:10.610 +07:00 [DBG] No relationship from 'WorkflowState' to 'SubmissionWorkflowLog' has been configured by convention because there are multiple properties on one entity type - {'FromStateLogs', 'ToStateLogs'} that could be matched with the properties on the other entity type - {'FromState', 'ToState'}. This message can be disregarded if explicit configuration has been specified in 'OnModelCreating'.
+2025-08-12 10:21:10.631 +07:00 [DBG] The index {'LecturerId'} was not created on entity type 'LecturerSkill' as the properties are already covered by the index {'LecturerId', 'SkillTag'}.
+2025-08-12 10:21:10.631 +07:00 [DBG] The index {'SemesterId'} was not created on entity type 'Phase' as the properties are already covered by the index {'SemesterId', 'PhaseTypeId'}.
+2025-08-12 10:21:10.632 +07:00 [DBG] The index {'AssignmentId'} was not created on entity type 'Review' as the properties are already covered by the index {'AssignmentId', 'Status'}.
+2025-08-12 10:21:10.632 +07:00 [DBG] The index {'ReviewId'} was not created on entity type 'ReviewComment' as the properties are already covered by the index {'ReviewId', 'SectionName'}.
+2025-08-12 10:21:10.632 +07:00 [DBG] The index {'ReviewId'} was not created on entity type 'ReviewCriteriaScore' as the properties are already covered by the index {'ReviewId', 'CriteriaId'}.
+2025-08-12 10:21:10.632 +07:00 [DBG] The index {'ReviewerId'} was not created on entity type 'ReviewerAssignment' as the properties are already covered by the index {'ReviewerId', 'Status'}.
+2025-08-12 10:21:10.633 +07:00 [DBG] The index {'SubmissionId'} was not created on entity type 'ReviewerAssignment' as the properties are already covered by the index {'SubmissionId', 'ReviewerId'}.
+2025-08-12 10:21:10.633 +07:00 [DBG] The index {'ReviewerId'} was not created on entity type 'ReviewerPerformance' as the properties are already covered by the index {'ReviewerId', 'SemesterId'}.
+2025-08-12 10:21:10.633 +07:00 [DBG] The index {'PhaseId'} was not created on entity type 'Submission' as the properties are already covered by the index {'PhaseId', 'Status'}.
+2025-08-12 10:21:10.634 +07:00 [DBG] The index {'PhaseId'} was not created on entity type 'Submission' as the properties are already covered by the index {'PhaseId', 'Status', 'SubmittedAt'}.
+2025-08-12 10:21:10.634 +07:00 [DBG] The index {'TopicVersionId'} was not created on entity type 'Submission' as the properties are already covered by the index {'TopicVersionId', 'PhaseId', 'SubmissionRound'}.
+2025-08-12 10:21:10.634 +07:00 [DBG] The index {'SubmissionId'} was not created on entity type 'SubmissionWorkflowLog' as the properties are already covered by the index {'SubmissionId', 'CreatedAt'}.
+2025-08-12 10:21:10.635 +07:00 [DBG] The index {'UserId'} was not created on entity type 'SystemNotification' as the properties are already covered by the index {'UserId', 'IsRead', 'CreatedAt'}.
+2025-08-12 10:21:10.635 +07:00 [DBG] The index {'SemesterId'} was not created on entity type 'Topic' as the properties are already covered by the index {'SemesterId', 'IsApproved'}.
+2025-08-12 10:21:10.635 +07:00 [DBG] The index {'SupervisorId'} was not created on entity type 'Topic' as the properties are already covered by the index {'SupervisorId', 'SemesterId'}.
+2025-08-12 10:21:10.636 +07:00 [DBG] The index {'TopicId'} was not created on entity type 'TopicVersion' as the properties are already covered by the index {'TopicId', 'Status'}.
+2025-08-12 10:21:10.636 +07:00 [DBG] The index {'TopicId'} was not created on entity type 'TopicVersion' as the properties are already covered by the index {'TopicId', 'VersionNumber'}.
+2025-08-12 10:21:10.636 +07:00 [DBG] The index {'UserId'} was not created on entity type 'UserRole' as the properties are already covered by the index {'UserId', 'RoleId'}.
+2025-08-12 10:21:10.636 +07:00 [DBG] The index {'UserId'} was not created on entity type 'UserToken' as the properties are already covered by the index {'UserId', 'LoginProvider', 'Name'}.
+2025-08-12 10:21:10.737 +07:00 [WRN] The 'ProficiencyLevels' property 'ProficiencyLevel' on entity type 'LecturerSkill' is configured with a database-generated default, but has no configured sentinel value. The database-generated default will always be used for inserts when the property has the value '0', since this is the CLR default for the 'ProficiencyLevels' type. Consider using a nullable type, using a nullable backing field, or setting the sentinel value for the property to ensure the database default is used when, and only when, appropriate. See https://aka.ms/efcore-docs-default-values for more information.
+2025-08-12 10:21:10.738 +07:00 [WRN] The 'ReviewRecommendations' property 'Recommendation' on entity type 'Review' is configured with a database-generated default, but has no configured sentinel value. The database-generated default will always be used for inserts when the property has the value '0', since this is the CLR default for the 'ReviewRecommendations' type. Consider using a nullable type, using a nullable backing field, or setting the sentinel value for the property to ensure the database default is used when, and only when, appropriate. See https://aka.ms/efcore-docs-default-values for more information.
+2025-08-12 10:21:10.739 +07:00 [WRN] The 'ReviewStatus' property 'Status' on entity type 'Review' is configured with a database-generated default, but has no configured sentinel value. The database-generated default will always be used for inserts when the property has the value '0', since this is the CLR default for the 'ReviewStatus' type. Consider using a nullable type, using a nullable backing field, or setting the sentinel value for the property to ensure the database default is used when, and only when, appropriate. See https://aka.ms/efcore-docs-default-values for more information.
+2025-08-12 10:21:10.739 +07:00 [WRN] The 'CommentTypes' property 'CommentType' on entity type 'ReviewComment' is configured with a database-generated default, but has no configured sentinel value. The database-generated default will always be used for inserts when the property has the value '0', since this is the CLR default for the 'CommentTypes' type. Consider using a nullable type, using a nullable backing field, or setting the sentinel value for the property to ensure the database default is used when, and only when, appropriate. See https://aka.ms/efcore-docs-default-values for more information.
+2025-08-12 10:21:10.740 +07:00 [WRN] The 'PriorityLevels' property 'Priority' on entity type 'ReviewComment' is configured with a database-generated default, but has no configured sentinel value. The database-generated default will always be used for inserts when the property has the value '0', since this is the CLR default for the 'PriorityLevels' type. Consider using a nullable type, using a nullable backing field, or setting the sentinel value for the property to ensure the database default is used when, and only when, appropriate. See https://aka.ms/efcore-docs-default-values for more information.
+2025-08-12 10:21:10.740 +07:00 [WRN] The 'AssignmentTypes' property 'AssignmentType' on entity type 'ReviewerAssignment' is configured with a database-generated default, but has no configured sentinel value. The database-generated default will always be used for inserts when the property has the value '0', since this is the CLR default for the 'AssignmentTypes' type. Consider using a nullable type, using a nullable backing field, or setting the sentinel value for the property to ensure the database default is used when, and only when, appropriate. See https://aka.ms/efcore-docs-default-values for more information.
+2025-08-12 10:21:10.740 +07:00 [WRN] The 'AssignmentStatus' property 'Status' on entity type 'ReviewerAssignment' is configured with a database-generated default, but has no configured sentinel value. The database-generated default will always be used for inserts when the property has the value '0', since this is the CLR default for the 'AssignmentStatus' type. Consider using a nullable type, using a nullable backing field, or setting the sentinel value for the property to ensure the database default is used when, and only when, appropriate. See https://aka.ms/efcore-docs-default-values for more information.
+2025-08-12 10:21:10.741 +07:00 [WRN] The 'AiCheckStatus' property 'AiCheckStatus' on entity type 'Submission' is configured with a database-generated default, but has no configured sentinel value. The database-generated default will always be used for inserts when the property has the value '0', since this is the CLR default for the 'AiCheckStatus' type. Consider using a nullable type, using a nullable backing field, or setting the sentinel value for the property to ensure the database default is used when, and only when, appropriate. See https://aka.ms/efcore-docs-default-values for more information.
+2025-08-12 10:21:10.741 +07:00 [WRN] The 'SubmissionStatus' property 'Status' on entity type 'Submission' is configured with a database-generated default, but has no configured sentinel value. The database-generated default will always be used for inserts when the property has the value '0', since this is the CLR default for the 'SubmissionStatus' type. Consider using a nullable type, using a nullable backing field, or setting the sentinel value for the property to ensure the database default is used when, and only when, appropriate. See https://aka.ms/efcore-docs-default-values for more information.
+2025-08-12 10:21:10.741 +07:00 [WRN] The 'NotificationTypes' property 'Type' on entity type 'SystemNotification' is configured with a database-generated default, but has no configured sentinel value. The database-generated default will always be used for inserts when the property has the value '0', since this is the CLR default for the 'NotificationTypes' type. Consider using a nullable type, using a nullable backing field, or setting the sentinel value for the property to ensure the database default is used when, and only when, appropriate. See https://aka.ms/efcore-docs-default-values for more information.
+2025-08-12 10:21:10.741 +07:00 [WRN] The 'TopicStatus' property 'Status' on entity type 'TopicVersion' is configured with a database-generated default, but has no configured sentinel value. The database-generated default will always be used for inserts when the property has the value '0', since this is the CLR default for the 'TopicStatus' type. Consider using a nullable type, using a nullable backing field, or setting the sentinel value for the property to ensure the database default is used when, and only when, appropriate. See https://aka.ms/efcore-docs-default-values for more information.
+2025-08-12 10:21:10.855 +07:00 [DBG] Entity Framework Core 8.0.16 initialized 'MyDbContext' using provider 'Microsoft.EntityFrameworkCore.SqlServer:8.0.13' with options: MigrationsAssembly=App.DAL 
+2025-08-12 10:21:10.935 +07:00 [DBG] Compiling query expression: 
+'DbSet<Role>()
+    .FirstOrDefault(r => r.NormalizedName == __normalizedName_0)'
+2025-08-12 10:21:11.071 +07:00 [DBG] Generated query execution expression: 
+'queryContext => ShapedQueryCompilingExpressionVisitor.SingleOrDefaultAsync<Role>(
+    asyncEnumerable: new SingleQueryingEnumerable<Role>(
+        (RelationalQueryContext)queryContext, 
+        RelationalCommandCache.QueryExpression(
+            Projection Mapping:
+                EmptyProjectionMember -> Dictionary<IProperty, int> { [Property: Role.Id (int) Required PK AfterSave:Throw ValueGenerated.OnAdd, 0], [Property: Role.ConcurrencyStamp (string), 1], [Property: Role.IsAdmin (bool) Required, 2], [Property: Role.Name (string), 3], [Property: Role.NormalizedName (string), 4] }
+            SELECT TOP(1) r.Id, r.ConcurrencyStamp, r.IsAdmin, r.Name, r.NormalizedName
+            FROM roles AS r
+            WHERE r.NormalizedName == @__normalizedName_0), 
+        null, 
+        Func<QueryContext, DbDataReader, ResultContext, SingleQueryResultCoordinator, Role>, 
+        App.DAL.Context.MyDbContext, 
+        False, 
+        False, 
+        True
+    ), 
+    cancellationToken: queryContext.CancellationToken)'
+2025-08-12 10:21:11.098 +07:00 [DBG] Creating DbConnection.
+2025-08-12 10:21:11.116 +07:00 [DBG] Created DbConnection. (16ms).
+2025-08-12 10:21:11.119 +07:00 [DBG] Opening connection to database 'capbot_db' on server 'localhost'.
+2025-08-12 10:21:11.528 +07:00 [DBG] Opened connection to database 'capbot_db' on server 'localhost'.
+2025-08-12 10:21:11.530 +07:00 [DBG] Creating DbCommand for 'ExecuteReader'.
+2025-08-12 10:21:11.535 +07:00 [DBG] Created DbCommand for 'ExecuteReader' (3ms).
+2025-08-12 10:21:11.541 +07:00 [DBG] Initialized DbCommand for 'ExecuteReader' (10ms).
+2025-08-12 10:21:11.546 +07:00 [DBG] Executing DbCommand [Parameters=[@__normalizedName_0='?' (Size = 4000)], CommandType='"Text"', CommandTimeout='30']
+SELECT TOP(1) [r].[Id], [r].[ConcurrencyStamp], [r].[IsAdmin], [r].[Name], [r].[NormalizedName]
+FROM [roles] AS [r]
+WHERE [r].[NormalizedName] = @__normalizedName_0
+2025-08-12 10:21:11.601 +07:00 [INF] Executed DbCommand (55ms) [Parameters=[@__normalizedName_0='?' (Size = 4000)], CommandType='"Text"', CommandTimeout='30']
+SELECT TOP(1) [r].[Id], [r].[ConcurrencyStamp], [r].[IsAdmin], [r].[Name], [r].[NormalizedName]
+FROM [roles] AS [r]
+WHERE [r].[NormalizedName] = @__normalizedName_0
+2025-08-12 10:21:11.645 +07:00 [DBG] Context 'MyDbContext' started tracking 'Role' entity. Consider using 'DbContextOptionsBuilder.EnableSensitiveDataLogging' to see key values.
+2025-08-12 10:21:11.658 +07:00 [DBG] Closing data reader to 'capbot_db' on server 'localhost'.
+2025-08-12 10:21:11.663 +07:00 [DBG] A data reader for 'capbot_db' on server 'localhost' is being disposed after spending 58ms reading results.
+2025-08-12 10:21:11.665 +07:00 [DBG] Closing connection to database 'capbot_db' on server 'localhost'.
+2025-08-12 10:21:11.669 +07:00 [DBG] Closed connection to database 'capbot_db' on server 'localhost' (3ms).
+2025-08-12 10:21:11.673 +07:00 [DBG] Opening connection to database 'capbot_db' on server 'localhost'.
+2025-08-12 10:21:11.674 +07:00 [DBG] Opened connection to database 'capbot_db' on server 'localhost'.
+2025-08-12 10:21:11.674 +07:00 [DBG] Creating DbCommand for 'ExecuteReader'.
+2025-08-12 10:21:11.675 +07:00 [DBG] Created DbCommand for 'ExecuteReader' (0ms).
+2025-08-12 10:21:11.675 +07:00 [DBG] Initialized DbCommand for 'ExecuteReader' (0ms).
+2025-08-12 10:21:11.675 +07:00 [DBG] Executing DbCommand [Parameters=[@__normalizedName_0='?' (Size = 4000)], CommandType='"Text"', CommandTimeout='30']
+SELECT TOP(1) [r].[Id], [r].[ConcurrencyStamp], [r].[IsAdmin], [r].[Name], [r].[NormalizedName]
+FROM [roles] AS [r]
+WHERE [r].[NormalizedName] = @__normalizedName_0
+2025-08-12 10:21:11.679 +07:00 [INF] Executed DbCommand (3ms) [Parameters=[@__normalizedName_0='?' (Size = 4000)], CommandType='"Text"', CommandTimeout='30']
+SELECT TOP(1) [r].[Id], [r].[ConcurrencyStamp], [r].[IsAdmin], [r].[Name], [r].[NormalizedName]
+FROM [roles] AS [r]
+WHERE [r].[NormalizedName] = @__normalizedName_0
+2025-08-12 10:21:11.680 +07:00 [DBG] Context 'MyDbContext' started tracking 'Role' entity. Consider using 'DbContextOptionsBuilder.EnableSensitiveDataLogging' to see key values.
+2025-08-12 10:21:11.681 +07:00 [DBG] Closing data reader to 'capbot_db' on server 'localhost'.
+2025-08-12 10:21:11.681 +07:00 [DBG] A data reader for 'capbot_db' on server 'localhost' is being disposed after spending 1ms reading results.
+2025-08-12 10:21:11.681 +07:00 [DBG] Closing connection to database 'capbot_db' on server 'localhost'.
+2025-08-12 10:21:11.681 +07:00 [DBG] Closed connection to database 'capbot_db' on server 'localhost' (0ms).
+2025-08-12 10:21:11.682 +07:00 [DBG] Opening connection to database 'capbot_db' on server 'localhost'.
+2025-08-12 10:21:11.682 +07:00 [DBG] Opened connection to database 'capbot_db' on server 'localhost'.
+2025-08-12 10:21:11.682 +07:00 [DBG] Creating DbCommand for 'ExecuteReader'.
+2025-08-12 10:21:11.682 +07:00 [DBG] Created DbCommand for 'ExecuteReader' (0ms).
+2025-08-12 10:21:11.682 +07:00 [DBG] Initialized DbCommand for 'ExecuteReader' (0ms).
+2025-08-12 10:21:11.682 +07:00 [DBG] Executing DbCommand [Parameters=[@__normalizedName_0='?' (Size = 4000)], CommandType='"Text"', CommandTimeout='30']
+SELECT TOP(1) [r].[Id], [r].[ConcurrencyStamp], [r].[IsAdmin], [r].[Name], [r].[NormalizedName]
+FROM [roles] AS [r]
+WHERE [r].[NormalizedName] = @__normalizedName_0
+2025-08-12 10:21:11.683 +07:00 [INF] Executed DbCommand (1ms) [Parameters=[@__normalizedName_0='?' (Size = 4000)], CommandType='"Text"', CommandTimeout='30']
+SELECT TOP(1) [r].[Id], [r].[ConcurrencyStamp], [r].[IsAdmin], [r].[Name], [r].[NormalizedName]
+FROM [roles] AS [r]
+WHERE [r].[NormalizedName] = @__normalizedName_0
+2025-08-12 10:21:11.684 +07:00 [DBG] Context 'MyDbContext' started tracking 'Role' entity. Consider using 'DbContextOptionsBuilder.EnableSensitiveDataLogging' to see key values.
+2025-08-12 10:21:11.684 +07:00 [DBG] Closing data reader to 'capbot_db' on server 'localhost'.
+2025-08-12 10:21:11.684 +07:00 [DBG] A data reader for 'capbot_db' on server 'localhost' is being disposed after spending 0ms reading results.
+2025-08-12 10:21:11.684 +07:00 [DBG] Closing connection to database 'capbot_db' on server 'localhost'.
+2025-08-12 10:21:11.684 +07:00 [DBG] Closed connection to database 'capbot_db' on server 'localhost' (0ms).
+2025-08-12 10:21:11.685 +07:00 [DBG] Opening connection to database 'capbot_db' on server 'localhost'.
+2025-08-12 10:21:11.685 +07:00 [DBG] Opened connection to database 'capbot_db' on server 'localhost'.
+2025-08-12 10:21:11.685 +07:00 [DBG] Creating DbCommand for 'ExecuteReader'.
+2025-08-12 10:21:11.685 +07:00 [DBG] Created DbCommand for 'ExecuteReader' (0ms).
+2025-08-12 10:21:11.685 +07:00 [DBG] Initialized DbCommand for 'ExecuteReader' (0ms).
+2025-08-12 10:21:11.685 +07:00 [DBG] Executing DbCommand [Parameters=[@__normalizedName_0='?' (Size = 4000)], CommandType='"Text"', CommandTimeout='30']
+SELECT TOP(1) [r].[Id], [r].[ConcurrencyStamp], [r].[IsAdmin], [r].[Name], [r].[NormalizedName]
+FROM [roles] AS [r]
+WHERE [r].[NormalizedName] = @__normalizedName_0
+2025-08-12 10:21:11.686 +07:00 [INF] Executed DbCommand (1ms) [Parameters=[@__normalizedName_0='?' (Size = 4000)], CommandType='"Text"', CommandTimeout='30']
+SELECT TOP(1) [r].[Id], [r].[ConcurrencyStamp], [r].[IsAdmin], [r].[Name], [r].[NormalizedName]
+FROM [roles] AS [r]
+WHERE [r].[NormalizedName] = @__normalizedName_0
+2025-08-12 10:21:11.687 +07:00 [DBG] Context 'MyDbContext' started tracking 'Role' entity. Consider using 'DbContextOptionsBuilder.EnableSensitiveDataLogging' to see key values.
+2025-08-12 10:21:11.687 +07:00 [DBG] Closing data reader to 'capbot_db' on server 'localhost'.
+2025-08-12 10:21:11.687 +07:00 [DBG] A data reader for 'capbot_db' on server 'localhost' is being disposed after spending 0ms reading results.
+2025-08-12 10:21:11.687 +07:00 [DBG] Closing connection to database 'capbot_db' on server 'localhost'.
+2025-08-12 10:21:11.687 +07:00 [DBG] Closed connection to database 'capbot_db' on server 'localhost' (0ms).
+2025-08-12 10:21:11.691 +07:00 [DBG] Compiling query expression: 
+'DbSet<User>()
+    .SingleOrDefault(u => u.NormalizedEmail == __normalizedEmail_0)'
+2025-08-12 10:21:11.696 +07:00 [DBG] Generated query execution expression: 
+'queryContext => ShapedQueryCompilingExpressionVisitor.SingleOrDefaultAsync<User>(
+    asyncEnumerable: new SingleQueryingEnumerable<User>(
+        (RelationalQueryContext)queryContext, 
+        RelationalCommandCache.QueryExpression(
+            Projection Mapping:
+                EmptyProjectionMember -> Dictionary<IProperty, int> { [Property: User.Id (int) Required PK AfterSave:Throw ValueGenerated.OnAdd, 0], [Property: User.AccessFailedCount (int) Required, 1], [Property: User.ConcurrencyStamp (string), 2], [Property: User.CreatedAt (DateTime) Required, 3], [Property: User.DeletedAt (DateTime?), 4], [Property: User.Email (string), 5], [Property: User.EmailConfirmed (bool) Required, 6], [Property: User.LastModifiedAt (DateTime) Required, 7], [Property: User.LastModifiedBy (string), 8], [Property: User.LockoutEnabled (bool) Required, 9], [Property: User.LockoutEnd (DateTimeOffset?), 10], [Property: User.NormalizedEmail (string), 11], [Property: User.NormalizedUserName (string), 12], [Property: User.PasswordHash (string), 13], [Property: User.PhoneNumber (string), 14], [Property: User.PhoneNumberConfirmed (bool) Required, 15], [Property: User.SecurityStamp (string), 16], [Property: User.TwoFactorEnabled (bool) Required, 17], [Property: User.UserName (string), 18] }
+            SELECT TOP(2) u.Id, u.AccessFailedCount, u.ConcurrencyStamp, u.CreatedAt, u.DeletedAt, u.Email, u.EmailConfirmed, u.LastModifiedAt, u.LastModifiedBy, u.LockoutEnabled, u.LockoutEnd, u.NormalizedEmail, u.NormalizedUserName, u.PasswordHash, u.PhoneNumber, u.PhoneNumberConfirmed, u.SecurityStamp, u.TwoFactorEnabled, u.UserName
+            FROM users AS u
+            WHERE u.NormalizedEmail == @__normalizedEmail_0), 
+        null, 
+        Func<QueryContext, DbDataReader, ResultContext, SingleQueryResultCoordinator, User>, 
+        App.DAL.Context.MyDbContext, 
+        False, 
+        False, 
+        True
+    ), 
+    cancellationToken: queryContext.CancellationToken)'
+2025-08-12 10:21:11.697 +07:00 [DBG] Opening connection to database 'capbot_db' on server 'localhost'.
+2025-08-12 10:21:11.698 +07:00 [DBG] Opened connection to database 'capbot_db' on server 'localhost'.
+2025-08-12 10:21:11.699 +07:00 [DBG] Creating DbCommand for 'ExecuteReader'.
+2025-08-12 10:21:11.699 +07:00 [DBG] Created DbCommand for 'ExecuteReader' (0ms).
+2025-08-12 10:21:11.699 +07:00 [DBG] Initialized DbCommand for 'ExecuteReader' (0ms).
+2025-08-12 10:21:11.699 +07:00 [DBG] Executing DbCommand [Parameters=[@__normalizedEmail_0='?' (Size = 4000)], CommandType='"Text"', CommandTimeout='30']
+SELECT TOP(2) [u].[Id], [u].[AccessFailedCount], [u].[ConcurrencyStamp], [u].[CreatedAt], [u].[DeletedAt], [u].[Email], [u].[EmailConfirmed], [u].[LastModifiedAt], [u].[LastModifiedBy], [u].[LockoutEnabled], [u].[LockoutEnd], [u].[NormalizedEmail], [u].[NormalizedUserName], [u].[PasswordHash], [u].[PhoneNumber], [u].[PhoneNumberConfirmed], [u].[SecurityStamp], [u].[TwoFactorEnabled], [u].[UserName]
+FROM [users] AS [u]
+WHERE [u].[NormalizedEmail] = @__normalizedEmail_0
+2025-08-12 10:21:11.704 +07:00 [INF] Executed DbCommand (4ms) [Parameters=[@__normalizedEmail_0='?' (Size = 4000)], CommandType='"Text"', CommandTimeout='30']
+SELECT TOP(2) [u].[Id], [u].[AccessFailedCount], [u].[ConcurrencyStamp], [u].[CreatedAt], [u].[DeletedAt], [u].[Email], [u].[EmailConfirmed], [u].[LastModifiedAt], [u].[LastModifiedBy], [u].[LockoutEnabled], [u].[LockoutEnd], [u].[NormalizedEmail], [u].[NormalizedUserName], [u].[PasswordHash], [u].[PhoneNumber], [u].[PhoneNumberConfirmed], [u].[SecurityStamp], [u].[TwoFactorEnabled], [u].[UserName]
+FROM [users] AS [u]
+WHERE [u].[NormalizedEmail] = @__normalizedEmail_0
+2025-08-12 10:21:11.719 +07:00 [DBG] Context 'MyDbContext' started tracking 'User' entity. Consider using 'DbContextOptionsBuilder.EnableSensitiveDataLogging' to see key values.
+2025-08-12 10:21:11.744 +07:00 [DBG] Closing data reader to 'capbot_db' on server 'localhost'.
+2025-08-12 10:21:11.744 +07:00 [DBG] A data reader for 'capbot_db' on server 'localhost' is being disposed after spending 39ms reading results.
+2025-08-12 10:21:11.744 +07:00 [DBG] Closing connection to database 'capbot_db' on server 'localhost'.
+2025-08-12 10:21:11.745 +07:00 [DBG] Closed connection to database 'capbot_db' on server 'localhost' (0ms).
+2025-08-12 10:21:11.747 +07:00 [INF] Admin user 'fptslayer@gmail.com' already exists
+2025-08-12 10:21:11.749 +07:00 [DBG] Opening connection to database 'capbot_db' on server 'localhost'.
+2025-08-12 10:21:11.749 +07:00 [DBG] Opened connection to database 'capbot_db' on server 'localhost'.
+2025-08-12 10:21:11.750 +07:00 [DBG] Creating DbCommand for 'ExecuteReader'.
+2025-08-12 10:21:11.750 +07:00 [DBG] Created DbCommand for 'ExecuteReader' (0ms).
+2025-08-12 10:21:11.750 +07:00 [DBG] Initialized DbCommand for 'ExecuteReader' (0ms).
+2025-08-12 10:21:11.751 +07:00 [DBG] Executing DbCommand [Parameters=[@__normalizedEmail_0='?' (Size = 4000)], CommandType='"Text"', CommandTimeout='30']
+SELECT TOP(2) [u].[Id], [u].[AccessFailedCount], [u].[ConcurrencyStamp], [u].[CreatedAt], [u].[DeletedAt], [u].[Email], [u].[EmailConfirmed], [u].[LastModifiedAt], [u].[LastModifiedBy], [u].[LockoutEnabled], [u].[LockoutEnd], [u].[NormalizedEmail], [u].[NormalizedUserName], [u].[PasswordHash], [u].[PhoneNumber], [u].[PhoneNumberConfirmed], [u].[SecurityStamp], [u].[TwoFactorEnabled], [u].[UserName]
+FROM [users] AS [u]
+WHERE [u].[NormalizedEmail] = @__normalizedEmail_0
+2025-08-12 10:21:11.753 +07:00 [INF] Executed DbCommand (2ms) [Parameters=[@__normalizedEmail_0='?' (Size = 4000)], CommandType='"Text"', CommandTimeout='30']
+SELECT TOP(2) [u].[Id], [u].[AccessFailedCount], [u].[ConcurrencyStamp], [u].[CreatedAt], [u].[DeletedAt], [u].[Email], [u].[EmailConfirmed], [u].[LastModifiedAt], [u].[LastModifiedBy], [u].[LockoutEnabled], [u].[LockoutEnd], [u].[NormalizedEmail], [u].[NormalizedUserName], [u].[PasswordHash], [u].[PhoneNumber], [u].[PhoneNumberConfirmed], [u].[SecurityStamp], [u].[TwoFactorEnabled], [u].[UserName]
+FROM [users] AS [u]
+WHERE [u].[NormalizedEmail] = @__normalizedEmail_0
+2025-08-12 10:21:11.753 +07:00 [DBG] Context 'MyDbContext' started tracking 'User' entity. Consider using 'DbContextOptionsBuilder.EnableSensitiveDataLogging' to see key values.
+2025-08-12 10:21:11.754 +07:00 [DBG] Closing data reader to 'capbot_db' on server 'localhost'.
+2025-08-12 10:21:11.754 +07:00 [DBG] A data reader for 'capbot_db' on server 'localhost' is being disposed after spending 0ms reading results.
+2025-08-12 10:21:11.754 +07:00 [DBG] Closing connection to database 'capbot_db' on server 'localhost'.
+2025-08-12 10:21:11.755 +07:00 [DBG] Closed connection to database 'capbot_db' on server 'localhost' (0ms).
+2025-08-12 10:21:11.755 +07:00 [INF] Sample moderator 'moderator@example.com' already exists
+2025-08-12 10:21:11.755 +07:00 [DBG] Opening connection to database 'capbot_db' on server 'localhost'.
+2025-08-12 10:21:11.756 +07:00 [DBG] Opened connection to database 'capbot_db' on server 'localhost'.
+2025-08-12 10:21:11.756 +07:00 [DBG] Creating DbCommand for 'ExecuteReader'.
+2025-08-12 10:21:11.756 +07:00 [DBG] Created DbCommand for 'ExecuteReader' (0ms).
+2025-08-12 10:21:11.756 +07:00 [DBG] Initialized DbCommand for 'ExecuteReader' (0ms).
+2025-08-12 10:21:11.756 +07:00 [DBG] Executing DbCommand [Parameters=[@__normalizedEmail_0='?' (Size = 4000)], CommandType='"Text"', CommandTimeout='30']
+SELECT TOP(2) [u].[Id], [u].[AccessFailedCount], [u].[ConcurrencyStamp], [u].[CreatedAt], [u].[DeletedAt], [u].[Email], [u].[EmailConfirmed], [u].[LastModifiedAt], [u].[LastModifiedBy], [u].[LockoutEnabled], [u].[LockoutEnd], [u].[NormalizedEmail], [u].[NormalizedUserName], [u].[PasswordHash], [u].[PhoneNumber], [u].[PhoneNumberConfirmed], [u].[SecurityStamp], [u].[TwoFactorEnabled], [u].[UserName]
+FROM [users] AS [u]
+WHERE [u].[NormalizedEmail] = @__normalizedEmail_0
+2025-08-12 10:21:11.758 +07:00 [INF] Executed DbCommand (1ms) [Parameters=[@__normalizedEmail_0='?' (Size = 4000)], CommandType='"Text"', CommandTimeout='30']
+SELECT TOP(2) [u].[Id], [u].[AccessFailedCount], [u].[ConcurrencyStamp], [u].[CreatedAt], [u].[DeletedAt], [u].[Email], [u].[EmailConfirmed], [u].[LastModifiedAt], [u].[LastModifiedBy], [u].[LockoutEnabled], [u].[LockoutEnd], [u].[NormalizedEmail], [u].[NormalizedUserName], [u].[PasswordHash], [u].[PhoneNumber], [u].[PhoneNumberConfirmed], [u].[SecurityStamp], [u].[TwoFactorEnabled], [u].[UserName]
+FROM [users] AS [u]
+WHERE [u].[NormalizedEmail] = @__normalizedEmail_0
+2025-08-12 10:21:11.759 +07:00 [DBG] Context 'MyDbContext' started tracking 'User' entity. Consider using 'DbContextOptionsBuilder.EnableSensitiveDataLogging' to see key values.
+2025-08-12 10:21:11.759 +07:00 [DBG] Closing data reader to 'capbot_db' on server 'localhost'.
+2025-08-12 10:21:11.759 +07:00 [DBG] A data reader for 'capbot_db' on server 'localhost' is being disposed after spending 0ms reading results.
+2025-08-12 10:21:11.759 +07:00 [DBG] Closing connection to database 'capbot_db' on server 'localhost'.
+2025-08-12 10:21:11.759 +07:00 [DBG] Closed connection to database 'capbot_db' on server 'localhost' (0ms).
+2025-08-12 10:21:11.760 +07:00 [DBG] Opening connection to database 'capbot_db' on server 'localhost'.
+2025-08-12 10:21:11.760 +07:00 [DBG] Opened connection to database 'capbot_db' on server 'localhost'.
+2025-08-12 10:21:11.760 +07:00 [DBG] Creating DbCommand for 'ExecuteReader'.
+2025-08-12 10:21:11.760 +07:00 [DBG] Created DbCommand for 'ExecuteReader' (0ms).
+2025-08-12 10:21:11.760 +07:00 [DBG] Initialized DbCommand for 'ExecuteReader' (0ms).
+2025-08-12 10:21:11.760 +07:00 [DBG] Executing DbCommand [Parameters=[@__normalizedEmail_0='?' (Size = 4000)], CommandType='"Text"', CommandTimeout='30']
+SELECT TOP(2) [u].[Id], [u].[AccessFailedCount], [u].[ConcurrencyStamp], [u].[CreatedAt], [u].[DeletedAt], [u].[Email], [u].[EmailConfirmed], [u].[LastModifiedAt], [u].[LastModifiedBy], [u].[LockoutEnabled], [u].[LockoutEnd], [u].[NormalizedEmail], [u].[NormalizedUserName], [u].[PasswordHash], [u].[PhoneNumber], [u].[PhoneNumberConfirmed], [u].[SecurityStamp], [u].[TwoFactorEnabled], [u].[UserName]
+FROM [users] AS [u]
+WHERE [u].[NormalizedEmail] = @__normalizedEmail_0
+2025-08-12 10:21:11.762 +07:00 [INF] Executed DbCommand (1ms) [Parameters=[@__normalizedEmail_0='?' (Size = 4000)], CommandType='"Text"', CommandTimeout='30']
+SELECT TOP(2) [u].[Id], [u].[AccessFailedCount], [u].[ConcurrencyStamp], [u].[CreatedAt], [u].[DeletedAt], [u].[Email], [u].[EmailConfirmed], [u].[LastModifiedAt], [u].[LastModifiedBy], [u].[LockoutEnabled], [u].[LockoutEnd], [u].[NormalizedEmail], [u].[NormalizedUserName], [u].[PasswordHash], [u].[PhoneNumber], [u].[PhoneNumberConfirmed], [u].[SecurityStamp], [u].[TwoFactorEnabled], [u].[UserName]
+FROM [users] AS [u]
+WHERE [u].[NormalizedEmail] = @__normalizedEmail_0
+2025-08-12 10:21:11.763 +07:00 [DBG] Context 'MyDbContext' started tracking 'User' entity. Consider using 'DbContextOptionsBuilder.EnableSensitiveDataLogging' to see key values.
+2025-08-12 10:21:11.763 +07:00 [DBG] Closing data reader to 'capbot_db' on server 'localhost'.
+2025-08-12 10:21:11.763 +07:00 [DBG] A data reader for 'capbot_db' on server 'localhost' is being disposed after spending 0ms reading results.
+2025-08-12 10:21:11.764 +07:00 [DBG] Closing connection to database 'capbot_db' on server 'localhost'.
+2025-08-12 10:21:11.764 +07:00 [DBG] Closed connection to database 'capbot_db' on server 'localhost' (0ms).
+2025-08-12 10:21:11.764 +07:00 [INF] Data seeding completed successfully
+2025-08-12 10:21:11.765 +07:00 [DBG] 'MyDbContext' disposed.
+2025-08-12 10:21:11.767 +07:00 [DBG] Disposing connection to database 'capbot_db' on server 'localhost'.
+2025-08-12 10:21:11.767 +07:00 [DBG] Disposed connection to database '' on server '' (0ms).
+2025-08-12 10:21:11.945 +07:00 [DBG] Registered model binder providers, in the following order: ["Microsoft.AspNetCore.Mvc.ModelBinding.Binders.BinderTypeModelBinderProvider","Microsoft.AspNetCore.Mvc.ModelBinding.Binders.ServicesModelBinderProvider","Microsoft.AspNetCore.Mvc.ModelBinding.Binders.BodyModelBinderProvider","Microsoft.AspNetCore.Mvc.ModelBinding.Binders.HeaderModelBinderProvider","Microsoft.AspNetCore.Mvc.ModelBinding.Binders.FloatingPointTypeModelBinderProvider","Microsoft.AspNetCore.Mvc.ModelBinding.Binders.EnumTypeModelBinderProvider","Microsoft.AspNetCore.Mvc.ModelBinding.Binders.DateTimeModelBinderProvider","Microsoft.AspNetCore.Mvc.ModelBinding.Binders.SimpleTypeModelBinderProvider","Microsoft.AspNetCore.Mvc.ModelBinding.Binders.TryParseModelBinderProvider","Microsoft.AspNetCore.Mvc.ModelBinding.Binders.CancellationTokenModelBinderProvider"]
+2025-08-12 10:21:12.019 +07:00 [DBG] Hosting starting
+2025-08-12 10:21:12.024 +07:00 [DBG] Reading data from file 'C:\Users\Admin\AppData\Local\ASP.NET\DataProtection-Keys\key-1d6bcff1-a155-4167-8a22-de35a5f05047.xml'.
+2025-08-12 10:21:12.061 +07:00 [DBG] Reading data from file 'C:\Users\Admin\AppData\Local\ASP.NET\DataProtection-Keys\key-2459dd29-32d5-4c49-ac9d-33896047bb78.xml'.
+2025-08-12 10:21:12.074 +07:00 [DBG] Reading data from file 'C:\Users\Admin\AppData\Local\ASP.NET\DataProtection-Keys\key-374624f1-e856-4617-8ae6-fe6a81ce6346.xml'.
+2025-08-12 10:21:12.094 +07:00 [DBG] Found key {1d6bcff1-a155-4167-8a22-de35a5f05047}.
+2025-08-12 10:21:12.100 +07:00 [DBG] Found key {2459dd29-32d5-4c49-ac9d-33896047bb78}.
+2025-08-12 10:21:12.101 +07:00 [DBG] Found key {374624f1-e856-4617-8ae6-fe6a81ce6346}.
+2025-08-12 10:21:12.105 +07:00 [DBG] Considering key {2459dd29-32d5-4c49-ac9d-33896047bb78} with expiration date 2025-11-03 12:40:53Z as default key.
+2025-08-12 10:21:12.107 +07:00 [DBG] Forwarded activator type request from Microsoft.AspNetCore.DataProtection.XmlEncryption.DpapiXmlDecryptor, Microsoft.AspNetCore.DataProtection, Version=8.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60 to Microsoft.AspNetCore.DataProtection.XmlEncryption.DpapiXmlDecryptor, Microsoft.AspNetCore.DataProtection, Culture=neutral, PublicKeyToken=adb9793829ddae60
+2025-08-12 10:21:12.108 +07:00 [DBG] Decrypting secret element using Windows DPAPI.
+2025-08-12 10:21:12.110 +07:00 [DBG] Forwarded activator type request from Microsoft.AspNetCore.DataProtection.AuthenticatedEncryption.ConfigurationModel.AuthenticatedEncryptorDescriptorDeserializer, Microsoft.AspNetCore.DataProtection, Version=8.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60 to Microsoft.AspNetCore.DataProtection.AuthenticatedEncryption.ConfigurationModel.AuthenticatedEncryptorDescriptorDeserializer, Microsoft.AspNetCore.DataProtection, Culture=neutral, PublicKeyToken=adb9793829ddae60
+2025-08-12 10:21:12.111 +07:00 [DBG] Opening CNG algorithm 'AES' from provider 'null' with chaining mode CBC.
+2025-08-12 10:21:12.113 +07:00 [DBG] Opening CNG algorithm 'SHA256' from provider 'null' with HMAC.
+2025-08-12 10:21:12.114 +07:00 [DBG] Using key {2459dd29-32d5-4c49-ac9d-33896047bb78} as the default key.
+2025-08-12 10:21:12.115 +07:00 [DBG] Key ring with default key {2459dd29-32d5-4c49-ac9d-33896047bb78} was loaded during application startup.
+2025-08-12 10:21:12.239 +07:00 [INF] Now listening on: https://localhost:7190
+2025-08-12 10:21:12.240 +07:00 [DBG] Loaded hosting startup assembly CapBot.api
+2025-08-12 10:21:12.240 +07:00 [DBG] Loaded hosting startup assembly Microsoft.WebTools.ApiEndpointDiscovery
+2025-08-12 10:21:12.240 +07:00 [DBG] Loaded hosting startup assembly Microsoft.AspNetCore.Watch.BrowserRefresh
+2025-08-12 10:21:12.240 +07:00 [DBG] Loaded hosting startup assembly Microsoft.WebTools.BrowserLink.Net
+2025-08-12 10:21:12.301 +07:00 [INF] Application started. Press Ctrl+C to shut down.
+2025-08-12 10:21:12.301 +07:00 [INF] Hosting environment: Development
+2025-08-12 10:21:12.301 +07:00 [INF] Content root path: C:\Users\Admin\Downloads\CBAI_API\CapBot.api
+2025-08-12 10:21:12.301 +07:00 [DBG] Hosting started
+2025-08-12 10:21:12.349 +07:00 [DBG] Connection id "0HNEP9T4VRHJH" received FIN.
+2025-08-12 10:21:12.349 +07:00 [DBG] Connection id "0HNEP9T4VRHJG" received FIN.
+2025-08-12 10:21:12.367 +07:00 [DBG] Connection id "0HNEP9T4VRHJH" accepted.
+2025-08-12 10:21:12.367 +07:00 [DBG] Connection id "0HNEP9T4VRHJG" accepted.
+2025-08-12 10:21:12.368 +07:00 [DBG] Connection id "0HNEP9T4VRHJH" started.
+2025-08-12 10:21:12.368 +07:00 [DBG] Connection id "0HNEP9T4VRHJG" started.
+2025-08-12 10:21:12.383 +07:00 [DBG] Failed to authenticate HTTPS connection.
+System.IO.IOException: Received an unexpected EOF or 0 bytes from the transport stream.
+   at System.Net.Security.SslStream.ReceiveHandshakeFrameAsync[TIOAdapter](CancellationToken cancellationToken)
+   at System.Net.Security.SslStream.ForceAuthenticationAsync[TIOAdapter](Boolean receiveFirst, Byte[] reAuthenticationData, CancellationToken cancellationToken)
+   at System.Net.Security.SslStream.ProcessAuthenticationWithTelemetryAsync(Boolean isAsync, CancellationToken cancellationToken)
+   at Microsoft.AspNetCore.Server.Kestrel.Https.Internal.HttpsConnectionMiddleware.OnConnectionAsync(ConnectionContext context)
+2025-08-12 10:21:12.383 +07:00 [DBG] Failed to authenticate HTTPS connection.
+System.IO.IOException: Received an unexpected EOF or 0 bytes from the transport stream.
+   at System.Net.Security.SslStream.ReceiveHandshakeFrameAsync[TIOAdapter](CancellationToken cancellationToken)
+   at System.Net.Security.SslStream.ForceAuthenticationAsync[TIOAdapter](Boolean receiveFirst, Byte[] reAuthenticationData, CancellationToken cancellationToken)
+   at System.Net.Security.SslStream.ProcessAuthenticationWithTelemetryAsync(Boolean isAsync, CancellationToken cancellationToken)
+   at Microsoft.AspNetCore.Server.Kestrel.Https.Internal.HttpsConnectionMiddleware.OnConnectionAsync(ConnectionContext context)
+2025-08-12 10:21:12.392 +07:00 [DBG] Connection id "0HNEP9T4VRHJG" stopped.
+2025-08-12 10:21:12.392 +07:00 [DBG] Connection id "0HNEP9T4VRHJH" stopped.
+2025-08-12 10:21:12.395 +07:00 [DBG] Connection id "0HNEP9T4VRHJH" sending FIN because: "The Socket transport's send loop completed gracefully."
+2025-08-12 10:21:12.395 +07:00 [DBG] Connection id "0HNEP9T4VRHJG" sending FIN because: "The Socket transport's send loop completed gracefully."
+2025-08-12 10:21:12.613 +07:00 [DBG] Connection id "0HNEP9T4VRHJI" accepted.
+2025-08-12 10:21:12.613 +07:00 [DBG] Connection id "0HNEP9T4VRHJI" started.
+2025-08-12 10:21:12.699 +07:00 [DBG] Connection 0HNEP9T4VRHJI established using the following protocol: "Tls13"
+2025-08-12 10:21:12.766 +07:00 [INF] Request starting HTTP/2 GET https://localhost:7190/index.html - null null
+2025-08-12 10:21:12.837 +07:00 [DBG] Wildcard detected, all requests with hosts will be allowed.
+2025-08-12 10:21:12.870 +07:00 [DBG] Response markup is scheduled to include Browser Link script injection.
+2025-08-12 10:21:12.872 +07:00 [DBG] Response markup is scheduled to include browser refresh script injection.
+2025-08-12 10:21:12.890 +07:00 [DBG] Response markup was updated to include Browser Link script injection.
+2025-08-12 10:21:12.890 +07:00 [DBG] Response markup was updated to include browser refresh script injection.
+2025-08-12 10:21:12.893 +07:00 [INF] Request finished HTTP/2 GET https://localhost:7190/index.html - 200 null text/html;charset=utf-8 132.0835ms
+2025-08-12 10:21:12.901 +07:00 [INF] Request starting HTTP/2 GET https://localhost:7190/_framework/aspnetcore-browser-refresh.js - null null
+2025-08-12 10:21:12.901 +07:00 [INF] Request starting HTTP/2 GET https://localhost:7190/_vs/browserLink - null null
+2025-08-12 10:21:12.908 +07:00 [INF] Request finished HTTP/2 GET https://localhost:7190/_framework/aspnetcore-browser-refresh.js - 200 13756 application/javascript; charset=utf-8 6.6472ms
+2025-08-12 10:21:12.950 +07:00 [INF] Request finished HTTP/2 GET https://localhost:7190/_vs/browserLink - 200 null text/javascript; charset=UTF-8 48.9612ms
+2025-08-12 10:21:12.970 +07:00 [INF] Request starting HTTP/2 GET https://localhost:7190/swagger/v1/swagger.json - null null
+2025-08-12 10:21:13.000 +07:00 [INF] Request finished HTTP/2 GET https://localhost:7190/swagger/v1/swagger.json - 200 null application/json;charset=utf-8 29.7921ms
+2025-08-12 10:22:16.495 +07:00 [INF] Application is shutting down...
+2025-08-12 10:22:16.505 +07:00 [DBG] Hosting stopping
+2025-08-12 10:22:16.535 +07:00 [DBG] Connection id "0HNEP9T4VRHJI" is closing.
+2025-08-12 10:22:16.535 +07:00 [DBG] Connection id "0HNEP9T4VRHJI" is closed. The last processed stream ID was 7.
+2025-08-12 10:22:16.537 +07:00 [DBG] Connection id "0HNEP9T4VRHJI" received FIN.
+2025-08-12 10:22:16.538 +07:00 [DBG] Connection id "0HNEP9T4VRHJI" sending FIN because: "The Socket transport's send loop completed gracefully."
+2025-08-12 10:22:16.540 +07:00 [DBG] The connection queue processing loop for 0HNEP9T4VRHJI completed.
+2025-08-12 10:22:16.542 +07:00 [DBG] Connection id "0HNEP9T4VRHJI" stopped.
+2025-08-12 10:22:16.547 +07:00 [DBG] Hosting stopped
+2025-08-12 10:22:53.215 +07:00 [DBG] An 'IServiceProvider' was created for internal use by Entity Framework.
+2025-08-12 10:22:53.306 +07:00 [INF] User profile is available. Using 'C:\Users\Admin\AppData\Local\ASP.NET\DataProtection-Keys' as key repository and Windows DPAPI to encrypt keys at rest.
+2025-08-12 10:22:53.486 +07:00 [DBG] No relationship from 'ReviewerAssignment' to 'User' has been configured by convention because there are multiple properties on one entity type - {'AssignedByUser', 'Reviewer'} that could be matched with the properties on the other entity type - {'ReviewerAssignments'}. This message can be disregarded if explicit configuration has been specified in 'OnModelCreating'.
+2025-08-12 10:22:53.500 +07:00 [DBG] No relationship from 'SubmissionWorkflowLog' to 'WorkflowState' has been configured by convention because there are multiple properties on one entity type - {'FromState', 'ToState'} that could be matched with the properties on the other entity type - {'FromStateLogs', 'ToStateLogs'}. This message can be disregarded if explicit configuration has been specified in 'OnModelCreating'.
+2025-08-12 10:22:53.510 +07:00 [DBG] No relationship from 'User' to 'ReviewerAssignment' has been configured by convention because there are multiple properties on one entity type - {'ReviewerAssignments'} that could be matched with the properties on the other entity type - {'AssignedByUser', 'Reviewer'}. This message can be disregarded if explicit configuration has been specified in 'OnModelCreating'.
+2025-08-12 10:22:53.511 +07:00 [DBG] No relationship from 'WorkflowState' to 'SubmissionWorkflowLog' has been configured by convention because there are multiple properties on one entity type - {'FromStateLogs', 'ToStateLogs'} that could be matched with the properties on the other entity type - {'FromState', 'ToState'}. This message can be disregarded if explicit configuration has been specified in 'OnModelCreating'.
+2025-08-12 10:22:53.512 +07:00 [DBG] No relationship from 'WorkflowState' to 'WorkflowTransition' has been configured by convention because there are multiple properties on one entity type - {'FromTransitions', 'ToTransitions'} that could be matched with the properties on the other entity type - {'FromState', 'ToState'}. This message can be disregarded if explicit configuration has been specified in 'OnModelCreating'.
+2025-08-12 10:22:53.513 +07:00 [DBG] No relationship from 'WorkflowTransition' to 'WorkflowState' has been configured by convention because there are multiple properties on one entity type - {'FromState', 'ToState'} that could be matched with the properties on the other entity type - {'FromTransitions', 'ToTransitions'}. This message can be disregarded if explicit configuration has been specified in 'OnModelCreating'.
+2025-08-12 10:22:53.650 +07:00 [DBG] No relationship from 'ReviewerAssignment' to 'User' has been configured by convention because there are multiple properties on one entity type - {'AssignedByUser', 'Reviewer'} that could be matched with the properties on the other entity type - {'ReviewerAssignments'}. This message can be disregarded if explicit configuration has been specified in 'OnModelCreating'.
+2025-08-12 10:22:53.652 +07:00 [DBG] No relationship from 'User' to 'ReviewerAssignment' has been configured by convention because there are multiple properties on one entity type - {'ReviewerAssignments'} that could be matched with the properties on the other entity type - {'AssignedByUser', 'Reviewer'}. This message can be disregarded if explicit configuration has been specified in 'OnModelCreating'.
+2025-08-12 10:22:53.666 +07:00 [DBG] No relationship from 'WorkflowTransition' to 'WorkflowState' has been configured by convention because there are multiple properties on one entity type - {'FromState', 'ToState'} that could be matched with the properties on the other entity type - {'FromTransitions', 'ToTransitions'}. This message can be disregarded if explicit configuration has been specified in 'OnModelCreating'.
+2025-08-12 10:22:53.667 +07:00 [DBG] No relationship from 'WorkflowState' to 'SubmissionWorkflowLog' has been configured by convention because there are multiple properties on one entity type - {'FromStateLogs', 'ToStateLogs'} that could be matched with the properties on the other entity type - {'FromState', 'ToState'}. This message can be disregarded if explicit configuration has been specified in 'OnModelCreating'.
+2025-08-12 10:22:53.667 +07:00 [DBG] No relationship from 'WorkflowState' to 'WorkflowTransition' has been configured by convention because there are multiple properties on one entity type - {'FromTransitions', 'ToTransitions'} that could be matched with the properties on the other entity type - {'FromState', 'ToState'}. This message can be disregarded if explicit configuration has been specified in 'OnModelCreating'.
+2025-08-12 10:22:53.668 +07:00 [DBG] No relationship from 'WorkflowState' to 'SubmissionWorkflowLog' has been configured by convention because there are multiple properties on one entity type - {'FromStateLogs', 'ToStateLogs'} that could be matched with the properties on the other entity type - {'FromState', 'ToState'}. This message can be disregarded if explicit configuration has been specified in 'OnModelCreating'.
+2025-08-12 10:22:53.671 +07:00 [DBG] No relationship from 'SubmissionWorkflowLog' to 'WorkflowState' has been configured by convention because there are multiple properties on one entity type - {'FromState', 'ToState'} that could be matched with the properties on the other entity type - {'FromStateLogs', 'ToStateLogs'}. This message can be disregarded if explicit configuration has been specified in 'OnModelCreating'.
+2025-08-12 10:22:53.672 +07:00 [DBG] No relationship from 'WorkflowState' to 'SubmissionWorkflowLog' has been configured by convention because there are multiple properties on one entity type - {'FromStateLogs', 'ToStateLogs'} that could be matched with the properties on the other entity type - {'FromState', 'ToState'}. This message can be disregarded if explicit configuration has been specified in 'OnModelCreating'.
+2025-08-12 10:22:53.697 +07:00 [DBG] The index {'LecturerId'} was not created on entity type 'LecturerSkill' as the properties are already covered by the index {'LecturerId', 'SkillTag'}.
+2025-08-12 10:22:53.697 +07:00 [DBG] The index {'SemesterId'} was not created on entity type 'Phase' as the properties are already covered by the index {'SemesterId', 'PhaseTypeId'}.
+2025-08-12 10:22:53.698 +07:00 [DBG] The index {'AssignmentId'} was not created on entity type 'Review' as the properties are already covered by the index {'AssignmentId', 'Status'}.
+2025-08-12 10:22:53.698 +07:00 [DBG] The index {'ReviewId'} was not created on entity type 'ReviewComment' as the properties are already covered by the index {'ReviewId', 'SectionName'}.
+2025-08-12 10:22:53.699 +07:00 [DBG] The index {'ReviewId'} was not created on entity type 'ReviewCriteriaScore' as the properties are already covered by the index {'ReviewId', 'CriteriaId'}.
+2025-08-12 10:22:53.699 +07:00 [DBG] The index {'ReviewerId'} was not created on entity type 'ReviewerAssignment' as the properties are already covered by the index {'ReviewerId', 'Status'}.
+2025-08-12 10:22:53.699 +07:00 [DBG] The index {'SubmissionId'} was not created on entity type 'ReviewerAssignment' as the properties are already covered by the index {'SubmissionId', 'ReviewerId'}.
+2025-08-12 10:22:53.699 +07:00 [DBG] The index {'ReviewerId'} was not created on entity type 'ReviewerPerformance' as the properties are already covered by the index {'ReviewerId', 'SemesterId'}.
+2025-08-12 10:22:53.700 +07:00 [DBG] The index {'PhaseId'} was not created on entity type 'Submission' as the properties are already covered by the index {'PhaseId', 'Status'}.
+2025-08-12 10:22:53.700 +07:00 [DBG] The index {'PhaseId'} was not created on entity type 'Submission' as the properties are already covered by the index {'PhaseId', 'Status', 'SubmittedAt'}.
+2025-08-12 10:22:53.700 +07:00 [DBG] The index {'TopicVersionId'} was not created on entity type 'Submission' as the properties are already covered by the index {'TopicVersionId', 'PhaseId', 'SubmissionRound'}.
+2025-08-12 10:22:53.700 +07:00 [DBG] The index {'SubmissionId'} was not created on entity type 'SubmissionWorkflowLog' as the properties are already covered by the index {'SubmissionId', 'CreatedAt'}.
+2025-08-12 10:22:53.701 +07:00 [DBG] The index {'UserId'} was not created on entity type 'SystemNotification' as the properties are already covered by the index {'UserId', 'IsRead', 'CreatedAt'}.
+2025-08-12 10:22:53.701 +07:00 [DBG] The index {'SemesterId'} was not created on entity type 'Topic' as the properties are already covered by the index {'SemesterId', 'IsApproved'}.
+2025-08-12 10:22:53.701 +07:00 [DBG] The index {'SupervisorId'} was not created on entity type 'Topic' as the properties are already covered by the index {'SupervisorId', 'SemesterId'}.
+2025-08-12 10:22:53.701 +07:00 [DBG] The index {'TopicId'} was not created on entity type 'TopicVersion' as the properties are already covered by the index {'TopicId', 'Status'}.
+2025-08-12 10:22:53.701 +07:00 [DBG] The index {'TopicId'} was not created on entity type 'TopicVersion' as the properties are already covered by the index {'TopicId', 'VersionNumber'}.
+2025-08-12 10:22:53.701 +07:00 [DBG] The index {'UserId'} was not created on entity type 'UserRole' as the properties are already covered by the index {'UserId', 'RoleId'}.
+2025-08-12 10:22:53.701 +07:00 [DBG] The index {'UserId'} was not created on entity type 'UserToken' as the properties are already covered by the index {'UserId', 'LoginProvider', 'Name'}.
+2025-08-12 10:22:53.790 +07:00 [WRN] The 'ProficiencyLevels' property 'ProficiencyLevel' on entity type 'LecturerSkill' is configured with a database-generated default, but has no configured sentinel value. The database-generated default will always be used for inserts when the property has the value '0', since this is the CLR default for the 'ProficiencyLevels' type. Consider using a nullable type, using a nullable backing field, or setting the sentinel value for the property to ensure the database default is used when, and only when, appropriate. See https://aka.ms/efcore-docs-default-values for more information.
+2025-08-12 10:22:53.791 +07:00 [WRN] The 'ReviewRecommendations' property 'Recommendation' on entity type 'Review' is configured with a database-generated default, but has no configured sentinel value. The database-generated default will always be used for inserts when the property has the value '0', since this is the CLR default for the 'ReviewRecommendations' type. Consider using a nullable type, using a nullable backing field, or setting the sentinel value for the property to ensure the database default is used when, and only when, appropriate. See https://aka.ms/efcore-docs-default-values for more information.
+2025-08-12 10:22:53.792 +07:00 [WRN] The 'ReviewStatus' property 'Status' on entity type 'Review' is configured with a database-generated default, but has no configured sentinel value. The database-generated default will always be used for inserts when the property has the value '0', since this is the CLR default for the 'ReviewStatus' type. Consider using a nullable type, using a nullable backing field, or setting the sentinel value for the property to ensure the database default is used when, and only when, appropriate. See https://aka.ms/efcore-docs-default-values for more information.
+2025-08-12 10:22:53.792 +07:00 [WRN] The 'CommentTypes' property 'CommentType' on entity type 'ReviewComment' is configured with a database-generated default, but has no configured sentinel value. The database-generated default will always be used for inserts when the property has the value '0', since this is the CLR default for the 'CommentTypes' type. Consider using a nullable type, using a nullable backing field, or setting the sentinel value for the property to ensure the database default is used when, and only when, appropriate. See https://aka.ms/efcore-docs-default-values for more information.
+2025-08-12 10:22:53.792 +07:00 [WRN] The 'PriorityLevels' property 'Priority' on entity type 'ReviewComment' is configured with a database-generated default, but has no configured sentinel value. The database-generated default will always be used for inserts when the property has the value '0', since this is the CLR default for the 'PriorityLevels' type. Consider using a nullable type, using a nullable backing field, or setting the sentinel value for the property to ensure the database default is used when, and only when, appropriate. See https://aka.ms/efcore-docs-default-values for more information.
+2025-08-12 10:22:53.793 +07:00 [WRN] The 'AssignmentTypes' property 'AssignmentType' on entity type 'ReviewerAssignment' is configured with a database-generated default, but has no configured sentinel value. The database-generated default will always be used for inserts when the property has the value '0', since this is the CLR default for the 'AssignmentTypes' type. Consider using a nullable type, using a nullable backing field, or setting the sentinel value for the property to ensure the database default is used when, and only when, appropriate. See https://aka.ms/efcore-docs-default-values for more information.
+2025-08-12 10:22:53.793 +07:00 [WRN] The 'AssignmentStatus' property 'Status' on entity type 'ReviewerAssignment' is configured with a database-generated default, but has no configured sentinel value. The database-generated default will always be used for inserts when the property has the value '0', since this is the CLR default for the 'AssignmentStatus' type. Consider using a nullable type, using a nullable backing field, or setting the sentinel value for the property to ensure the database default is used when, and only when, appropriate. See https://aka.ms/efcore-docs-default-values for more information.
+2025-08-12 10:22:53.793 +07:00 [WRN] The 'AiCheckStatus' property 'AiCheckStatus' on entity type 'Submission' is configured with a database-generated default, but has no configured sentinel value. The database-generated default will always be used for inserts when the property has the value '0', since this is the CLR default for the 'AiCheckStatus' type. Consider using a nullable type, using a nullable backing field, or setting the sentinel value for the property to ensure the database default is used when, and only when, appropriate. See https://aka.ms/efcore-docs-default-values for more information.
+2025-08-12 10:22:53.793 +07:00 [WRN] The 'SubmissionStatus' property 'Status' on entity type 'Submission' is configured with a database-generated default, but has no configured sentinel value. The database-generated default will always be used for inserts when the property has the value '0', since this is the CLR default for the 'SubmissionStatus' type. Consider using a nullable type, using a nullable backing field, or setting the sentinel value for the property to ensure the database default is used when, and only when, appropriate. See https://aka.ms/efcore-docs-default-values for more information.
+2025-08-12 10:22:53.794 +07:00 [WRN] The 'NotificationTypes' property 'Type' on entity type 'SystemNotification' is configured with a database-generated default, but has no configured sentinel value. The database-generated default will always be used for inserts when the property has the value '0', since this is the CLR default for the 'NotificationTypes' type. Consider using a nullable type, using a nullable backing field, or setting the sentinel value for the property to ensure the database default is used when, and only when, appropriate. See https://aka.ms/efcore-docs-default-values for more information.
+2025-08-12 10:22:53.794 +07:00 [WRN] The 'TopicStatus' property 'Status' on entity type 'TopicVersion' is configured with a database-generated default, but has no configured sentinel value. The database-generated default will always be used for inserts when the property has the value '0', since this is the CLR default for the 'TopicStatus' type. Consider using a nullable type, using a nullable backing field, or setting the sentinel value for the property to ensure the database default is used when, and only when, appropriate. See https://aka.ms/efcore-docs-default-values for more information.
+2025-08-12 10:22:53.900 +07:00 [DBG] Entity Framework Core 8.0.16 initialized 'MyDbContext' using provider 'Microsoft.EntityFrameworkCore.SqlServer:8.0.13' with options: MigrationsAssembly=App.DAL 
+2025-08-12 10:22:53.981 +07:00 [DBG] Compiling query expression: 
+'DbSet<Role>()
+    .FirstOrDefault(r => r.NormalizedName == __normalizedName_0)'
+2025-08-12 10:22:54.082 +07:00 [DBG] Generated query execution expression: 
+'queryContext => ShapedQueryCompilingExpressionVisitor.SingleOrDefaultAsync<Role>(
+    asyncEnumerable: new SingleQueryingEnumerable<Role>(
+        (RelationalQueryContext)queryContext, 
+        RelationalCommandCache.QueryExpression(
+            Projection Mapping:
+                EmptyProjectionMember -> Dictionary<IProperty, int> { [Property: Role.Id (int) Required PK AfterSave:Throw ValueGenerated.OnAdd, 0], [Property: Role.ConcurrencyStamp (string), 1], [Property: Role.IsAdmin (bool) Required, 2], [Property: Role.Name (string), 3], [Property: Role.NormalizedName (string), 4] }
+            SELECT TOP(1) r.Id, r.ConcurrencyStamp, r.IsAdmin, r.Name, r.NormalizedName
+            FROM roles AS r
+            WHERE r.NormalizedName == @__normalizedName_0), 
+        null, 
+        Func<QueryContext, DbDataReader, ResultContext, SingleQueryResultCoordinator, Role>, 
+        App.DAL.Context.MyDbContext, 
+        False, 
+        False, 
+        True
+    ), 
+    cancellationToken: queryContext.CancellationToken)'
+2025-08-12 10:22:54.106 +07:00 [DBG] Creating DbConnection.
+2025-08-12 10:22:54.117 +07:00 [DBG] Created DbConnection. (9ms).
+2025-08-12 10:22:54.120 +07:00 [DBG] Opening connection to database 'capbot_db' on server 'localhost'.
+2025-08-12 10:22:54.319 +07:00 [DBG] Opened connection to database 'capbot_db' on server 'localhost'.
+2025-08-12 10:22:54.321 +07:00 [DBG] Creating DbCommand for 'ExecuteReader'.
+2025-08-12 10:22:54.325 +07:00 [DBG] Created DbCommand for 'ExecuteReader' (2ms).
+2025-08-12 10:22:54.330 +07:00 [DBG] Initialized DbCommand for 'ExecuteReader' (9ms).
+2025-08-12 10:22:54.335 +07:00 [DBG] Executing DbCommand [Parameters=[@__normalizedName_0='?' (Size = 4000)], CommandType='"Text"', CommandTimeout='30']
+SELECT TOP(1) [r].[Id], [r].[ConcurrencyStamp], [r].[IsAdmin], [r].[Name], [r].[NormalizedName]
+FROM [roles] AS [r]
+WHERE [r].[NormalizedName] = @__normalizedName_0
+2025-08-12 10:22:54.383 +07:00 [INF] Executed DbCommand (48ms) [Parameters=[@__normalizedName_0='?' (Size = 4000)], CommandType='"Text"', CommandTimeout='30']
+SELECT TOP(1) [r].[Id], [r].[ConcurrencyStamp], [r].[IsAdmin], [r].[Name], [r].[NormalizedName]
+FROM [roles] AS [r]
+WHERE [r].[NormalizedName] = @__normalizedName_0
+2025-08-12 10:22:54.412 +07:00 [DBG] Context 'MyDbContext' started tracking 'Role' entity. Consider using 'DbContextOptionsBuilder.EnableSensitiveDataLogging' to see key values.
+2025-08-12 10:22:54.427 +07:00 [DBG] Closing data reader to 'capbot_db' on server 'localhost'.
+2025-08-12 10:22:54.432 +07:00 [DBG] A data reader for 'capbot_db' on server 'localhost' is being disposed after spending 45ms reading results.
+2025-08-12 10:22:54.434 +07:00 [DBG] Closing connection to database 'capbot_db' on server 'localhost'.
+2025-08-12 10:22:54.438 +07:00 [DBG] Closed connection to database 'capbot_db' on server 'localhost' (3ms).
+2025-08-12 10:22:54.440 +07:00 [DBG] Opening connection to database 'capbot_db' on server 'localhost'.
+2025-08-12 10:22:54.441 +07:00 [DBG] Opened connection to database 'capbot_db' on server 'localhost'.
+2025-08-12 10:22:54.442 +07:00 [DBG] Creating DbCommand for 'ExecuteReader'.
+2025-08-12 10:22:54.442 +07:00 [DBG] Created DbCommand for 'ExecuteReader' (0ms).
+2025-08-12 10:22:54.442 +07:00 [DBG] Initialized DbCommand for 'ExecuteReader' (0ms).
+2025-08-12 10:22:54.443 +07:00 [DBG] Executing DbCommand [Parameters=[@__normalizedName_0='?' (Size = 4000)], CommandType='"Text"', CommandTimeout='30']
+SELECT TOP(1) [r].[Id], [r].[ConcurrencyStamp], [r].[IsAdmin], [r].[Name], [r].[NormalizedName]
+FROM [roles] AS [r]
+WHERE [r].[NormalizedName] = @__normalizedName_0
+2025-08-12 10:22:54.446 +07:00 [INF] Executed DbCommand (3ms) [Parameters=[@__normalizedName_0='?' (Size = 4000)], CommandType='"Text"', CommandTimeout='30']
+SELECT TOP(1) [r].[Id], [r].[ConcurrencyStamp], [r].[IsAdmin], [r].[Name], [r].[NormalizedName]
+FROM [roles] AS [r]
+WHERE [r].[NormalizedName] = @__normalizedName_0
+2025-08-12 10:22:54.447 +07:00 [DBG] Context 'MyDbContext' started tracking 'Role' entity. Consider using 'DbContextOptionsBuilder.EnableSensitiveDataLogging' to see key values.
+2025-08-12 10:22:54.447 +07:00 [DBG] Closing data reader to 'capbot_db' on server 'localhost'.
+2025-08-12 10:22:54.447 +07:00 [DBG] A data reader for 'capbot_db' on server 'localhost' is being disposed after spending 0ms reading results.
+2025-08-12 10:22:54.447 +07:00 [DBG] Closing connection to database 'capbot_db' on server 'localhost'.
+2025-08-12 10:22:54.448 +07:00 [DBG] Closed connection to database 'capbot_db' on server 'localhost' (0ms).
+2025-08-12 10:22:54.448 +07:00 [DBG] Opening connection to database 'capbot_db' on server 'localhost'.
+2025-08-12 10:22:54.449 +07:00 [DBG] Opened connection to database 'capbot_db' on server 'localhost'.
+2025-08-12 10:22:54.449 +07:00 [DBG] Creating DbCommand for 'ExecuteReader'.
+2025-08-12 10:22:54.449 +07:00 [DBG] Created DbCommand for 'ExecuteReader' (0ms).
+2025-08-12 10:22:54.450 +07:00 [DBG] Initialized DbCommand for 'ExecuteReader' (0ms).
+2025-08-12 10:22:54.450 +07:00 [DBG] Executing DbCommand [Parameters=[@__normalizedName_0='?' (Size = 4000)], CommandType='"Text"', CommandTimeout='30']
+SELECT TOP(1) [r].[Id], [r].[ConcurrencyStamp], [r].[IsAdmin], [r].[Name], [r].[NormalizedName]
+FROM [roles] AS [r]
+WHERE [r].[NormalizedName] = @__normalizedName_0
+2025-08-12 10:22:54.451 +07:00 [INF] Executed DbCommand (1ms) [Parameters=[@__normalizedName_0='?' (Size = 4000)], CommandType='"Text"', CommandTimeout='30']
+SELECT TOP(1) [r].[Id], [r].[ConcurrencyStamp], [r].[IsAdmin], [r].[Name], [r].[NormalizedName]
+FROM [roles] AS [r]
+WHERE [r].[NormalizedName] = @__normalizedName_0
+2025-08-12 10:22:54.452 +07:00 [DBG] Context 'MyDbContext' started tracking 'Role' entity. Consider using 'DbContextOptionsBuilder.EnableSensitiveDataLogging' to see key values.
+2025-08-12 10:22:54.452 +07:00 [DBG] Closing data reader to 'capbot_db' on server 'localhost'.
+2025-08-12 10:22:54.452 +07:00 [DBG] A data reader for 'capbot_db' on server 'localhost' is being disposed after spending 0ms reading results.
+2025-08-12 10:22:54.452 +07:00 [DBG] Closing connection to database 'capbot_db' on server 'localhost'.
+2025-08-12 10:22:54.452 +07:00 [DBG] Closed connection to database 'capbot_db' on server 'localhost' (0ms).
+2025-08-12 10:22:54.453 +07:00 [DBG] Opening connection to database 'capbot_db' on server 'localhost'.
+2025-08-12 10:22:54.453 +07:00 [DBG] Opened connection to database 'capbot_db' on server 'localhost'.
+2025-08-12 10:22:54.453 +07:00 [DBG] Creating DbCommand for 'ExecuteReader'.
+2025-08-12 10:22:54.453 +07:00 [DBG] Created DbCommand for 'ExecuteReader' (0ms).
+2025-08-12 10:22:54.453 +07:00 [DBG] Initialized DbCommand for 'ExecuteReader' (0ms).
+2025-08-12 10:22:54.453 +07:00 [DBG] Executing DbCommand [Parameters=[@__normalizedName_0='?' (Size = 4000)], CommandType='"Text"', CommandTimeout='30']
+SELECT TOP(1) [r].[Id], [r].[ConcurrencyStamp], [r].[IsAdmin], [r].[Name], [r].[NormalizedName]
+FROM [roles] AS [r]
+WHERE [r].[NormalizedName] = @__normalizedName_0
+2025-08-12 10:22:54.454 +07:00 [INF] Executed DbCommand (1ms) [Parameters=[@__normalizedName_0='?' (Size = 4000)], CommandType='"Text"', CommandTimeout='30']
+SELECT TOP(1) [r].[Id], [r].[ConcurrencyStamp], [r].[IsAdmin], [r].[Name], [r].[NormalizedName]
+FROM [roles] AS [r]
+WHERE [r].[NormalizedName] = @__normalizedName_0
+2025-08-12 10:22:54.454 +07:00 [DBG] Context 'MyDbContext' started tracking 'Role' entity. Consider using 'DbContextOptionsBuilder.EnableSensitiveDataLogging' to see key values.
+2025-08-12 10:22:54.454 +07:00 [DBG] Closing data reader to 'capbot_db' on server 'localhost'.
+2025-08-12 10:22:54.454 +07:00 [DBG] A data reader for 'capbot_db' on server 'localhost' is being disposed after spending 0ms reading results.
+2025-08-12 10:22:54.454 +07:00 [DBG] Closing connection to database 'capbot_db' on server 'localhost'.
+2025-08-12 10:22:54.455 +07:00 [DBG] Closed connection to database 'capbot_db' on server 'localhost' (0ms).
+2025-08-12 10:22:54.458 +07:00 [DBG] Compiling query expression: 
+'DbSet<User>()
+    .SingleOrDefault(u => u.NormalizedEmail == __normalizedEmail_0)'
+2025-08-12 10:22:54.464 +07:00 [DBG] Generated query execution expression: 
+'queryContext => ShapedQueryCompilingExpressionVisitor.SingleOrDefaultAsync<User>(
+    asyncEnumerable: new SingleQueryingEnumerable<User>(
+        (RelationalQueryContext)queryContext, 
+        RelationalCommandCache.QueryExpression(
+            Projection Mapping:
+                EmptyProjectionMember -> Dictionary<IProperty, int> { [Property: User.Id (int) Required PK AfterSave:Throw ValueGenerated.OnAdd, 0], [Property: User.AccessFailedCount (int) Required, 1], [Property: User.ConcurrencyStamp (string), 2], [Property: User.CreatedAt (DateTime) Required, 3], [Property: User.DeletedAt (DateTime?), 4], [Property: User.Email (string), 5], [Property: User.EmailConfirmed (bool) Required, 6], [Property: User.LastModifiedAt (DateTime) Required, 7], [Property: User.LastModifiedBy (string), 8], [Property: User.LockoutEnabled (bool) Required, 9], [Property: User.LockoutEnd (DateTimeOffset?), 10], [Property: User.NormalizedEmail (string), 11], [Property: User.NormalizedUserName (string), 12], [Property: User.PasswordHash (string), 13], [Property: User.PhoneNumber (string), 14], [Property: User.PhoneNumberConfirmed (bool) Required, 15], [Property: User.SecurityStamp (string), 16], [Property: User.TwoFactorEnabled (bool) Required, 17], [Property: User.UserName (string), 18] }
+            SELECT TOP(2) u.Id, u.AccessFailedCount, u.ConcurrencyStamp, u.CreatedAt, u.DeletedAt, u.Email, u.EmailConfirmed, u.LastModifiedAt, u.LastModifiedBy, u.LockoutEnabled, u.LockoutEnd, u.NormalizedEmail, u.NormalizedUserName, u.PasswordHash, u.PhoneNumber, u.PhoneNumberConfirmed, u.SecurityStamp, u.TwoFactorEnabled, u.UserName
+            FROM users AS u
+            WHERE u.NormalizedEmail == @__normalizedEmail_0), 
+        null, 
+        Func<QueryContext, DbDataReader, ResultContext, SingleQueryResultCoordinator, User>, 
+        App.DAL.Context.MyDbContext, 
+        False, 
+        False, 
+        True
+    ), 
+    cancellationToken: queryContext.CancellationToken)'
+2025-08-12 10:22:54.467 +07:00 [DBG] Opening connection to database 'capbot_db' on server 'localhost'.
+2025-08-12 10:22:54.467 +07:00 [DBG] Opened connection to database 'capbot_db' on server 'localhost'.
+2025-08-12 10:22:54.467 +07:00 [DBG] Creating DbCommand for 'ExecuteReader'.
+2025-08-12 10:22:54.468 +07:00 [DBG] Created DbCommand for 'ExecuteReader' (0ms).
+2025-08-12 10:22:54.468 +07:00 [DBG] Initialized DbCommand for 'ExecuteReader' (0ms).
+2025-08-12 10:22:54.468 +07:00 [DBG] Executing DbCommand [Parameters=[@__normalizedEmail_0='?' (Size = 4000)], CommandType='"Text"', CommandTimeout='30']
+SELECT TOP(2) [u].[Id], [u].[AccessFailedCount], [u].[ConcurrencyStamp], [u].[CreatedAt], [u].[DeletedAt], [u].[Email], [u].[EmailConfirmed], [u].[LastModifiedAt], [u].[LastModifiedBy], [u].[LockoutEnabled], [u].[LockoutEnd], [u].[NormalizedEmail], [u].[NormalizedUserName], [u].[PasswordHash], [u].[PhoneNumber], [u].[PhoneNumberConfirmed], [u].[SecurityStamp], [u].[TwoFactorEnabled], [u].[UserName]
+FROM [users] AS [u]
+WHERE [u].[NormalizedEmail] = @__normalizedEmail_0
+2025-08-12 10:22:54.474 +07:00 [INF] Executed DbCommand (6ms) [Parameters=[@__normalizedEmail_0='?' (Size = 4000)], CommandType='"Text"', CommandTimeout='30']
+SELECT TOP(2) [u].[Id], [u].[AccessFailedCount], [u].[ConcurrencyStamp], [u].[CreatedAt], [u].[DeletedAt], [u].[Email], [u].[EmailConfirmed], [u].[LastModifiedAt], [u].[LastModifiedBy], [u].[LockoutEnabled], [u].[LockoutEnd], [u].[NormalizedEmail], [u].[NormalizedUserName], [u].[PasswordHash], [u].[PhoneNumber], [u].[PhoneNumberConfirmed], [u].[SecurityStamp], [u].[TwoFactorEnabled], [u].[UserName]
+FROM [users] AS [u]
+WHERE [u].[NormalizedEmail] = @__normalizedEmail_0
+2025-08-12 10:22:54.489 +07:00 [DBG] Context 'MyDbContext' started tracking 'User' entity. Consider using 'DbContextOptionsBuilder.EnableSensitiveDataLogging' to see key values.
+2025-08-12 10:22:54.529 +07:00 [DBG] Closing data reader to 'capbot_db' on server 'localhost'.
+2025-08-12 10:22:54.529 +07:00 [DBG] A data reader for 'capbot_db' on server 'localhost' is being disposed after spending 55ms reading results.
+2025-08-12 10:22:54.530 +07:00 [DBG] Closing connection to database 'capbot_db' on server 'localhost'.
+2025-08-12 10:22:54.530 +07:00 [DBG] Closed connection to database 'capbot_db' on server 'localhost' (0ms).
+2025-08-12 10:22:54.532 +07:00 [INF] Admin user 'fptslayer@gmail.com' already exists
+2025-08-12 10:22:54.534 +07:00 [DBG] Opening connection to database 'capbot_db' on server 'localhost'.
+2025-08-12 10:22:54.535 +07:00 [DBG] Opened connection to database 'capbot_db' on server 'localhost'.
+2025-08-12 10:22:54.535 +07:00 [DBG] Creating DbCommand for 'ExecuteReader'.
+2025-08-12 10:22:54.535 +07:00 [DBG] Created DbCommand for 'ExecuteReader' (0ms).
+2025-08-12 10:22:54.536 +07:00 [DBG] Initialized DbCommand for 'ExecuteReader' (0ms).
+2025-08-12 10:22:54.536 +07:00 [DBG] Executing DbCommand [Parameters=[@__normalizedEmail_0='?' (Size = 4000)], CommandType='"Text"', CommandTimeout='30']
+SELECT TOP(2) [u].[Id], [u].[AccessFailedCount], [u].[ConcurrencyStamp], [u].[CreatedAt], [u].[DeletedAt], [u].[Email], [u].[EmailConfirmed], [u].[LastModifiedAt], [u].[LastModifiedBy], [u].[LockoutEnabled], [u].[LockoutEnd], [u].[NormalizedEmail], [u].[NormalizedUserName], [u].[PasswordHash], [u].[PhoneNumber], [u].[PhoneNumberConfirmed], [u].[SecurityStamp], [u].[TwoFactorEnabled], [u].[UserName]
+FROM [users] AS [u]
+WHERE [u].[NormalizedEmail] = @__normalizedEmail_0
+2025-08-12 10:22:54.538 +07:00 [INF] Executed DbCommand (1ms) [Parameters=[@__normalizedEmail_0='?' (Size = 4000)], CommandType='"Text"', CommandTimeout='30']
+SELECT TOP(2) [u].[Id], [u].[AccessFailedCount], [u].[ConcurrencyStamp], [u].[CreatedAt], [u].[DeletedAt], [u].[Email], [u].[EmailConfirmed], [u].[LastModifiedAt], [u].[LastModifiedBy], [u].[LockoutEnabled], [u].[LockoutEnd], [u].[NormalizedEmail], [u].[NormalizedUserName], [u].[PasswordHash], [u].[PhoneNumber], [u].[PhoneNumberConfirmed], [u].[SecurityStamp], [u].[TwoFactorEnabled], [u].[UserName]
+FROM [users] AS [u]
+WHERE [u].[NormalizedEmail] = @__normalizedEmail_0
+2025-08-12 10:22:54.538 +07:00 [DBG] Context 'MyDbContext' started tracking 'User' entity. Consider using 'DbContextOptionsBuilder.EnableSensitiveDataLogging' to see key values.
+2025-08-12 10:22:54.539 +07:00 [DBG] Closing data reader to 'capbot_db' on server 'localhost'.
+2025-08-12 10:22:54.539 +07:00 [DBG] A data reader for 'capbot_db' on server 'localhost' is being disposed after spending 0ms reading results.
+2025-08-12 10:22:54.539 +07:00 [DBG] Closing connection to database 'capbot_db' on server 'localhost'.
+2025-08-12 10:22:54.540 +07:00 [DBG] Closed connection to database 'capbot_db' on server 'localhost' (0ms).
+2025-08-12 10:22:54.540 +07:00 [INF] Sample moderator 'moderator@example.com' already exists
+2025-08-12 10:22:54.540 +07:00 [DBG] Opening connection to database 'capbot_db' on server 'localhost'.
+2025-08-12 10:22:54.541 +07:00 [DBG] Opened connection to database 'capbot_db' on server 'localhost'.
+2025-08-12 10:22:54.541 +07:00 [DBG] Creating DbCommand for 'ExecuteReader'.
+2025-08-12 10:22:54.541 +07:00 [DBG] Created DbCommand for 'ExecuteReader' (0ms).
+2025-08-12 10:22:54.541 +07:00 [DBG] Initialized DbCommand for 'ExecuteReader' (0ms).
+2025-08-12 10:22:54.542 +07:00 [DBG] Executing DbCommand [Parameters=[@__normalizedEmail_0='?' (Size = 4000)], CommandType='"Text"', CommandTimeout='30']
+SELECT TOP(2) [u].[Id], [u].[AccessFailedCount], [u].[ConcurrencyStamp], [u].[CreatedAt], [u].[DeletedAt], [u].[Email], [u].[EmailConfirmed], [u].[LastModifiedAt], [u].[LastModifiedBy], [u].[LockoutEnabled], [u].[LockoutEnd], [u].[NormalizedEmail], [u].[NormalizedUserName], [u].[PasswordHash], [u].[PhoneNumber], [u].[PhoneNumberConfirmed], [u].[SecurityStamp], [u].[TwoFactorEnabled], [u].[UserName]
+FROM [users] AS [u]
+WHERE [u].[NormalizedEmail] = @__normalizedEmail_0
+2025-08-12 10:22:54.543 +07:00 [INF] Executed DbCommand (1ms) [Parameters=[@__normalizedEmail_0='?' (Size = 4000)], CommandType='"Text"', CommandTimeout='30']
+SELECT TOP(2) [u].[Id], [u].[AccessFailedCount], [u].[ConcurrencyStamp], [u].[CreatedAt], [u].[DeletedAt], [u].[Email], [u].[EmailConfirmed], [u].[LastModifiedAt], [u].[LastModifiedBy], [u].[LockoutEnabled], [u].[LockoutEnd], [u].[NormalizedEmail], [u].[NormalizedUserName], [u].[PasswordHash], [u].[PhoneNumber], [u].[PhoneNumberConfirmed], [u].[SecurityStamp], [u].[TwoFactorEnabled], [u].[UserName]
+FROM [users] AS [u]
+WHERE [u].[NormalizedEmail] = @__normalizedEmail_0
+2025-08-12 10:22:54.543 +07:00 [DBG] Context 'MyDbContext' started tracking 'User' entity. Consider using 'DbContextOptionsBuilder.EnableSensitiveDataLogging' to see key values.
+2025-08-12 10:22:54.544 +07:00 [DBG] Closing data reader to 'capbot_db' on server 'localhost'.
+2025-08-12 10:22:54.544 +07:00 [DBG] A data reader for 'capbot_db' on server 'localhost' is being disposed after spending 0ms reading results.
+2025-08-12 10:22:54.544 +07:00 [DBG] Closing connection to database 'capbot_db' on server 'localhost'.
+2025-08-12 10:22:54.544 +07:00 [DBG] Closed connection to database 'capbot_db' on server 'localhost' (0ms).
+2025-08-12 10:22:54.545 +07:00 [DBG] Opening connection to database 'capbot_db' on server 'localhost'.
+2025-08-12 10:22:54.545 +07:00 [DBG] Opened connection to database 'capbot_db' on server 'localhost'.
+2025-08-12 10:22:54.546 +07:00 [DBG] Creating DbCommand for 'ExecuteReader'.
+2025-08-12 10:22:54.546 +07:00 [DBG] Created DbCommand for 'ExecuteReader' (0ms).
+2025-08-12 10:22:54.546 +07:00 [DBG] Initialized DbCommand for 'ExecuteReader' (0ms).
+2025-08-12 10:22:54.546 +07:00 [DBG] Executing DbCommand [Parameters=[@__normalizedEmail_0='?' (Size = 4000)], CommandType='"Text"', CommandTimeout='30']
+SELECT TOP(2) [u].[Id], [u].[AccessFailedCount], [u].[ConcurrencyStamp], [u].[CreatedAt], [u].[DeletedAt], [u].[Email], [u].[EmailConfirmed], [u].[LastModifiedAt], [u].[LastModifiedBy], [u].[LockoutEnabled], [u].[LockoutEnd], [u].[NormalizedEmail], [u].[NormalizedUserName], [u].[PasswordHash], [u].[PhoneNumber], [u].[PhoneNumberConfirmed], [u].[SecurityStamp], [u].[TwoFactorEnabled], [u].[UserName]
+FROM [users] AS [u]
+WHERE [u].[NormalizedEmail] = @__normalizedEmail_0
+2025-08-12 10:22:54.547 +07:00 [INF] Executed DbCommand (1ms) [Parameters=[@__normalizedEmail_0='?' (Size = 4000)], CommandType='"Text"', CommandTimeout='30']
+SELECT TOP(2) [u].[Id], [u].[AccessFailedCount], [u].[ConcurrencyStamp], [u].[CreatedAt], [u].[DeletedAt], [u].[Email], [u].[EmailConfirmed], [u].[LastModifiedAt], [u].[LastModifiedBy], [u].[LockoutEnabled], [u].[LockoutEnd], [u].[NormalizedEmail], [u].[NormalizedUserName], [u].[PasswordHash], [u].[PhoneNumber], [u].[PhoneNumberConfirmed], [u].[SecurityStamp], [u].[TwoFactorEnabled], [u].[UserName]
+FROM [users] AS [u]
+WHERE [u].[NormalizedEmail] = @__normalizedEmail_0
+2025-08-12 10:22:54.548 +07:00 [DBG] Context 'MyDbContext' started tracking 'User' entity. Consider using 'DbContextOptionsBuilder.EnableSensitiveDataLogging' to see key values.
+2025-08-12 10:22:54.548 +07:00 [DBG] Closing data reader to 'capbot_db' on server 'localhost'.
+2025-08-12 10:22:54.549 +07:00 [DBG] A data reader for 'capbot_db' on server 'localhost' is being disposed after spending 0ms reading results.
+2025-08-12 10:22:54.549 +07:00 [DBG] Closing connection to database 'capbot_db' on server 'localhost'.
+2025-08-12 10:22:54.549 +07:00 [DBG] Closed connection to database 'capbot_db' on server 'localhost' (0ms).
+2025-08-12 10:22:54.549 +07:00 [INF] Data seeding completed successfully
+2025-08-12 10:22:54.550 +07:00 [DBG] 'MyDbContext' disposed.
+2025-08-12 10:22:54.552 +07:00 [DBG] Disposing connection to database 'capbot_db' on server 'localhost'.
+2025-08-12 10:22:54.553 +07:00 [DBG] Disposed connection to database '' on server '' (0ms).
+2025-08-12 10:22:54.686 +07:00 [DBG] Registered model binder providers, in the following order: ["Microsoft.AspNetCore.Mvc.ModelBinding.Binders.BinderTypeModelBinderProvider","Microsoft.AspNetCore.Mvc.ModelBinding.Binders.ServicesModelBinderProvider","Microsoft.AspNetCore.Mvc.ModelBinding.Binders.BodyModelBinderProvider","Microsoft.AspNetCore.Mvc.ModelBinding.Binders.HeaderModelBinderProvider","Microsoft.AspNetCore.Mvc.ModelBinding.Binders.FloatingPointTypeModelBinderProvider","Microsoft.AspNetCore.Mvc.ModelBinding.Binders.EnumTypeModelBinderProvider","Microsoft.AspNetCore.Mvc.ModelBinding.Binders.DateTimeModelBinderProvider","Microsoft.AspNetCore.Mvc.ModelBinding.Binders.SimpleTypeModelBinderProvider","Microsoft.AspNetCore.Mvc.ModelBinding.Binders.TryParseModelBinderProvider","Microsoft.AspNetCore.Mvc.ModelBinding.Binders.CancellationTokenModelBinderProvider"]
+2025-08-12 10:22:54.758 +07:00 [DBG] Hosting starting
+2025-08-12 10:22:54.763 +07:00 [DBG] Reading data from file 'C:\Users\Admin\AppData\Local\ASP.NET\DataProtection-Keys\key-1d6bcff1-a155-4167-8a22-de35a5f05047.xml'.
+2025-08-12 10:22:54.765 +07:00 [DBG] Reading data from file 'C:\Users\Admin\AppData\Local\ASP.NET\DataProtection-Keys\key-2459dd29-32d5-4c49-ac9d-33896047bb78.xml'.
+2025-08-12 10:22:54.766 +07:00 [DBG] Reading data from file 'C:\Users\Admin\AppData\Local\ASP.NET\DataProtection-Keys\key-374624f1-e856-4617-8ae6-fe6a81ce6346.xml'.
+2025-08-12 10:22:54.769 +07:00 [DBG] Found key {1d6bcff1-a155-4167-8a22-de35a5f05047}.
+2025-08-12 10:22:54.772 +07:00 [DBG] Found key {2459dd29-32d5-4c49-ac9d-33896047bb78}.
+2025-08-12 10:22:54.773 +07:00 [DBG] Found key {374624f1-e856-4617-8ae6-fe6a81ce6346}.
+2025-08-12 10:22:54.777 +07:00 [DBG] Considering key {2459dd29-32d5-4c49-ac9d-33896047bb78} with expiration date 2025-11-03 12:40:53Z as default key.
+2025-08-12 10:22:54.780 +07:00 [DBG] Forwarded activator type request from Microsoft.AspNetCore.DataProtection.XmlEncryption.DpapiXmlDecryptor, Microsoft.AspNetCore.DataProtection, Version=8.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60 to Microsoft.AspNetCore.DataProtection.XmlEncryption.DpapiXmlDecryptor, Microsoft.AspNetCore.DataProtection, Culture=neutral, PublicKeyToken=adb9793829ddae60
+2025-08-12 10:22:54.781 +07:00 [DBG] Decrypting secret element using Windows DPAPI.
+2025-08-12 10:22:54.782 +07:00 [DBG] Forwarded activator type request from Microsoft.AspNetCore.DataProtection.AuthenticatedEncryption.ConfigurationModel.AuthenticatedEncryptorDescriptorDeserializer, Microsoft.AspNetCore.DataProtection, Version=8.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60 to Microsoft.AspNetCore.DataProtection.AuthenticatedEncryption.ConfigurationModel.AuthenticatedEncryptorDescriptorDeserializer, Microsoft.AspNetCore.DataProtection, Culture=neutral, PublicKeyToken=adb9793829ddae60
+2025-08-12 10:22:54.784 +07:00 [DBG] Opening CNG algorithm 'AES' from provider 'null' with chaining mode CBC.
+2025-08-12 10:22:54.785 +07:00 [DBG] Opening CNG algorithm 'SHA256' from provider 'null' with HMAC.
+2025-08-12 10:22:54.786 +07:00 [DBG] Using key {2459dd29-32d5-4c49-ac9d-33896047bb78} as the default key.
+2025-08-12 10:22:54.787 +07:00 [DBG] Key ring with default key {2459dd29-32d5-4c49-ac9d-33896047bb78} was loaded during application startup.
+2025-08-12 10:22:54.889 +07:00 [INF] Now listening on: https://localhost:7190
+2025-08-12 10:22:54.892 +07:00 [DBG] Loaded hosting startup assembly CapBot.api
+2025-08-12 10:22:54.895 +07:00 [DBG] Loaded hosting startup assembly Microsoft.WebTools.ApiEndpointDiscovery
+2025-08-12 10:22:54.896 +07:00 [DBG] Loaded hosting startup assembly Microsoft.AspNetCore.Watch.BrowserRefresh
+2025-08-12 10:22:54.898 +07:00 [DBG] Loaded hosting startup assembly Microsoft.WebTools.BrowserLink.Net
+2025-08-12 10:22:54.959 +07:00 [INF] Application started. Press Ctrl+C to shut down.
+2025-08-12 10:22:54.960 +07:00 [INF] Hosting environment: Development
+2025-08-12 10:22:54.960 +07:00 [INF] Content root path: C:\Users\Admin\Downloads\CBAI_API\CapBot.api
+2025-08-12 10:22:54.961 +07:00 [DBG] Hosting started
+2025-08-12 10:22:55.054 +07:00 [DBG] Connection id "0HNEP9U3JAM0T" accepted.
+2025-08-12 10:22:55.055 +07:00 [DBG] Connection id "0HNEP9U3JAM0T" started.
+2025-08-12 10:22:55.065 +07:00 [DBG] Connection id "0HNEP9U3JAM0T" received FIN.
+2025-08-12 10:22:55.080 +07:00 [DBG] Failed to authenticate HTTPS connection.
+System.IO.IOException: Received an unexpected EOF or 0 bytes from the transport stream.
+   at System.Net.Security.SslStream.ReceiveHandshakeFrameAsync[TIOAdapter](CancellationToken cancellationToken)
+   at System.Net.Security.SslStream.ForceAuthenticationAsync[TIOAdapter](Boolean receiveFirst, Byte[] reAuthenticationData, CancellationToken cancellationToken)
+   at System.Net.Security.SslStream.ProcessAuthenticationWithTelemetryAsync(Boolean isAsync, CancellationToken cancellationToken)
+   at Microsoft.AspNetCore.Server.Kestrel.Https.Internal.HttpsConnectionMiddleware.OnConnectionAsync(ConnectionContext context)
+2025-08-12 10:22:55.089 +07:00 [DBG] Connection id "0HNEP9U3JAM0T" stopped.
+2025-08-12 10:22:55.091 +07:00 [DBG] Connection id "0HNEP9U3JAM0T" sending FIN because: "The Socket transport's send loop completed gracefully."
+2025-08-12 10:22:55.159 +07:00 [DBG] Connection id "0HNEP9U3JAM0U" accepted.
+2025-08-12 10:22:55.160 +07:00 [DBG] Connection id "0HNEP9U3JAM0U" started.
+2025-08-12 10:22:55.235 +07:00 [DBG] Connection 0HNEP9U3JAM0U established using the following protocol: "Tls13"
+2025-08-12 10:22:55.289 +07:00 [INF] Request starting HTTP/2 GET https://localhost:7190/index.html - null null
+2025-08-12 10:22:55.322 +07:00 [DBG] Wildcard detected, all requests with hosts will be allowed.
+2025-08-12 10:22:55.350 +07:00 [DBG] Response markup is scheduled to include Browser Link script injection.
+2025-08-12 10:22:55.351 +07:00 [DBG] Response markup is scheduled to include browser refresh script injection.
+2025-08-12 10:22:55.369 +07:00 [DBG] Response markup was updated to include Browser Link script injection.
+2025-08-12 10:22:55.370 +07:00 [DBG] Response markup was updated to include browser refresh script injection.
+2025-08-12 10:22:55.374 +07:00 [INF] Request finished HTTP/2 GET https://localhost:7190/index.html - 200 null text/html;charset=utf-8 90.2869ms
+2025-08-12 10:22:55.380 +07:00 [INF] Request starting HTTP/2 GET https://localhost:7190/_vs/browserLink - null null
+2025-08-12 10:22:55.380 +07:00 [INF] Request starting HTTP/2 GET https://localhost:7190/_framework/aspnetcore-browser-refresh.js - null null
+2025-08-12 10:22:55.388 +07:00 [INF] Request finished HTTP/2 GET https://localhost:7190/_framework/aspnetcore-browser-refresh.js - 200 13756 application/javascript; charset=utf-8 9.4634ms
+2025-08-12 10:22:55.422 +07:00 [INF] Request finished HTTP/2 GET https://localhost:7190/_vs/browserLink - 200 null text/javascript; charset=UTF-8 42.3369ms
+2025-08-12 10:22:55.445 +07:00 [INF] Request starting HTTP/2 GET https://localhost:7190/swagger/v1/swagger.json - null null
+2025-08-12 10:22:55.474 +07:00 [INF] Request finished HTTP/2 GET https://localhost:7190/swagger/v1/swagger.json - 200 null application/json;charset=utf-8 30.0186ms
+2025-08-12 10:23:29.888 +07:00 [INF] Application is shutting down...
+2025-08-12 10:23:29.892 +07:00 [DBG] Hosting stopping
+2025-08-12 10:23:29.915 +07:00 [DBG] Connection id "0HNEP9U3JAM0U" is closing.
+2025-08-12 10:23:29.916 +07:00 [DBG] Connection id "0HNEP9U3JAM0U" is closed. The last processed stream ID was 7.
+2025-08-12 10:23:29.918 +07:00 [DBG] Connection id "0HNEP9U3JAM0U" received FIN.
+2025-08-12 10:23:29.919 +07:00 [DBG] Connection id "0HNEP9U3JAM0U" sending FIN because: "The Socket transport's send loop completed gracefully."
+2025-08-12 10:23:29.922 +07:00 [DBG] The connection queue processing loop for 0HNEP9U3JAM0U completed.
+2025-08-12 10:23:29.925 +07:00 [DBG] Connection id "0HNEP9U3JAM0U" stopped.
+2025-08-12 10:23:29.932 +07:00 [DBG] Hosting stopped
+2025-08-12 10:23:49.564 +07:00 [DBG] An 'IServiceProvider' was created for internal use by Entity Framework.
+2025-08-12 10:23:49.652 +07:00 [INF] User profile is available. Using 'C:\Users\Admin\AppData\Local\ASP.NET\DataProtection-Keys' as key repository and Windows DPAPI to encrypt keys at rest.
+2025-08-12 10:23:49.828 +07:00 [DBG] No relationship from 'ReviewerAssignment' to 'User' has been configured by convention because there are multiple properties on one entity type - {'AssignedByUser', 'Reviewer'} that could be matched with the properties on the other entity type - {'ReviewerAssignments'}. This message can be disregarded if explicit configuration has been specified in 'OnModelCreating'.
+2025-08-12 10:23:49.843 +07:00 [DBG] No relationship from 'SubmissionWorkflowLog' to 'WorkflowState' has been configured by convention because there are multiple properties on one entity type - {'FromState', 'ToState'} that could be matched with the properties on the other entity type - {'FromStateLogs', 'ToStateLogs'}. This message can be disregarded if explicit configuration has been specified in 'OnModelCreating'.
+2025-08-12 10:23:49.851 +07:00 [DBG] No relationship from 'User' to 'ReviewerAssignment' has been configured by convention because there are multiple properties on one entity type - {'ReviewerAssignments'} that could be matched with the properties on the other entity type - {'AssignedByUser', 'Reviewer'}. This message can be disregarded if explicit configuration has been specified in 'OnModelCreating'.
+2025-08-12 10:23:49.853 +07:00 [DBG] No relationship from 'WorkflowState' to 'SubmissionWorkflowLog' has been configured by convention because there are multiple properties on one entity type - {'FromStateLogs', 'ToStateLogs'} that could be matched with the properties on the other entity type - {'FromState', 'ToState'}. This message can be disregarded if explicit configuration has been specified in 'OnModelCreating'.
+2025-08-12 10:23:49.853 +07:00 [DBG] No relationship from 'WorkflowState' to 'WorkflowTransition' has been configured by convention because there are multiple properties on one entity type - {'FromTransitions', 'ToTransitions'} that could be matched with the properties on the other entity type - {'FromState', 'ToState'}. This message can be disregarded if explicit configuration has been specified in 'OnModelCreating'.
+2025-08-12 10:23:49.854 +07:00 [DBG] No relationship from 'WorkflowTransition' to 'WorkflowState' has been configured by convention because there are multiple properties on one entity type - {'FromState', 'ToState'} that could be matched with the properties on the other entity type - {'FromTransitions', 'ToTransitions'}. This message can be disregarded if explicit configuration has been specified in 'OnModelCreating'.
+2025-08-12 10:23:49.973 +07:00 [DBG] No relationship from 'ReviewerAssignment' to 'User' has been configured by convention because there are multiple properties on one entity type - {'AssignedByUser', 'Reviewer'} that could be matched with the properties on the other entity type - {'ReviewerAssignments'}. This message can be disregarded if explicit configuration has been specified in 'OnModelCreating'.
+2025-08-12 10:23:49.975 +07:00 [DBG] No relationship from 'User' to 'ReviewerAssignment' has been configured by convention because there are multiple properties on one entity type - {'ReviewerAssignments'} that could be matched with the properties on the other entity type - {'AssignedByUser', 'Reviewer'}. This message can be disregarded if explicit configuration has been specified in 'OnModelCreating'.
+2025-08-12 10:23:49.989 +07:00 [DBG] No relationship from 'WorkflowTransition' to 'WorkflowState' has been configured by convention because there are multiple properties on one entity type - {'FromState', 'ToState'} that could be matched with the properties on the other entity type - {'FromTransitions', 'ToTransitions'}. This message can be disregarded if explicit configuration has been specified in 'OnModelCreating'.
+2025-08-12 10:23:49.990 +07:00 [DBG] No relationship from 'WorkflowState' to 'SubmissionWorkflowLog' has been configured by convention because there are multiple properties on one entity type - {'FromStateLogs', 'ToStateLogs'} that could be matched with the properties on the other entity type - {'FromState', 'ToState'}. This message can be disregarded if explicit configuration has been specified in 'OnModelCreating'.
+2025-08-12 10:23:49.990 +07:00 [DBG] No relationship from 'WorkflowState' to 'WorkflowTransition' has been configured by convention because there are multiple properties on one entity type - {'FromTransitions', 'ToTransitions'} that could be matched with the properties on the other entity type - {'FromState', 'ToState'}. This message can be disregarded if explicit configuration has been specified in 'OnModelCreating'.
+2025-08-12 10:23:49.991 +07:00 [DBG] No relationship from 'WorkflowState' to 'SubmissionWorkflowLog' has been configured by convention because there are multiple properties on one entity type - {'FromStateLogs', 'ToStateLogs'} that could be matched with the properties on the other entity type - {'FromState', 'ToState'}. This message can be disregarded if explicit configuration has been specified in 'OnModelCreating'.
+2025-08-12 10:23:49.995 +07:00 [DBG] No relationship from 'SubmissionWorkflowLog' to 'WorkflowState' has been configured by convention because there are multiple properties on one entity type - {'FromState', 'ToState'} that could be matched with the properties on the other entity type - {'FromStateLogs', 'ToStateLogs'}. This message can be disregarded if explicit configuration has been specified in 'OnModelCreating'.
+2025-08-12 10:23:49.995 +07:00 [DBG] No relationship from 'WorkflowState' to 'SubmissionWorkflowLog' has been configured by convention because there are multiple properties on one entity type - {'FromStateLogs', 'ToStateLogs'} that could be matched with the properties on the other entity type - {'FromState', 'ToState'}. This message can be disregarded if explicit configuration has been specified in 'OnModelCreating'.
+2025-08-12 10:23:50.017 +07:00 [DBG] The index {'LecturerId'} was not created on entity type 'LecturerSkill' as the properties are already covered by the index {'LecturerId', 'SkillTag'}.
+2025-08-12 10:23:50.018 +07:00 [DBG] The index {'SemesterId'} was not created on entity type 'Phase' as the properties are already covered by the index {'SemesterId', 'PhaseTypeId'}.
+2025-08-12 10:23:50.018 +07:00 [DBG] The index {'AssignmentId'} was not created on entity type 'Review' as the properties are already covered by the index {'AssignmentId', 'Status'}.
+2025-08-12 10:23:50.019 +07:00 [DBG] The index {'ReviewId'} was not created on entity type 'ReviewComment' as the properties are already covered by the index {'ReviewId', 'SectionName'}.
+2025-08-12 10:23:50.019 +07:00 [DBG] The index {'ReviewId'} was not created on entity type 'ReviewCriteriaScore' as the properties are already covered by the index {'ReviewId', 'CriteriaId'}.
+2025-08-12 10:23:50.019 +07:00 [DBG] The index {'ReviewerId'} was not created on entity type 'ReviewerAssignment' as the properties are already covered by the index {'ReviewerId', 'Status'}.
+2025-08-12 10:23:50.019 +07:00 [DBG] The index {'SubmissionId'} was not created on entity type 'ReviewerAssignment' as the properties are already covered by the index {'SubmissionId', 'ReviewerId'}.
+2025-08-12 10:23:50.019 +07:00 [DBG] The index {'ReviewerId'} was not created on entity type 'ReviewerPerformance' as the properties are already covered by the index {'ReviewerId', 'SemesterId'}.
+2025-08-12 10:23:50.019 +07:00 [DBG] The index {'PhaseId'} was not created on entity type 'Submission' as the properties are already covered by the index {'PhaseId', 'Status'}.
+2025-08-12 10:23:50.020 +07:00 [DBG] The index {'PhaseId'} was not created on entity type 'Submission' as the properties are already covered by the index {'PhaseId', 'Status', 'SubmittedAt'}.
+2025-08-12 10:23:50.020 +07:00 [DBG] The index {'TopicVersionId'} was not created on entity type 'Submission' as the properties are already covered by the index {'TopicVersionId', 'PhaseId', 'SubmissionRound'}.
+2025-08-12 10:23:50.020 +07:00 [DBG] The index {'SubmissionId'} was not created on entity type 'SubmissionWorkflowLog' as the properties are already covered by the index {'SubmissionId', 'CreatedAt'}.
+2025-08-12 10:23:50.020 +07:00 [DBG] The index {'UserId'} was not created on entity type 'SystemNotification' as the properties are already covered by the index {'UserId', 'IsRead', 'CreatedAt'}.
+2025-08-12 10:23:50.020 +07:00 [DBG] The index {'SemesterId'} was not created on entity type 'Topic' as the properties are already covered by the index {'SemesterId', 'IsApproved'}.
+2025-08-12 10:23:50.020 +07:00 [DBG] The index {'SupervisorId'} was not created on entity type 'Topic' as the properties are already covered by the index {'SupervisorId', 'SemesterId'}.
+2025-08-12 10:23:50.020 +07:00 [DBG] The index {'TopicId'} was not created on entity type 'TopicVersion' as the properties are already covered by the index {'TopicId', 'Status'}.
+2025-08-12 10:23:50.020 +07:00 [DBG] The index {'TopicId'} was not created on entity type 'TopicVersion' as the properties are already covered by the index {'TopicId', 'VersionNumber'}.
+2025-08-12 10:23:50.020 +07:00 [DBG] The index {'UserId'} was not created on entity type 'UserRole' as the properties are already covered by the index {'UserId', 'RoleId'}.
+2025-08-12 10:23:50.021 +07:00 [DBG] The index {'UserId'} was not created on entity type 'UserToken' as the properties are already covered by the index {'UserId', 'LoginProvider', 'Name'}.
+2025-08-12 10:23:50.113 +07:00 [WRN] The 'ProficiencyLevels' property 'ProficiencyLevel' on entity type 'LecturerSkill' is configured with a database-generated default, but has no configured sentinel value. The database-generated default will always be used for inserts when the property has the value '0', since this is the CLR default for the 'ProficiencyLevels' type. Consider using a nullable type, using a nullable backing field, or setting the sentinel value for the property to ensure the database default is used when, and only when, appropriate. See https://aka.ms/efcore-docs-default-values for more information.
+2025-08-12 10:23:50.115 +07:00 [WRN] The 'ReviewRecommendations' property 'Recommendation' on entity type 'Review' is configured with a database-generated default, but has no configured sentinel value. The database-generated default will always be used for inserts when the property has the value '0', since this is the CLR default for the 'ReviewRecommendations' type. Consider using a nullable type, using a nullable backing field, or setting the sentinel value for the property to ensure the database default is used when, and only when, appropriate. See https://aka.ms/efcore-docs-default-values for more information.
+2025-08-12 10:23:50.115 +07:00 [WRN] The 'ReviewStatus' property 'Status' on entity type 'Review' is configured with a database-generated default, but has no configured sentinel value. The database-generated default will always be used for inserts when the property has the value '0', since this is the CLR default for the 'ReviewStatus' type. Consider using a nullable type, using a nullable backing field, or setting the sentinel value for the property to ensure the database default is used when, and only when, appropriate. See https://aka.ms/efcore-docs-default-values for more information.
+2025-08-12 10:23:50.116 +07:00 [WRN] The 'CommentTypes' property 'CommentType' on entity type 'ReviewComment' is configured with a database-generated default, but has no configured sentinel value. The database-generated default will always be used for inserts when the property has the value '0', since this is the CLR default for the 'CommentTypes' type. Consider using a nullable type, using a nullable backing field, or setting the sentinel value for the property to ensure the database default is used when, and only when, appropriate. See https://aka.ms/efcore-docs-default-values for more information.
+2025-08-12 10:23:50.116 +07:00 [WRN] The 'PriorityLevels' property 'Priority' on entity type 'ReviewComment' is configured with a database-generated default, but has no configured sentinel value. The database-generated default will always be used for inserts when the property has the value '0', since this is the CLR default for the 'PriorityLevels' type. Consider using a nullable type, using a nullable backing field, or setting the sentinel value for the property to ensure the database default is used when, and only when, appropriate. See https://aka.ms/efcore-docs-default-values for more information.
+2025-08-12 10:23:50.116 +07:00 [WRN] The 'AssignmentTypes' property 'AssignmentType' on entity type 'ReviewerAssignment' is configured with a database-generated default, but has no configured sentinel value. The database-generated default will always be used for inserts when the property has the value '0', since this is the CLR default for the 'AssignmentTypes' type. Consider using a nullable type, using a nullable backing field, or setting the sentinel value for the property to ensure the database default is used when, and only when, appropriate. See https://aka.ms/efcore-docs-default-values for more information.
+2025-08-12 10:23:50.117 +07:00 [WRN] The 'AssignmentStatus' property 'Status' on entity type 'ReviewerAssignment' is configured with a database-generated default, but has no configured sentinel value. The database-generated default will always be used for inserts when the property has the value '0', since this is the CLR default for the 'AssignmentStatus' type. Consider using a nullable type, using a nullable backing field, or setting the sentinel value for the property to ensure the database default is used when, and only when, appropriate. See https://aka.ms/efcore-docs-default-values for more information.
+2025-08-12 10:23:50.117 +07:00 [WRN] The 'AiCheckStatus' property 'AiCheckStatus' on entity type 'Submission' is configured with a database-generated default, but has no configured sentinel value. The database-generated default will always be used for inserts when the property has the value '0', since this is the CLR default for the 'AiCheckStatus' type. Consider using a nullable type, using a nullable backing field, or setting the sentinel value for the property to ensure the database default is used when, and only when, appropriate. See https://aka.ms/efcore-docs-default-values for more information.
+2025-08-12 10:23:50.117 +07:00 [WRN] The 'SubmissionStatus' property 'Status' on entity type 'Submission' is configured with a database-generated default, but has no configured sentinel value. The database-generated default will always be used for inserts when the property has the value '0', since this is the CLR default for the 'SubmissionStatus' type. Consider using a nullable type, using a nullable backing field, or setting the sentinel value for the property to ensure the database default is used when, and only when, appropriate. See https://aka.ms/efcore-docs-default-values for more information.
+2025-08-12 10:23:50.117 +07:00 [WRN] The 'NotificationTypes' property 'Type' on entity type 'SystemNotification' is configured with a database-generated default, but has no configured sentinel value. The database-generated default will always be used for inserts when the property has the value '0', since this is the CLR default for the 'NotificationTypes' type. Consider using a nullable type, using a nullable backing field, or setting the sentinel value for the property to ensure the database default is used when, and only when, appropriate. See https://aka.ms/efcore-docs-default-values for more information.
+2025-08-12 10:23:50.117 +07:00 [WRN] The 'TopicStatus' property 'Status' on entity type 'TopicVersion' is configured with a database-generated default, but has no configured sentinel value. The database-generated default will always be used for inserts when the property has the value '0', since this is the CLR default for the 'TopicStatus' type. Consider using a nullable type, using a nullable backing field, or setting the sentinel value for the property to ensure the database default is used when, and only when, appropriate. See https://aka.ms/efcore-docs-default-values for more information.
+2025-08-12 10:23:50.212 +07:00 [DBG] Entity Framework Core 8.0.16 initialized 'MyDbContext' using provider 'Microsoft.EntityFrameworkCore.SqlServer:8.0.13' with options: MigrationsAssembly=App.DAL 
+2025-08-12 10:23:50.267 +07:00 [DBG] Compiling query expression: 
+'DbSet<Role>()
+    .FirstOrDefault(r => r.NormalizedName == __normalizedName_0)'
+2025-08-12 10:23:50.366 +07:00 [DBG] Generated query execution expression: 
+'queryContext => ShapedQueryCompilingExpressionVisitor.SingleOrDefaultAsync<Role>(
+    asyncEnumerable: new SingleQueryingEnumerable<Role>(
+        (RelationalQueryContext)queryContext, 
+        RelationalCommandCache.QueryExpression(
+            Projection Mapping:
+                EmptyProjectionMember -> Dictionary<IProperty, int> { [Property: Role.Id (int) Required PK AfterSave:Throw ValueGenerated.OnAdd, 0], [Property: Role.ConcurrencyStamp (string), 1], [Property: Role.IsAdmin (bool) Required, 2], [Property: Role.Name (string), 3], [Property: Role.NormalizedName (string), 4] }
+            SELECT TOP(1) r.Id, r.ConcurrencyStamp, r.IsAdmin, r.Name, r.NormalizedName
+            FROM roles AS r
+            WHERE r.NormalizedName == @__normalizedName_0), 
+        null, 
+        Func<QueryContext, DbDataReader, ResultContext, SingleQueryResultCoordinator, Role>, 
+        App.DAL.Context.MyDbContext, 
+        False, 
+        False, 
+        True
+    ), 
+    cancellationToken: queryContext.CancellationToken)'
+2025-08-12 10:23:50.391 +07:00 [DBG] Creating DbConnection.
+2025-08-12 10:23:50.402 +07:00 [DBG] Created DbConnection. (9ms).
+2025-08-12 10:23:50.405 +07:00 [DBG] Opening connection to database 'capbot_db' on server 'localhost'.
+2025-08-12 10:23:50.598 +07:00 [DBG] Opened connection to database 'capbot_db' on server 'localhost'.
+2025-08-12 10:23:50.600 +07:00 [DBG] Creating DbCommand for 'ExecuteReader'.
+2025-08-12 10:23:50.604 +07:00 [DBG] Created DbCommand for 'ExecuteReader' (2ms).
+2025-08-12 10:23:50.609 +07:00 [DBG] Initialized DbCommand for 'ExecuteReader' (8ms).
+2025-08-12 10:23:50.613 +07:00 [DBG] Executing DbCommand [Parameters=[@__normalizedName_0='?' (Size = 4000)], CommandType='"Text"', CommandTimeout='30']
+SELECT TOP(1) [r].[Id], [r].[ConcurrencyStamp], [r].[IsAdmin], [r].[Name], [r].[NormalizedName]
+FROM [roles] AS [r]
+WHERE [r].[NormalizedName] = @__normalizedName_0
+2025-08-12 10:23:50.663 +07:00 [INF] Executed DbCommand (46ms) [Parameters=[@__normalizedName_0='?' (Size = 4000)], CommandType='"Text"', CommandTimeout='30']
+SELECT TOP(1) [r].[Id], [r].[ConcurrencyStamp], [r].[IsAdmin], [r].[Name], [r].[NormalizedName]
+FROM [roles] AS [r]
+WHERE [r].[NormalizedName] = @__normalizedName_0
+2025-08-12 10:23:50.689 +07:00 [DBG] Context 'MyDbContext' started tracking 'Role' entity. Consider using 'DbContextOptionsBuilder.EnableSensitiveDataLogging' to see key values.
+2025-08-12 10:23:50.704 +07:00 [DBG] Closing data reader to 'capbot_db' on server 'localhost'.
+2025-08-12 10:23:50.708 +07:00 [DBG] A data reader for 'capbot_db' on server 'localhost' is being disposed after spending 41ms reading results.
+2025-08-12 10:23:50.710 +07:00 [DBG] Closing connection to database 'capbot_db' on server 'localhost'.
+2025-08-12 10:23:50.714 +07:00 [DBG] Closed connection to database 'capbot_db' on server 'localhost' (3ms).
+2025-08-12 10:23:50.718 +07:00 [DBG] Opening connection to database 'capbot_db' on server 'localhost'.
+2025-08-12 10:23:50.719 +07:00 [DBG] Opened connection to database 'capbot_db' on server 'localhost'.
+2025-08-12 10:23:50.720 +07:00 [DBG] Creating DbCommand for 'ExecuteReader'.
+2025-08-12 10:23:50.720 +07:00 [DBG] Created DbCommand for 'ExecuteReader' (0ms).
+2025-08-12 10:23:50.720 +07:00 [DBG] Initialized DbCommand for 'ExecuteReader' (0ms).
+2025-08-12 10:23:50.720 +07:00 [DBG] Executing DbCommand [Parameters=[@__normalizedName_0='?' (Size = 4000)], CommandType='"Text"', CommandTimeout='30']
+SELECT TOP(1) [r].[Id], [r].[ConcurrencyStamp], [r].[IsAdmin], [r].[Name], [r].[NormalizedName]
+FROM [roles] AS [r]
+WHERE [r].[NormalizedName] = @__normalizedName_0
+2025-08-12 10:23:50.723 +07:00 [INF] Executed DbCommand (3ms) [Parameters=[@__normalizedName_0='?' (Size = 4000)], CommandType='"Text"', CommandTimeout='30']
+SELECT TOP(1) [r].[Id], [r].[ConcurrencyStamp], [r].[IsAdmin], [r].[Name], [r].[NormalizedName]
+FROM [roles] AS [r]
+WHERE [r].[NormalizedName] = @__normalizedName_0
+2025-08-12 10:23:50.724 +07:00 [DBG] Context 'MyDbContext' started tracking 'Role' entity. Consider using 'DbContextOptionsBuilder.EnableSensitiveDataLogging' to see key values.
+2025-08-12 10:23:50.724 +07:00 [DBG] Closing data reader to 'capbot_db' on server 'localhost'.
+2025-08-12 10:23:50.724 +07:00 [DBG] A data reader for 'capbot_db' on server 'localhost' is being disposed after spending 0ms reading results.
+2025-08-12 10:23:50.724 +07:00 [DBG] Closing connection to database 'capbot_db' on server 'localhost'.
+2025-08-12 10:23:50.725 +07:00 [DBG] Closed connection to database 'capbot_db' on server 'localhost' (0ms).
+2025-08-12 10:23:50.725 +07:00 [DBG] Opening connection to database 'capbot_db' on server 'localhost'.
+2025-08-12 10:23:50.725 +07:00 [DBG] Opened connection to database 'capbot_db' on server 'localhost'.
+2025-08-12 10:23:50.725 +07:00 [DBG] Creating DbCommand for 'ExecuteReader'.
+2025-08-12 10:23:50.726 +07:00 [DBG] Created DbCommand for 'ExecuteReader' (0ms).
+2025-08-12 10:23:50.726 +07:00 [DBG] Initialized DbCommand for 'ExecuteReader' (0ms).
+2025-08-12 10:23:50.726 +07:00 [DBG] Executing DbCommand [Parameters=[@__normalizedName_0='?' (Size = 4000)], CommandType='"Text"', CommandTimeout='30']
+SELECT TOP(1) [r].[Id], [r].[ConcurrencyStamp], [r].[IsAdmin], [r].[Name], [r].[NormalizedName]
+FROM [roles] AS [r]
+WHERE [r].[NormalizedName] = @__normalizedName_0
+2025-08-12 10:23:50.727 +07:00 [INF] Executed DbCommand (1ms) [Parameters=[@__normalizedName_0='?' (Size = 4000)], CommandType='"Text"', CommandTimeout='30']
+SELECT TOP(1) [r].[Id], [r].[ConcurrencyStamp], [r].[IsAdmin], [r].[Name], [r].[NormalizedName]
+FROM [roles] AS [r]
+WHERE [r].[NormalizedName] = @__normalizedName_0
+2025-08-12 10:23:50.727 +07:00 [DBG] Context 'MyDbContext' started tracking 'Role' entity. Consider using 'DbContextOptionsBuilder.EnableSensitiveDataLogging' to see key values.
+2025-08-12 10:23:50.727 +07:00 [DBG] Closing data reader to 'capbot_db' on server 'localhost'.
+2025-08-12 10:23:50.727 +07:00 [DBG] A data reader for 'capbot_db' on server 'localhost' is being disposed after spending 0ms reading results.
+2025-08-12 10:23:50.728 +07:00 [DBG] Closing connection to database 'capbot_db' on server 'localhost'.
+2025-08-12 10:23:50.728 +07:00 [DBG] Closed connection to database 'capbot_db' on server 'localhost' (0ms).
+2025-08-12 10:23:50.728 +07:00 [DBG] Opening connection to database 'capbot_db' on server 'localhost'.
+2025-08-12 10:23:50.728 +07:00 [DBG] Opened connection to database 'capbot_db' on server 'localhost'.
+2025-08-12 10:23:50.728 +07:00 [DBG] Creating DbCommand for 'ExecuteReader'.
+2025-08-12 10:23:50.728 +07:00 [DBG] Created DbCommand for 'ExecuteReader' (0ms).
+2025-08-12 10:23:50.728 +07:00 [DBG] Initialized DbCommand for 'ExecuteReader' (0ms).
+2025-08-12 10:23:50.728 +07:00 [DBG] Executing DbCommand [Parameters=[@__normalizedName_0='?' (Size = 4000)], CommandType='"Text"', CommandTimeout='30']
+SELECT TOP(1) [r].[Id], [r].[ConcurrencyStamp], [r].[IsAdmin], [r].[Name], [r].[NormalizedName]
+FROM [roles] AS [r]
+WHERE [r].[NormalizedName] = @__normalizedName_0
+2025-08-12 10:23:50.729 +07:00 [INF] Executed DbCommand (1ms) [Parameters=[@__normalizedName_0='?' (Size = 4000)], CommandType='"Text"', CommandTimeout='30']
+SELECT TOP(1) [r].[Id], [r].[ConcurrencyStamp], [r].[IsAdmin], [r].[Name], [r].[NormalizedName]
+FROM [roles] AS [r]
+WHERE [r].[NormalizedName] = @__normalizedName_0
+2025-08-12 10:23:50.730 +07:00 [DBG] Context 'MyDbContext' started tracking 'Role' entity. Consider using 'DbContextOptionsBuilder.EnableSensitiveDataLogging' to see key values.
+2025-08-12 10:23:50.730 +07:00 [DBG] Closing data reader to 'capbot_db' on server 'localhost'.
+2025-08-12 10:23:50.731 +07:00 [DBG] A data reader for 'capbot_db' on server 'localhost' is being disposed after spending 0ms reading results.
+2025-08-12 10:23:50.731 +07:00 [DBG] Closing connection to database 'capbot_db' on server 'localhost'.
+2025-08-12 10:23:50.732 +07:00 [DBG] Closed connection to database 'capbot_db' on server 'localhost' (0ms).
+2025-08-12 10:23:50.735 +07:00 [DBG] Compiling query expression: 
+'DbSet<User>()
+    .SingleOrDefault(u => u.NormalizedEmail == __normalizedEmail_0)'
+2025-08-12 10:23:50.741 +07:00 [DBG] Generated query execution expression: 
+'queryContext => ShapedQueryCompilingExpressionVisitor.SingleOrDefaultAsync<User>(
+    asyncEnumerable: new SingleQueryingEnumerable<User>(
+        (RelationalQueryContext)queryContext, 
+        RelationalCommandCache.QueryExpression(
+            Projection Mapping:
+                EmptyProjectionMember -> Dictionary<IProperty, int> { [Property: User.Id (int) Required PK AfterSave:Throw ValueGenerated.OnAdd, 0], [Property: User.AccessFailedCount (int) Required, 1], [Property: User.ConcurrencyStamp (string), 2], [Property: User.CreatedAt (DateTime) Required, 3], [Property: User.DeletedAt (DateTime?), 4], [Property: User.Email (string), 5], [Property: User.EmailConfirmed (bool) Required, 6], [Property: User.LastModifiedAt (DateTime) Required, 7], [Property: User.LastModifiedBy (string), 8], [Property: User.LockoutEnabled (bool) Required, 9], [Property: User.LockoutEnd (DateTimeOffset?), 10], [Property: User.NormalizedEmail (string), 11], [Property: User.NormalizedUserName (string), 12], [Property: User.PasswordHash (string), 13], [Property: User.PhoneNumber (string), 14], [Property: User.PhoneNumberConfirmed (bool) Required, 15], [Property: User.SecurityStamp (string), 16], [Property: User.TwoFactorEnabled (bool) Required, 17], [Property: User.UserName (string), 18] }
+            SELECT TOP(2) u.Id, u.AccessFailedCount, u.ConcurrencyStamp, u.CreatedAt, u.DeletedAt, u.Email, u.EmailConfirmed, u.LastModifiedAt, u.LastModifiedBy, u.LockoutEnabled, u.LockoutEnd, u.NormalizedEmail, u.NormalizedUserName, u.PasswordHash, u.PhoneNumber, u.PhoneNumberConfirmed, u.SecurityStamp, u.TwoFactorEnabled, u.UserName
+            FROM users AS u
+            WHERE u.NormalizedEmail == @__normalizedEmail_0), 
+        null, 
+        Func<QueryContext, DbDataReader, ResultContext, SingleQueryResultCoordinator, User>, 
+        App.DAL.Context.MyDbContext, 
+        False, 
+        False, 
+        True
+    ), 
+    cancellationToken: queryContext.CancellationToken)'
+2025-08-12 10:23:50.744 +07:00 [DBG] Opening connection to database 'capbot_db' on server 'localhost'.
+2025-08-12 10:23:50.744 +07:00 [DBG] Opened connection to database 'capbot_db' on server 'localhost'.
+2025-08-12 10:23:50.744 +07:00 [DBG] Creating DbCommand for 'ExecuteReader'.
+2025-08-12 10:23:50.744 +07:00 [DBG] Created DbCommand for 'ExecuteReader' (0ms).
+2025-08-12 10:23:50.745 +07:00 [DBG] Initialized DbCommand for 'ExecuteReader' (0ms).
+2025-08-12 10:23:50.745 +07:00 [DBG] Executing DbCommand [Parameters=[@__normalizedEmail_0='?' (Size = 4000)], CommandType='"Text"', CommandTimeout='30']
+SELECT TOP(2) [u].[Id], [u].[AccessFailedCount], [u].[ConcurrencyStamp], [u].[CreatedAt], [u].[DeletedAt], [u].[Email], [u].[EmailConfirmed], [u].[LastModifiedAt], [u].[LastModifiedBy], [u].[LockoutEnabled], [u].[LockoutEnd], [u].[NormalizedEmail], [u].[NormalizedUserName], [u].[PasswordHash], [u].[PhoneNumber], [u].[PhoneNumberConfirmed], [u].[SecurityStamp], [u].[TwoFactorEnabled], [u].[UserName]
+FROM [users] AS [u]
+WHERE [u].[NormalizedEmail] = @__normalizedEmail_0
+2025-08-12 10:23:50.751 +07:00 [INF] Executed DbCommand (6ms) [Parameters=[@__normalizedEmail_0='?' (Size = 4000)], CommandType='"Text"', CommandTimeout='30']
+SELECT TOP(2) [u].[Id], [u].[AccessFailedCount], [u].[ConcurrencyStamp], [u].[CreatedAt], [u].[DeletedAt], [u].[Email], [u].[EmailConfirmed], [u].[LastModifiedAt], [u].[LastModifiedBy], [u].[LockoutEnabled], [u].[LockoutEnd], [u].[NormalizedEmail], [u].[NormalizedUserName], [u].[PasswordHash], [u].[PhoneNumber], [u].[PhoneNumberConfirmed], [u].[SecurityStamp], [u].[TwoFactorEnabled], [u].[UserName]
+FROM [users] AS [u]
+WHERE [u].[NormalizedEmail] = @__normalizedEmail_0
+2025-08-12 10:23:50.768 +07:00 [DBG] Context 'MyDbContext' started tracking 'User' entity. Consider using 'DbContextOptionsBuilder.EnableSensitiveDataLogging' to see key values.
+2025-08-12 10:23:50.787 +07:00 [DBG] Closing data reader to 'capbot_db' on server 'localhost'.
+2025-08-12 10:23:50.787 +07:00 [DBG] A data reader for 'capbot_db' on server 'localhost' is being disposed after spending 35ms reading results.
+2025-08-12 10:23:50.788 +07:00 [DBG] Closing connection to database 'capbot_db' on server 'localhost'.
+2025-08-12 10:23:50.788 +07:00 [DBG] Closed connection to database 'capbot_db' on server 'localhost' (0ms).
+2025-08-12 10:23:50.790 +07:00 [INF] Admin user 'fptslayer@gmail.com' already exists
+2025-08-12 10:23:50.792 +07:00 [DBG] Opening connection to database 'capbot_db' on server 'localhost'.
+2025-08-12 10:23:50.793 +07:00 [DBG] Opened connection to database 'capbot_db' on server 'localhost'.
+2025-08-12 10:23:50.793 +07:00 [DBG] Creating DbCommand for 'ExecuteReader'.
+2025-08-12 10:23:50.793 +07:00 [DBG] Created DbCommand for 'ExecuteReader' (0ms).
+2025-08-12 10:23:50.793 +07:00 [DBG] Initialized DbCommand for 'ExecuteReader' (0ms).
+2025-08-12 10:23:50.794 +07:00 [DBG] Executing DbCommand [Parameters=[@__normalizedEmail_0='?' (Size = 4000)], CommandType='"Text"', CommandTimeout='30']
+SELECT TOP(2) [u].[Id], [u].[AccessFailedCount], [u].[ConcurrencyStamp], [u].[CreatedAt], [u].[DeletedAt], [u].[Email], [u].[EmailConfirmed], [u].[LastModifiedAt], [u].[LastModifiedBy], [u].[LockoutEnabled], [u].[LockoutEnd], [u].[NormalizedEmail], [u].[NormalizedUserName], [u].[PasswordHash], [u].[PhoneNumber], [u].[PhoneNumberConfirmed], [u].[SecurityStamp], [u].[TwoFactorEnabled], [u].[UserName]
+FROM [users] AS [u]
+WHERE [u].[NormalizedEmail] = @__normalizedEmail_0
+2025-08-12 10:23:50.796 +07:00 [INF] Executed DbCommand (2ms) [Parameters=[@__normalizedEmail_0='?' (Size = 4000)], CommandType='"Text"', CommandTimeout='30']
+SELECT TOP(2) [u].[Id], [u].[AccessFailedCount], [u].[ConcurrencyStamp], [u].[CreatedAt], [u].[DeletedAt], [u].[Email], [u].[EmailConfirmed], [u].[LastModifiedAt], [u].[LastModifiedBy], [u].[LockoutEnabled], [u].[LockoutEnd], [u].[NormalizedEmail], [u].[NormalizedUserName], [u].[PasswordHash], [u].[PhoneNumber], [u].[PhoneNumberConfirmed], [u].[SecurityStamp], [u].[TwoFactorEnabled], [u].[UserName]
+FROM [users] AS [u]
+WHERE [u].[NormalizedEmail] = @__normalizedEmail_0
+2025-08-12 10:23:50.796 +07:00 [DBG] Context 'MyDbContext' started tracking 'User' entity. Consider using 'DbContextOptionsBuilder.EnableSensitiveDataLogging' to see key values.
+2025-08-12 10:23:50.796 +07:00 [DBG] Closing data reader to 'capbot_db' on server 'localhost'.
+2025-08-12 10:23:50.797 +07:00 [DBG] A data reader for 'capbot_db' on server 'localhost' is being disposed after spending 0ms reading results.
+2025-08-12 10:23:50.797 +07:00 [DBG] Closing connection to database 'capbot_db' on server 'localhost'.
+2025-08-12 10:23:50.797 +07:00 [DBG] Closed connection to database 'capbot_db' on server 'localhost' (0ms).
+2025-08-12 10:23:50.798 +07:00 [INF] Sample moderator 'moderator@example.com' already exists
+2025-08-12 10:23:50.798 +07:00 [DBG] Opening connection to database 'capbot_db' on server 'localhost'.
+2025-08-12 10:23:50.798 +07:00 [DBG] Opened connection to database 'capbot_db' on server 'localhost'.
+2025-08-12 10:23:50.798 +07:00 [DBG] Creating DbCommand for 'ExecuteReader'.
+2025-08-12 10:23:50.799 +07:00 [DBG] Created DbCommand for 'ExecuteReader' (0ms).
+2025-08-12 10:23:50.799 +07:00 [DBG] Initialized DbCommand for 'ExecuteReader' (0ms).
+2025-08-12 10:23:50.799 +07:00 [DBG] Executing DbCommand [Parameters=[@__normalizedEmail_0='?' (Size = 4000)], CommandType='"Text"', CommandTimeout='30']
+SELECT TOP(2) [u].[Id], [u].[AccessFailedCount], [u].[ConcurrencyStamp], [u].[CreatedAt], [u].[DeletedAt], [u].[Email], [u].[EmailConfirmed], [u].[LastModifiedAt], [u].[LastModifiedBy], [u].[LockoutEnabled], [u].[LockoutEnd], [u].[NormalizedEmail], [u].[NormalizedUserName], [u].[PasswordHash], [u].[PhoneNumber], [u].[PhoneNumberConfirmed], [u].[SecurityStamp], [u].[TwoFactorEnabled], [u].[UserName]
+FROM [users] AS [u]
+WHERE [u].[NormalizedEmail] = @__normalizedEmail_0
+2025-08-12 10:23:50.800 +07:00 [INF] Executed DbCommand (1ms) [Parameters=[@__normalizedEmail_0='?' (Size = 4000)], CommandType='"Text"', CommandTimeout='30']
+SELECT TOP(2) [u].[Id], [u].[AccessFailedCount], [u].[ConcurrencyStamp], [u].[CreatedAt], [u].[DeletedAt], [u].[Email], [u].[EmailConfirmed], [u].[LastModifiedAt], [u].[LastModifiedBy], [u].[LockoutEnabled], [u].[LockoutEnd], [u].[NormalizedEmail], [u].[NormalizedUserName], [u].[PasswordHash], [u].[PhoneNumber], [u].[PhoneNumberConfirmed], [u].[SecurityStamp], [u].[TwoFactorEnabled], [u].[UserName]
+FROM [users] AS [u]
+WHERE [u].[NormalizedEmail] = @__normalizedEmail_0
+2025-08-12 10:23:50.801 +07:00 [DBG] Context 'MyDbContext' started tracking 'User' entity. Consider using 'DbContextOptionsBuilder.EnableSensitiveDataLogging' to see key values.
+2025-08-12 10:23:50.801 +07:00 [DBG] Closing data reader to 'capbot_db' on server 'localhost'.
+2025-08-12 10:23:50.802 +07:00 [DBG] A data reader for 'capbot_db' on server 'localhost' is being disposed after spending 0ms reading results.
+2025-08-12 10:23:50.802 +07:00 [DBG] Closing connection to database 'capbot_db' on server 'localhost'.
+2025-08-12 10:23:50.802 +07:00 [DBG] Closed connection to database 'capbot_db' on server 'localhost' (0ms).
+2025-08-12 10:23:50.802 +07:00 [DBG] Opening connection to database 'capbot_db' on server 'localhost'.
+2025-08-12 10:23:50.802 +07:00 [DBG] Opened connection to database 'capbot_db' on server 'localhost'.
+2025-08-12 10:23:50.803 +07:00 [DBG] Creating DbCommand for 'ExecuteReader'.
+2025-08-12 10:23:50.803 +07:00 [DBG] Created DbCommand for 'ExecuteReader' (0ms).
+2025-08-12 10:23:50.803 +07:00 [DBG] Initialized DbCommand for 'ExecuteReader' (0ms).
+2025-08-12 10:23:50.803 +07:00 [DBG] Executing DbCommand [Parameters=[@__normalizedEmail_0='?' (Size = 4000)], CommandType='"Text"', CommandTimeout='30']
+SELECT TOP(2) [u].[Id], [u].[AccessFailedCount], [u].[ConcurrencyStamp], [u].[CreatedAt], [u].[DeletedAt], [u].[Email], [u].[EmailConfirmed], [u].[LastModifiedAt], [u].[LastModifiedBy], [u].[LockoutEnabled], [u].[LockoutEnd], [u].[NormalizedEmail], [u].[NormalizedUserName], [u].[PasswordHash], [u].[PhoneNumber], [u].[PhoneNumberConfirmed], [u].[SecurityStamp], [u].[TwoFactorEnabled], [u].[UserName]
+FROM [users] AS [u]
+WHERE [u].[NormalizedEmail] = @__normalizedEmail_0
+2025-08-12 10:23:50.804 +07:00 [INF] Executed DbCommand (1ms) [Parameters=[@__normalizedEmail_0='?' (Size = 4000)], CommandType='"Text"', CommandTimeout='30']
+SELECT TOP(2) [u].[Id], [u].[AccessFailedCount], [u].[ConcurrencyStamp], [u].[CreatedAt], [u].[DeletedAt], [u].[Email], [u].[EmailConfirmed], [u].[LastModifiedAt], [u].[LastModifiedBy], [u].[LockoutEnabled], [u].[LockoutEnd], [u].[NormalizedEmail], [u].[NormalizedUserName], [u].[PasswordHash], [u].[PhoneNumber], [u].[PhoneNumberConfirmed], [u].[SecurityStamp], [u].[TwoFactorEnabled], [u].[UserName]
+FROM [users] AS [u]
+WHERE [u].[NormalizedEmail] = @__normalizedEmail_0
+2025-08-12 10:23:50.804 +07:00 [DBG] Context 'MyDbContext' started tracking 'User' entity. Consider using 'DbContextOptionsBuilder.EnableSensitiveDataLogging' to see key values.
+2025-08-12 10:23:50.805 +07:00 [DBG] Closing data reader to 'capbot_db' on server 'localhost'.
+2025-08-12 10:23:50.805 +07:00 [DBG] A data reader for 'capbot_db' on server 'localhost' is being disposed after spending 0ms reading results.
+2025-08-12 10:23:50.805 +07:00 [DBG] Closing connection to database 'capbot_db' on server 'localhost'.
+2025-08-12 10:23:50.805 +07:00 [DBG] Closed connection to database 'capbot_db' on server 'localhost' (0ms).
+2025-08-12 10:23:50.805 +07:00 [INF] Data seeding completed successfully
+2025-08-12 10:23:50.806 +07:00 [DBG] 'MyDbContext' disposed.
+2025-08-12 10:23:50.808 +07:00 [DBG] Disposing connection to database 'capbot_db' on server 'localhost'.
+2025-08-12 10:23:50.809 +07:00 [DBG] Disposed connection to database '' on server '' (0ms).
+2025-08-12 10:23:50.958 +07:00 [DBG] Registered model binder providers, in the following order: ["Microsoft.AspNetCore.Mvc.ModelBinding.Binders.BinderTypeModelBinderProvider","Microsoft.AspNetCore.Mvc.ModelBinding.Binders.ServicesModelBinderProvider","Microsoft.AspNetCore.Mvc.ModelBinding.Binders.BodyModelBinderProvider","Microsoft.AspNetCore.Mvc.ModelBinding.Binders.HeaderModelBinderProvider","Microsoft.AspNetCore.Mvc.ModelBinding.Binders.FloatingPointTypeModelBinderProvider","Microsoft.AspNetCore.Mvc.ModelBinding.Binders.EnumTypeModelBinderProvider","Microsoft.AspNetCore.Mvc.ModelBinding.Binders.DateTimeModelBinderProvider","Microsoft.AspNetCore.Mvc.ModelBinding.Binders.SimpleTypeModelBinderProvider","Microsoft.AspNetCore.Mvc.ModelBinding.Binders.TryParseModelBinderProvider","Microsoft.AspNetCore.Mvc.ModelBinding.Binders.CancellationTokenModelBinderProvider"]
+2025-08-12 10:23:51.029 +07:00 [DBG] Hosting starting
+2025-08-12 10:23:51.035 +07:00 [DBG] Reading data from file 'C:\Users\Admin\AppData\Local\ASP.NET\DataProtection-Keys\key-1d6bcff1-a155-4167-8a22-de35a5f05047.xml'.
+2025-08-12 10:23:51.037 +07:00 [DBG] Reading data from file 'C:\Users\Admin\AppData\Local\ASP.NET\DataProtection-Keys\key-2459dd29-32d5-4c49-ac9d-33896047bb78.xml'.
+2025-08-12 10:23:51.038 +07:00 [DBG] Reading data from file 'C:\Users\Admin\AppData\Local\ASP.NET\DataProtection-Keys\key-374624f1-e856-4617-8ae6-fe6a81ce6346.xml'.
+2025-08-12 10:23:51.041 +07:00 [DBG] Found key {1d6bcff1-a155-4167-8a22-de35a5f05047}.
+2025-08-12 10:23:51.044 +07:00 [DBG] Found key {2459dd29-32d5-4c49-ac9d-33896047bb78}.
+2025-08-12 10:23:51.045 +07:00 [DBG] Found key {374624f1-e856-4617-8ae6-fe6a81ce6346}.
+2025-08-12 10:23:51.050 +07:00 [DBG] Considering key {2459dd29-32d5-4c49-ac9d-33896047bb78} with expiration date 2025-11-03 12:40:53Z as default key.
+2025-08-12 10:23:51.053 +07:00 [DBG] Forwarded activator type request from Microsoft.AspNetCore.DataProtection.XmlEncryption.DpapiXmlDecryptor, Microsoft.AspNetCore.DataProtection, Version=8.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60 to Microsoft.AspNetCore.DataProtection.XmlEncryption.DpapiXmlDecryptor, Microsoft.AspNetCore.DataProtection, Culture=neutral, PublicKeyToken=adb9793829ddae60
+2025-08-12 10:23:51.054 +07:00 [DBG] Decrypting secret element using Windows DPAPI.
+2025-08-12 10:23:51.055 +07:00 [DBG] Forwarded activator type request from Microsoft.AspNetCore.DataProtection.AuthenticatedEncryption.ConfigurationModel.AuthenticatedEncryptorDescriptorDeserializer, Microsoft.AspNetCore.DataProtection, Version=8.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60 to Microsoft.AspNetCore.DataProtection.AuthenticatedEncryption.ConfigurationModel.AuthenticatedEncryptorDescriptorDeserializer, Microsoft.AspNetCore.DataProtection, Culture=neutral, PublicKeyToken=adb9793829ddae60
+2025-08-12 10:23:51.057 +07:00 [DBG] Opening CNG algorithm 'AES' from provider 'null' with chaining mode CBC.
+2025-08-12 10:23:51.058 +07:00 [DBG] Opening CNG algorithm 'SHA256' from provider 'null' with HMAC.
+2025-08-12 10:23:51.059 +07:00 [DBG] Using key {2459dd29-32d5-4c49-ac9d-33896047bb78} as the default key.
+2025-08-12 10:23:51.060 +07:00 [DBG] Key ring with default key {2459dd29-32d5-4c49-ac9d-33896047bb78} was loaded during application startup.
+2025-08-12 10:23:51.161 +07:00 [INF] Now listening on: https://localhost:7190
+2025-08-12 10:23:51.162 +07:00 [DBG] Loaded hosting startup assembly CapBot.api
+2025-08-12 10:23:51.162 +07:00 [DBG] Loaded hosting startup assembly Microsoft.WebTools.ApiEndpointDiscovery
+2025-08-12 10:23:51.162 +07:00 [DBG] Loaded hosting startup assembly Microsoft.AspNetCore.Watch.BrowserRefresh
+2025-08-12 10:23:51.163 +07:00 [DBG] Loaded hosting startup assembly Microsoft.WebTools.BrowserLink.Net
+2025-08-12 10:23:51.215 +07:00 [INF] Application started. Press Ctrl+C to shut down.
+2025-08-12 10:23:51.215 +07:00 [INF] Hosting environment: Development
+2025-08-12 10:23:51.215 +07:00 [INF] Content root path: C:\Users\Admin\Downloads\CBAI_API\CapBot.api
+2025-08-12 10:23:51.216 +07:00 [DBG] Hosting started
+2025-08-12 10:23:51.496 +07:00 [DBG] Connection id "0HNEP9UKDJDQC" received FIN.
+2025-08-12 10:23:51.496 +07:00 [DBG] Connection id "0HNEP9UKDJDQD" received FIN.
+2025-08-12 10:23:51.507 +07:00 [DBG] Connection id "0HNEP9UKDJDQD" accepted.
+2025-08-12 10:23:51.507 +07:00 [DBG] Connection id "0HNEP9UKDJDQC" accepted.
+2025-08-12 10:23:51.509 +07:00 [DBG] Connection id "0HNEP9UKDJDQC" started.
+2025-08-12 10:23:51.509 +07:00 [DBG] Connection id "0HNEP9UKDJDQD" started.
+2025-08-12 10:23:51.532 +07:00 [DBG] Failed to authenticate HTTPS connection.
+System.IO.IOException: Received an unexpected EOF or 0 bytes from the transport stream.
+   at System.Net.Security.SslStream.ReceiveHandshakeFrameAsync[TIOAdapter](CancellationToken cancellationToken)
+   at System.Net.Security.SslStream.ForceAuthenticationAsync[TIOAdapter](Boolean receiveFirst, Byte[] reAuthenticationData, CancellationToken cancellationToken)
+   at System.Net.Security.SslStream.ProcessAuthenticationWithTelemetryAsync(Boolean isAsync, CancellationToken cancellationToken)
+   at Microsoft.AspNetCore.Server.Kestrel.Https.Internal.HttpsConnectionMiddleware.OnConnectionAsync(ConnectionContext context)
+2025-08-12 10:23:51.532 +07:00 [DBG] Failed to authenticate HTTPS connection.
+System.IO.IOException: Received an unexpected EOF or 0 bytes from the transport stream.
+   at System.Net.Security.SslStream.ReceiveHandshakeFrameAsync[TIOAdapter](CancellationToken cancellationToken)
+   at System.Net.Security.SslStream.ForceAuthenticationAsync[TIOAdapter](Boolean receiveFirst, Byte[] reAuthenticationData, CancellationToken cancellationToken)
+   at System.Net.Security.SslStream.ProcessAuthenticationWithTelemetryAsync(Boolean isAsync, CancellationToken cancellationToken)
+   at Microsoft.AspNetCore.Server.Kestrel.Https.Internal.HttpsConnectionMiddleware.OnConnectionAsync(ConnectionContext context)
+2025-08-12 10:23:51.542 +07:00 [DBG] Connection id "0HNEP9UKDJDQD" stopped.
+2025-08-12 10:23:51.542 +07:00 [DBG] Connection id "0HNEP9UKDJDQC" stopped.
+2025-08-12 10:23:51.551 +07:00 [DBG] Connection id "0HNEP9UKDJDQD" sending FIN because: "The Socket transport's send loop completed gracefully."
+2025-08-12 10:23:51.551 +07:00 [DBG] Connection id "0HNEP9UKDJDQC" sending FIN because: "The Socket transport's send loop completed gracefully."
+2025-08-12 10:23:51.605 +07:00 [DBG] Connection id "0HNEP9UKDJDQE" accepted.
+2025-08-12 10:23:51.606 +07:00 [DBG] Connection id "0HNEP9UKDJDQE" started.
+2025-08-12 10:23:51.682 +07:00 [DBG] Connection 0HNEP9UKDJDQE established using the following protocol: "Tls13"
+2025-08-12 10:23:51.735 +07:00 [INF] Request starting HTTP/2 GET https://localhost:7190/index.html - null null
+2025-08-12 10:23:51.769 +07:00 [DBG] Wildcard detected, all requests with hosts will be allowed.
+2025-08-12 10:23:51.797 +07:00 [DBG] Response markup is scheduled to include Browser Link script injection.
+2025-08-12 10:23:51.799 +07:00 [DBG] Response markup is scheduled to include browser refresh script injection.
+2025-08-12 10:23:51.822 +07:00 [DBG] Response markup was updated to include Browser Link script injection.
+2025-08-12 10:23:51.823 +07:00 [DBG] Response markup was updated to include browser refresh script injection.
+2025-08-12 10:23:51.828 +07:00 [INF] Request finished HTTP/2 GET https://localhost:7190/index.html - 200 null text/html;charset=utf-8 99.0508ms
+2025-08-12 10:23:51.838 +07:00 [INF] Request starting HTTP/2 GET https://localhost:7190/_vs/browserLink - null null
+2025-08-12 10:23:51.838 +07:00 [INF] Request starting HTTP/2 GET https://localhost:7190/_framework/aspnetcore-browser-refresh.js - null null
+2025-08-12 10:23:51.844 +07:00 [INF] Request finished HTTP/2 GET https://localhost:7190/_framework/aspnetcore-browser-refresh.js - 200 13756 application/javascript; charset=utf-8 6.5164ms
+2025-08-12 10:23:51.876 +07:00 [INF] Request finished HTTP/2 GET https://localhost:7190/_vs/browserLink - 200 null text/javascript; charset=UTF-8 38.3955ms
+2025-08-12 10:23:51.898 +07:00 [INF] Request starting HTTP/2 GET https://localhost:7190/swagger/v1/swagger.json - null null
+2025-08-12 10:23:51.926 +07:00 [INF] Request finished HTTP/2 GET https://localhost:7190/swagger/v1/swagger.json - 200 null application/json;charset=utf-8 28.5551ms
+2025-08-12 10:24:42.325 +07:00 [INF] Application is shutting down...
+2025-08-12 10:24:42.327 +07:00 [DBG] Hosting stopping
+2025-08-12 10:24:42.370 +07:00 [DBG] Connection id "0HNEP9UKDJDQE" is closing.
+2025-08-12 10:24:42.371 +07:00 [DBG] Connection id "0HNEP9UKDJDQE" is closed. The last processed stream ID was 7.
+2025-08-12 10:24:42.373 +07:00 [DBG] Connection id "0HNEP9UKDJDQE" received FIN.
+2025-08-12 10:24:42.378 +07:00 [DBG] Connection id "0HNEP9UKDJDQE" sending FIN because: "The Socket transport's send loop completed gracefully."
+2025-08-12 10:24:42.378 +07:00 [DBG] The connection queue processing loop for 0HNEP9UKDJDQE completed.
+2025-08-12 10:24:42.381 +07:00 [DBG] Connection id "0HNEP9UKDJDQE" stopped.
+2025-08-12 10:24:42.387 +07:00 [DBG] Hosting stopped

--- a/CapBot.api/Logs/log20250812.txt
+++ b/CapBot.api/Logs/log20250812.txt
@@ -926,3 +926,920 @@ System.IO.IOException: Received an unexpected EOF or 0 bytes from the transport 
 2025-08-12 10:24:42.378 +07:00 [DBG] The connection queue processing loop for 0HNEP9UKDJDQE completed.
 2025-08-12 10:24:42.381 +07:00 [DBG] Connection id "0HNEP9UKDJDQE" stopped.
 2025-08-12 10:24:42.387 +07:00 [DBG] Hosting stopped
+2025-08-12 11:08:24.128 +07:00 [DBG] An 'IServiceProvider' was created for internal use by Entity Framework.
+2025-08-12 11:08:24.203 +07:00 [INF] User profile is available. Using 'C:\Users\Admin\AppData\Local\ASP.NET\DataProtection-Keys' as key repository and Windows DPAPI to encrypt keys at rest.
+2025-08-12 11:08:24.362 +07:00 [DBG] No relationship from 'ReviewerAssignment' to 'User' has been configured by convention because there are multiple properties on one entity type - {'AssignedByUser', 'Reviewer'} that could be matched with the properties on the other entity type - {'ReviewerAssignments'}. This message can be disregarded if explicit configuration has been specified in 'OnModelCreating'.
+2025-08-12 11:08:24.374 +07:00 [DBG] No relationship from 'SubmissionWorkflowLog' to 'WorkflowState' has been configured by convention because there are multiple properties on one entity type - {'FromState', 'ToState'} that could be matched with the properties on the other entity type - {'FromStateLogs', 'ToStateLogs'}. This message can be disregarded if explicit configuration has been specified in 'OnModelCreating'.
+2025-08-12 11:08:24.384 +07:00 [DBG] No relationship from 'User' to 'ReviewerAssignment' has been configured by convention because there are multiple properties on one entity type - {'ReviewerAssignments'} that could be matched with the properties on the other entity type - {'AssignedByUser', 'Reviewer'}. This message can be disregarded if explicit configuration has been specified in 'OnModelCreating'.
+2025-08-12 11:08:24.385 +07:00 [DBG] No relationship from 'WorkflowState' to 'SubmissionWorkflowLog' has been configured by convention because there are multiple properties on one entity type - {'FromStateLogs', 'ToStateLogs'} that could be matched with the properties on the other entity type - {'FromState', 'ToState'}. This message can be disregarded if explicit configuration has been specified in 'OnModelCreating'.
+2025-08-12 11:08:24.386 +07:00 [DBG] No relationship from 'WorkflowState' to 'WorkflowTransition' has been configured by convention because there are multiple properties on one entity type - {'FromTransitions', 'ToTransitions'} that could be matched with the properties on the other entity type - {'FromState', 'ToState'}. This message can be disregarded if explicit configuration has been specified in 'OnModelCreating'.
+2025-08-12 11:08:24.387 +07:00 [DBG] No relationship from 'WorkflowTransition' to 'WorkflowState' has been configured by convention because there are multiple properties on one entity type - {'FromState', 'ToState'} that could be matched with the properties on the other entity type - {'FromTransitions', 'ToTransitions'}. This message can be disregarded if explicit configuration has been specified in 'OnModelCreating'.
+2025-08-12 11:08:24.514 +07:00 [DBG] No relationship from 'ReviewerAssignment' to 'User' has been configured by convention because there are multiple properties on one entity type - {'AssignedByUser', 'Reviewer'} that could be matched with the properties on the other entity type - {'ReviewerAssignments'}. This message can be disregarded if explicit configuration has been specified in 'OnModelCreating'.
+2025-08-12 11:08:24.516 +07:00 [DBG] No relationship from 'User' to 'ReviewerAssignment' has been configured by convention because there are multiple properties on one entity type - {'ReviewerAssignments'} that could be matched with the properties on the other entity type - {'AssignedByUser', 'Reviewer'}. This message can be disregarded if explicit configuration has been specified in 'OnModelCreating'.
+2025-08-12 11:08:24.529 +07:00 [DBG] No relationship from 'WorkflowTransition' to 'WorkflowState' has been configured by convention because there are multiple properties on one entity type - {'FromState', 'ToState'} that could be matched with the properties on the other entity type - {'FromTransitions', 'ToTransitions'}. This message can be disregarded if explicit configuration has been specified in 'OnModelCreating'.
+2025-08-12 11:08:24.530 +07:00 [DBG] No relationship from 'WorkflowState' to 'SubmissionWorkflowLog' has been configured by convention because there are multiple properties on one entity type - {'FromStateLogs', 'ToStateLogs'} that could be matched with the properties on the other entity type - {'FromState', 'ToState'}. This message can be disregarded if explicit configuration has been specified in 'OnModelCreating'.
+2025-08-12 11:08:24.531 +07:00 [DBG] No relationship from 'WorkflowState' to 'WorkflowTransition' has been configured by convention because there are multiple properties on one entity type - {'FromTransitions', 'ToTransitions'} that could be matched with the properties on the other entity type - {'FromState', 'ToState'}. This message can be disregarded if explicit configuration has been specified in 'OnModelCreating'.
+2025-08-12 11:08:24.532 +07:00 [DBG] No relationship from 'WorkflowState' to 'SubmissionWorkflowLog' has been configured by convention because there are multiple properties on one entity type - {'FromStateLogs', 'ToStateLogs'} that could be matched with the properties on the other entity type - {'FromState', 'ToState'}. This message can be disregarded if explicit configuration has been specified in 'OnModelCreating'.
+2025-08-12 11:08:24.536 +07:00 [DBG] No relationship from 'SubmissionWorkflowLog' to 'WorkflowState' has been configured by convention because there are multiple properties on one entity type - {'FromState', 'ToState'} that could be matched with the properties on the other entity type - {'FromStateLogs', 'ToStateLogs'}. This message can be disregarded if explicit configuration has been specified in 'OnModelCreating'.
+2025-08-12 11:08:24.537 +07:00 [DBG] No relationship from 'WorkflowState' to 'SubmissionWorkflowLog' has been configured by convention because there are multiple properties on one entity type - {'FromStateLogs', 'ToStateLogs'} that could be matched with the properties on the other entity type - {'FromState', 'ToState'}. This message can be disregarded if explicit configuration has been specified in 'OnModelCreating'.
+2025-08-12 11:08:24.557 +07:00 [DBG] The index {'LecturerId'} was not created on entity type 'LecturerSkill' as the properties are already covered by the index {'LecturerId', 'SkillTag'}.
+2025-08-12 11:08:24.557 +07:00 [DBG] The index {'SemesterId'} was not created on entity type 'Phase' as the properties are already covered by the index {'SemesterId', 'PhaseTypeId'}.
+2025-08-12 11:08:24.558 +07:00 [DBG] The index {'AssignmentId'} was not created on entity type 'Review' as the properties are already covered by the index {'AssignmentId', 'Status'}.
+2025-08-12 11:08:24.558 +07:00 [DBG] The index {'ReviewId'} was not created on entity type 'ReviewComment' as the properties are already covered by the index {'ReviewId', 'SectionName'}.
+2025-08-12 11:08:24.559 +07:00 [DBG] The index {'ReviewId'} was not created on entity type 'ReviewCriteriaScore' as the properties are already covered by the index {'ReviewId', 'CriteriaId'}.
+2025-08-12 11:08:24.559 +07:00 [DBG] The index {'ReviewerId'} was not created on entity type 'ReviewerAssignment' as the properties are already covered by the index {'ReviewerId', 'Status'}.
+2025-08-12 11:08:24.560 +07:00 [DBG] The index {'SubmissionId'} was not created on entity type 'ReviewerAssignment' as the properties are already covered by the index {'SubmissionId', 'ReviewerId'}.
+2025-08-12 11:08:24.560 +07:00 [DBG] The index {'ReviewerId'} was not created on entity type 'ReviewerPerformance' as the properties are already covered by the index {'ReviewerId', 'SemesterId'}.
+2025-08-12 11:08:24.560 +07:00 [DBG] The index {'PhaseId'} was not created on entity type 'Submission' as the properties are already covered by the index {'PhaseId', 'Status'}.
+2025-08-12 11:08:24.560 +07:00 [DBG] The index {'PhaseId'} was not created on entity type 'Submission' as the properties are already covered by the index {'PhaseId', 'Status', 'SubmittedAt'}.
+2025-08-12 11:08:24.560 +07:00 [DBG] The index {'TopicVersionId'} was not created on entity type 'Submission' as the properties are already covered by the index {'TopicVersionId', 'PhaseId', 'SubmissionRound'}.
+2025-08-12 11:08:24.561 +07:00 [DBG] The index {'SubmissionId'} was not created on entity type 'SubmissionWorkflowLog' as the properties are already covered by the index {'SubmissionId', 'CreatedAt'}.
+2025-08-12 11:08:24.561 +07:00 [DBG] The index {'UserId'} was not created on entity type 'SystemNotification' as the properties are already covered by the index {'UserId', 'IsRead', 'CreatedAt'}.
+2025-08-12 11:08:24.561 +07:00 [DBG] The index {'SemesterId'} was not created on entity type 'Topic' as the properties are already covered by the index {'SemesterId', 'IsApproved'}.
+2025-08-12 11:08:24.561 +07:00 [DBG] The index {'SupervisorId'} was not created on entity type 'Topic' as the properties are already covered by the index {'SupervisorId', 'SemesterId'}.
+2025-08-12 11:08:24.561 +07:00 [DBG] The index {'TopicId'} was not created on entity type 'TopicVersion' as the properties are already covered by the index {'TopicId', 'Status'}.
+2025-08-12 11:08:24.562 +07:00 [DBG] The index {'TopicId'} was not created on entity type 'TopicVersion' as the properties are already covered by the index {'TopicId', 'VersionNumber'}.
+2025-08-12 11:08:24.562 +07:00 [DBG] The index {'UserId'} was not created on entity type 'UserRole' as the properties are already covered by the index {'UserId', 'RoleId'}.
+2025-08-12 11:08:24.562 +07:00 [DBG] The index {'UserId'} was not created on entity type 'UserToken' as the properties are already covered by the index {'UserId', 'LoginProvider', 'Name'}.
+2025-08-12 11:08:24.655 +07:00 [WRN] The 'ProficiencyLevels' property 'ProficiencyLevel' on entity type 'LecturerSkill' is configured with a database-generated default, but has no configured sentinel value. The database-generated default will always be used for inserts when the property has the value '0', since this is the CLR default for the 'ProficiencyLevels' type. Consider using a nullable type, using a nullable backing field, or setting the sentinel value for the property to ensure the database default is used when, and only when, appropriate. See https://aka.ms/efcore-docs-default-values for more information.
+2025-08-12 11:08:24.655 +07:00 [WRN] The 'ReviewRecommendations' property 'Recommendation' on entity type 'Review' is configured with a database-generated default, but has no configured sentinel value. The database-generated default will always be used for inserts when the property has the value '0', since this is the CLR default for the 'ReviewRecommendations' type. Consider using a nullable type, using a nullable backing field, or setting the sentinel value for the property to ensure the database default is used when, and only when, appropriate. See https://aka.ms/efcore-docs-default-values for more information.
+2025-08-12 11:08:24.656 +07:00 [WRN] The 'ReviewStatus' property 'Status' on entity type 'Review' is configured with a database-generated default, but has no configured sentinel value. The database-generated default will always be used for inserts when the property has the value '0', since this is the CLR default for the 'ReviewStatus' type. Consider using a nullable type, using a nullable backing field, or setting the sentinel value for the property to ensure the database default is used when, and only when, appropriate. See https://aka.ms/efcore-docs-default-values for more information.
+2025-08-12 11:08:24.657 +07:00 [WRN] The 'CommentTypes' property 'CommentType' on entity type 'ReviewComment' is configured with a database-generated default, but has no configured sentinel value. The database-generated default will always be used for inserts when the property has the value '0', since this is the CLR default for the 'CommentTypes' type. Consider using a nullable type, using a nullable backing field, or setting the sentinel value for the property to ensure the database default is used when, and only when, appropriate. See https://aka.ms/efcore-docs-default-values for more information.
+2025-08-12 11:08:24.657 +07:00 [WRN] The 'PriorityLevels' property 'Priority' on entity type 'ReviewComment' is configured with a database-generated default, but has no configured sentinel value. The database-generated default will always be used for inserts when the property has the value '0', since this is the CLR default for the 'PriorityLevels' type. Consider using a nullable type, using a nullable backing field, or setting the sentinel value for the property to ensure the database default is used when, and only when, appropriate. See https://aka.ms/efcore-docs-default-values for more information.
+2025-08-12 11:08:24.658 +07:00 [WRN] The 'AssignmentTypes' property 'AssignmentType' on entity type 'ReviewerAssignment' is configured with a database-generated default, but has no configured sentinel value. The database-generated default will always be used for inserts when the property has the value '0', since this is the CLR default for the 'AssignmentTypes' type. Consider using a nullable type, using a nullable backing field, or setting the sentinel value for the property to ensure the database default is used when, and only when, appropriate. See https://aka.ms/efcore-docs-default-values for more information.
+2025-08-12 11:08:24.658 +07:00 [WRN] The 'AssignmentStatus' property 'Status' on entity type 'ReviewerAssignment' is configured with a database-generated default, but has no configured sentinel value. The database-generated default will always be used for inserts when the property has the value '0', since this is the CLR default for the 'AssignmentStatus' type. Consider using a nullable type, using a nullable backing field, or setting the sentinel value for the property to ensure the database default is used when, and only when, appropriate. See https://aka.ms/efcore-docs-default-values for more information.
+2025-08-12 11:08:24.658 +07:00 [WRN] The 'AiCheckStatus' property 'AiCheckStatus' on entity type 'Submission' is configured with a database-generated default, but has no configured sentinel value. The database-generated default will always be used for inserts when the property has the value '0', since this is the CLR default for the 'AiCheckStatus' type. Consider using a nullable type, using a nullable backing field, or setting the sentinel value for the property to ensure the database default is used when, and only when, appropriate. See https://aka.ms/efcore-docs-default-values for more information.
+2025-08-12 11:08:24.659 +07:00 [WRN] The 'SubmissionStatus' property 'Status' on entity type 'Submission' is configured with a database-generated default, but has no configured sentinel value. The database-generated default will always be used for inserts when the property has the value '0', since this is the CLR default for the 'SubmissionStatus' type. Consider using a nullable type, using a nullable backing field, or setting the sentinel value for the property to ensure the database default is used when, and only when, appropriate. See https://aka.ms/efcore-docs-default-values for more information.
+2025-08-12 11:08:24.659 +07:00 [WRN] The 'NotificationTypes' property 'Type' on entity type 'SystemNotification' is configured with a database-generated default, but has no configured sentinel value. The database-generated default will always be used for inserts when the property has the value '0', since this is the CLR default for the 'NotificationTypes' type. Consider using a nullable type, using a nullable backing field, or setting the sentinel value for the property to ensure the database default is used when, and only when, appropriate. See https://aka.ms/efcore-docs-default-values for more information.
+2025-08-12 11:08:24.659 +07:00 [WRN] The 'TopicStatus' property 'Status' on entity type 'TopicVersion' is configured with a database-generated default, but has no configured sentinel value. The database-generated default will always be used for inserts when the property has the value '0', since this is the CLR default for the 'TopicStatus' type. Consider using a nullable type, using a nullable backing field, or setting the sentinel value for the property to ensure the database default is used when, and only when, appropriate. See https://aka.ms/efcore-docs-default-values for more information.
+2025-08-12 11:08:24.773 +07:00 [DBG] Entity Framework Core 8.0.16 initialized 'MyDbContext' using provider 'Microsoft.EntityFrameworkCore.SqlServer:8.0.13' with options: MigrationsAssembly=App.DAL 
+2025-08-12 11:08:24.825 +07:00 [DBG] Compiling query expression: 
+'DbSet<Role>()
+    .FirstOrDefault(r => r.NormalizedName == __normalizedName_0)'
+2025-08-12 11:08:24.931 +07:00 [DBG] Generated query execution expression: 
+'queryContext => ShapedQueryCompilingExpressionVisitor.SingleOrDefaultAsync<Role>(
+    asyncEnumerable: new SingleQueryingEnumerable<Role>(
+        (RelationalQueryContext)queryContext, 
+        RelationalCommandCache.QueryExpression(
+            Projection Mapping:
+                EmptyProjectionMember -> Dictionary<IProperty, int> { [Property: Role.Id (int) Required PK AfterSave:Throw ValueGenerated.OnAdd, 0], [Property: Role.ConcurrencyStamp (string), 1], [Property: Role.IsAdmin (bool) Required, 2], [Property: Role.Name (string), 3], [Property: Role.NormalizedName (string), 4] }
+            SELECT TOP(1) r.Id, r.ConcurrencyStamp, r.IsAdmin, r.Name, r.NormalizedName
+            FROM roles AS r
+            WHERE r.NormalizedName == @__normalizedName_0), 
+        null, 
+        Func<QueryContext, DbDataReader, ResultContext, SingleQueryResultCoordinator, Role>, 
+        App.DAL.Context.MyDbContext, 
+        False, 
+        False, 
+        True
+    ), 
+    cancellationToken: queryContext.CancellationToken)'
+2025-08-12 11:08:24.956 +07:00 [DBG] Creating DbConnection.
+2025-08-12 11:08:24.967 +07:00 [DBG] Created DbConnection. (10ms).
+2025-08-12 11:08:24.970 +07:00 [DBG] Opening connection to database 'capbot_db' on server 'localhost'.
+2025-08-12 11:08:25.194 +07:00 [DBG] Opened connection to database 'capbot_db' on server 'localhost'.
+2025-08-12 11:08:25.196 +07:00 [DBG] Creating DbCommand for 'ExecuteReader'.
+2025-08-12 11:08:25.200 +07:00 [DBG] Created DbCommand for 'ExecuteReader' (2ms).
+2025-08-12 11:08:25.206 +07:00 [DBG] Initialized DbCommand for 'ExecuteReader' (9ms).
+2025-08-12 11:08:25.211 +07:00 [DBG] Executing DbCommand [Parameters=[@__normalizedName_0='?' (Size = 4000)], CommandType='"Text"', CommandTimeout='30']
+SELECT TOP(1) [r].[Id], [r].[ConcurrencyStamp], [r].[IsAdmin], [r].[Name], [r].[NormalizedName]
+FROM [roles] AS [r]
+WHERE [r].[NormalizedName] = @__normalizedName_0
+2025-08-12 11:08:25.262 +07:00 [INF] Executed DbCommand (51ms) [Parameters=[@__normalizedName_0='?' (Size = 4000)], CommandType='"Text"', CommandTimeout='30']
+SELECT TOP(1) [r].[Id], [r].[ConcurrencyStamp], [r].[IsAdmin], [r].[Name], [r].[NormalizedName]
+FROM [roles] AS [r]
+WHERE [r].[NormalizedName] = @__normalizedName_0
+2025-08-12 11:08:25.293 +07:00 [DBG] Context 'MyDbContext' started tracking 'Role' entity. Consider using 'DbContextOptionsBuilder.EnableSensitiveDataLogging' to see key values.
+2025-08-12 11:08:25.308 +07:00 [DBG] Closing data reader to 'capbot_db' on server 'localhost'.
+2025-08-12 11:08:25.313 +07:00 [DBG] A data reader for 'capbot_db' on server 'localhost' is being disposed after spending 47ms reading results.
+2025-08-12 11:08:25.316 +07:00 [DBG] Closing connection to database 'capbot_db' on server 'localhost'.
+2025-08-12 11:08:25.319 +07:00 [DBG] Closed connection to database 'capbot_db' on server 'localhost' (3ms).
+2025-08-12 11:08:25.322 +07:00 [DBG] Opening connection to database 'capbot_db' on server 'localhost'.
+2025-08-12 11:08:25.323 +07:00 [DBG] Opened connection to database 'capbot_db' on server 'localhost'.
+2025-08-12 11:08:25.323 +07:00 [DBG] Creating DbCommand for 'ExecuteReader'.
+2025-08-12 11:08:25.324 +07:00 [DBG] Created DbCommand for 'ExecuteReader' (0ms).
+2025-08-12 11:08:25.324 +07:00 [DBG] Initialized DbCommand for 'ExecuteReader' (0ms).
+2025-08-12 11:08:25.324 +07:00 [DBG] Executing DbCommand [Parameters=[@__normalizedName_0='?' (Size = 4000)], CommandType='"Text"', CommandTimeout='30']
+SELECT TOP(1) [r].[Id], [r].[ConcurrencyStamp], [r].[IsAdmin], [r].[Name], [r].[NormalizedName]
+FROM [roles] AS [r]
+WHERE [r].[NormalizedName] = @__normalizedName_0
+2025-08-12 11:08:25.332 +07:00 [INF] Executed DbCommand (8ms) [Parameters=[@__normalizedName_0='?' (Size = 4000)], CommandType='"Text"', CommandTimeout='30']
+SELECT TOP(1) [r].[Id], [r].[ConcurrencyStamp], [r].[IsAdmin], [r].[Name], [r].[NormalizedName]
+FROM [roles] AS [r]
+WHERE [r].[NormalizedName] = @__normalizedName_0
+2025-08-12 11:08:25.333 +07:00 [DBG] Context 'MyDbContext' started tracking 'Role' entity. Consider using 'DbContextOptionsBuilder.EnableSensitiveDataLogging' to see key values.
+2025-08-12 11:08:25.333 +07:00 [DBG] Closing data reader to 'capbot_db' on server 'localhost'.
+2025-08-12 11:08:25.333 +07:00 [DBG] A data reader for 'capbot_db' on server 'localhost' is being disposed after spending 0ms reading results.
+2025-08-12 11:08:25.334 +07:00 [DBG] Closing connection to database 'capbot_db' on server 'localhost'.
+2025-08-12 11:08:25.334 +07:00 [DBG] Closed connection to database 'capbot_db' on server 'localhost' (0ms).
+2025-08-12 11:08:25.335 +07:00 [DBG] Opening connection to database 'capbot_db' on server 'localhost'.
+2025-08-12 11:08:25.335 +07:00 [DBG] Opened connection to database 'capbot_db' on server 'localhost'.
+2025-08-12 11:08:25.335 +07:00 [DBG] Creating DbCommand for 'ExecuteReader'.
+2025-08-12 11:08:25.335 +07:00 [DBG] Created DbCommand for 'ExecuteReader' (0ms).
+2025-08-12 11:08:25.336 +07:00 [DBG] Initialized DbCommand for 'ExecuteReader' (0ms).
+2025-08-12 11:08:25.336 +07:00 [DBG] Executing DbCommand [Parameters=[@__normalizedName_0='?' (Size = 4000)], CommandType='"Text"', CommandTimeout='30']
+SELECT TOP(1) [r].[Id], [r].[ConcurrencyStamp], [r].[IsAdmin], [r].[Name], [r].[NormalizedName]
+FROM [roles] AS [r]
+WHERE [r].[NormalizedName] = @__normalizedName_0
+2025-08-12 11:08:25.339 +07:00 [INF] Executed DbCommand (4ms) [Parameters=[@__normalizedName_0='?' (Size = 4000)], CommandType='"Text"', CommandTimeout='30']
+SELECT TOP(1) [r].[Id], [r].[ConcurrencyStamp], [r].[IsAdmin], [r].[Name], [r].[NormalizedName]
+FROM [roles] AS [r]
+WHERE [r].[NormalizedName] = @__normalizedName_0
+2025-08-12 11:08:25.340 +07:00 [DBG] Context 'MyDbContext' started tracking 'Role' entity. Consider using 'DbContextOptionsBuilder.EnableSensitiveDataLogging' to see key values.
+2025-08-12 11:08:25.340 +07:00 [DBG] Closing data reader to 'capbot_db' on server 'localhost'.
+2025-08-12 11:08:25.340 +07:00 [DBG] A data reader for 'capbot_db' on server 'localhost' is being disposed after spending 0ms reading results.
+2025-08-12 11:08:25.341 +07:00 [DBG] Closing connection to database 'capbot_db' on server 'localhost'.
+2025-08-12 11:08:25.341 +07:00 [DBG] Closed connection to database 'capbot_db' on server 'localhost' (0ms).
+2025-08-12 11:08:25.342 +07:00 [DBG] Opening connection to database 'capbot_db' on server 'localhost'.
+2025-08-12 11:08:25.342 +07:00 [DBG] Opened connection to database 'capbot_db' on server 'localhost'.
+2025-08-12 11:08:25.342 +07:00 [DBG] Creating DbCommand for 'ExecuteReader'.
+2025-08-12 11:08:25.342 +07:00 [DBG] Created DbCommand for 'ExecuteReader' (0ms).
+2025-08-12 11:08:25.343 +07:00 [DBG] Initialized DbCommand for 'ExecuteReader' (0ms).
+2025-08-12 11:08:25.343 +07:00 [DBG] Executing DbCommand [Parameters=[@__normalizedName_0='?' (Size = 4000)], CommandType='"Text"', CommandTimeout='30']
+SELECT TOP(1) [r].[Id], [r].[ConcurrencyStamp], [r].[IsAdmin], [r].[Name], [r].[NormalizedName]
+FROM [roles] AS [r]
+WHERE [r].[NormalizedName] = @__normalizedName_0
+2025-08-12 11:08:25.346 +07:00 [INF] Executed DbCommand (3ms) [Parameters=[@__normalizedName_0='?' (Size = 4000)], CommandType='"Text"', CommandTimeout='30']
+SELECT TOP(1) [r].[Id], [r].[ConcurrencyStamp], [r].[IsAdmin], [r].[Name], [r].[NormalizedName]
+FROM [roles] AS [r]
+WHERE [r].[NormalizedName] = @__normalizedName_0
+2025-08-12 11:08:25.346 +07:00 [DBG] Context 'MyDbContext' started tracking 'Role' entity. Consider using 'DbContextOptionsBuilder.EnableSensitiveDataLogging' to see key values.
+2025-08-12 11:08:25.347 +07:00 [DBG] Closing data reader to 'capbot_db' on server 'localhost'.
+2025-08-12 11:08:25.347 +07:00 [DBG] A data reader for 'capbot_db' on server 'localhost' is being disposed after spending 0ms reading results.
+2025-08-12 11:08:25.347 +07:00 [DBG] Closing connection to database 'capbot_db' on server 'localhost'.
+2025-08-12 11:08:25.348 +07:00 [DBG] Closed connection to database 'capbot_db' on server 'localhost' (0ms).
+2025-08-12 11:08:25.351 +07:00 [DBG] Compiling query expression: 
+'DbSet<User>()
+    .SingleOrDefault(u => u.NormalizedEmail == __normalizedEmail_0)'
+2025-08-12 11:08:25.356 +07:00 [DBG] Generated query execution expression: 
+'queryContext => ShapedQueryCompilingExpressionVisitor.SingleOrDefaultAsync<User>(
+    asyncEnumerable: new SingleQueryingEnumerable<User>(
+        (RelationalQueryContext)queryContext, 
+        RelationalCommandCache.QueryExpression(
+            Projection Mapping:
+                EmptyProjectionMember -> Dictionary<IProperty, int> { [Property: User.Id (int) Required PK AfterSave:Throw ValueGenerated.OnAdd, 0], [Property: User.AccessFailedCount (int) Required, 1], [Property: User.ConcurrencyStamp (string), 2], [Property: User.CreatedAt (DateTime) Required, 3], [Property: User.DeletedAt (DateTime?), 4], [Property: User.Email (string), 5], [Property: User.EmailConfirmed (bool) Required, 6], [Property: User.LastModifiedAt (DateTime) Required, 7], [Property: User.LastModifiedBy (string), 8], [Property: User.LockoutEnabled (bool) Required, 9], [Property: User.LockoutEnd (DateTimeOffset?), 10], [Property: User.NormalizedEmail (string), 11], [Property: User.NormalizedUserName (string), 12], [Property: User.PasswordHash (string), 13], [Property: User.PhoneNumber (string), 14], [Property: User.PhoneNumberConfirmed (bool) Required, 15], [Property: User.SecurityStamp (string), 16], [Property: User.TwoFactorEnabled (bool) Required, 17], [Property: User.UserName (string), 18] }
+            SELECT TOP(2) u.Id, u.AccessFailedCount, u.ConcurrencyStamp, u.CreatedAt, u.DeletedAt, u.Email, u.EmailConfirmed, u.LastModifiedAt, u.LastModifiedBy, u.LockoutEnabled, u.LockoutEnd, u.NormalizedEmail, u.NormalizedUserName, u.PasswordHash, u.PhoneNumber, u.PhoneNumberConfirmed, u.SecurityStamp, u.TwoFactorEnabled, u.UserName
+            FROM users AS u
+            WHERE u.NormalizedEmail == @__normalizedEmail_0), 
+        null, 
+        Func<QueryContext, DbDataReader, ResultContext, SingleQueryResultCoordinator, User>, 
+        App.DAL.Context.MyDbContext, 
+        False, 
+        False, 
+        True
+    ), 
+    cancellationToken: queryContext.CancellationToken)'
+2025-08-12 11:08:25.358 +07:00 [DBG] Opening connection to database 'capbot_db' on server 'localhost'.
+2025-08-12 11:08:25.358 +07:00 [DBG] Opened connection to database 'capbot_db' on server 'localhost'.
+2025-08-12 11:08:25.358 +07:00 [DBG] Creating DbCommand for 'ExecuteReader'.
+2025-08-12 11:08:25.359 +07:00 [DBG] Created DbCommand for 'ExecuteReader' (0ms).
+2025-08-12 11:08:25.359 +07:00 [DBG] Initialized DbCommand for 'ExecuteReader' (0ms).
+2025-08-12 11:08:25.359 +07:00 [DBG] Executing DbCommand [Parameters=[@__normalizedEmail_0='?' (Size = 4000)], CommandType='"Text"', CommandTimeout='30']
+SELECT TOP(2) [u].[Id], [u].[AccessFailedCount], [u].[ConcurrencyStamp], [u].[CreatedAt], [u].[DeletedAt], [u].[Email], [u].[EmailConfirmed], [u].[LastModifiedAt], [u].[LastModifiedBy], [u].[LockoutEnabled], [u].[LockoutEnd], [u].[NormalizedEmail], [u].[NormalizedUserName], [u].[PasswordHash], [u].[PhoneNumber], [u].[PhoneNumberConfirmed], [u].[SecurityStamp], [u].[TwoFactorEnabled], [u].[UserName]
+FROM [users] AS [u]
+WHERE [u].[NormalizedEmail] = @__normalizedEmail_0
+2025-08-12 11:08:25.364 +07:00 [INF] Executed DbCommand (5ms) [Parameters=[@__normalizedEmail_0='?' (Size = 4000)], CommandType='"Text"', CommandTimeout='30']
+SELECT TOP(2) [u].[Id], [u].[AccessFailedCount], [u].[ConcurrencyStamp], [u].[CreatedAt], [u].[DeletedAt], [u].[Email], [u].[EmailConfirmed], [u].[LastModifiedAt], [u].[LastModifiedBy], [u].[LockoutEnabled], [u].[LockoutEnd], [u].[NormalizedEmail], [u].[NormalizedUserName], [u].[PasswordHash], [u].[PhoneNumber], [u].[PhoneNumberConfirmed], [u].[SecurityStamp], [u].[TwoFactorEnabled], [u].[UserName]
+FROM [users] AS [u]
+WHERE [u].[NormalizedEmail] = @__normalizedEmail_0
+2025-08-12 11:08:25.384 +07:00 [DBG] Context 'MyDbContext' started tracking 'User' entity. Consider using 'DbContextOptionsBuilder.EnableSensitiveDataLogging' to see key values.
+2025-08-12 11:08:25.403 +07:00 [DBG] Closing data reader to 'capbot_db' on server 'localhost'.
+2025-08-12 11:08:25.404 +07:00 [DBG] A data reader for 'capbot_db' on server 'localhost' is being disposed after spending 38ms reading results.
+2025-08-12 11:08:25.404 +07:00 [DBG] Closing connection to database 'capbot_db' on server 'localhost'.
+2025-08-12 11:08:25.404 +07:00 [DBG] Closed connection to database 'capbot_db' on server 'localhost' (0ms).
+2025-08-12 11:08:25.406 +07:00 [INF] Admin user 'fptslayer@gmail.com' already exists
+2025-08-12 11:08:25.408 +07:00 [DBG] Opening connection to database 'capbot_db' on server 'localhost'.
+2025-08-12 11:08:25.408 +07:00 [DBG] Opened connection to database 'capbot_db' on server 'localhost'.
+2025-08-12 11:08:25.409 +07:00 [DBG] Creating DbCommand for 'ExecuteReader'.
+2025-08-12 11:08:25.409 +07:00 [DBG] Created DbCommand for 'ExecuteReader' (0ms).
+2025-08-12 11:08:25.409 +07:00 [DBG] Initialized DbCommand for 'ExecuteReader' (0ms).
+2025-08-12 11:08:25.409 +07:00 [DBG] Executing DbCommand [Parameters=[@__normalizedEmail_0='?' (Size = 4000)], CommandType='"Text"', CommandTimeout='30']
+SELECT TOP(2) [u].[Id], [u].[AccessFailedCount], [u].[ConcurrencyStamp], [u].[CreatedAt], [u].[DeletedAt], [u].[Email], [u].[EmailConfirmed], [u].[LastModifiedAt], [u].[LastModifiedBy], [u].[LockoutEnabled], [u].[LockoutEnd], [u].[NormalizedEmail], [u].[NormalizedUserName], [u].[PasswordHash], [u].[PhoneNumber], [u].[PhoneNumberConfirmed], [u].[SecurityStamp], [u].[TwoFactorEnabled], [u].[UserName]
+FROM [users] AS [u]
+WHERE [u].[NormalizedEmail] = @__normalizedEmail_0
+2025-08-12 11:08:25.411 +07:00 [INF] Executed DbCommand (2ms) [Parameters=[@__normalizedEmail_0='?' (Size = 4000)], CommandType='"Text"', CommandTimeout='30']
+SELECT TOP(2) [u].[Id], [u].[AccessFailedCount], [u].[ConcurrencyStamp], [u].[CreatedAt], [u].[DeletedAt], [u].[Email], [u].[EmailConfirmed], [u].[LastModifiedAt], [u].[LastModifiedBy], [u].[LockoutEnabled], [u].[LockoutEnd], [u].[NormalizedEmail], [u].[NormalizedUserName], [u].[PasswordHash], [u].[PhoneNumber], [u].[PhoneNumberConfirmed], [u].[SecurityStamp], [u].[TwoFactorEnabled], [u].[UserName]
+FROM [users] AS [u]
+WHERE [u].[NormalizedEmail] = @__normalizedEmail_0
+2025-08-12 11:08:25.412 +07:00 [DBG] Context 'MyDbContext' started tracking 'User' entity. Consider using 'DbContextOptionsBuilder.EnableSensitiveDataLogging' to see key values.
+2025-08-12 11:08:25.412 +07:00 [DBG] Closing data reader to 'capbot_db' on server 'localhost'.
+2025-08-12 11:08:25.412 +07:00 [DBG] A data reader for 'capbot_db' on server 'localhost' is being disposed after spending 0ms reading results.
+2025-08-12 11:08:25.412 +07:00 [DBG] Closing connection to database 'capbot_db' on server 'localhost'.
+2025-08-12 11:08:25.413 +07:00 [DBG] Closed connection to database 'capbot_db' on server 'localhost' (0ms).
+2025-08-12 11:08:25.413 +07:00 [INF] Sample moderator 'moderator@example.com' already exists
+2025-08-12 11:08:25.413 +07:00 [DBG] Opening connection to database 'capbot_db' on server 'localhost'.
+2025-08-12 11:08:25.413 +07:00 [DBG] Opened connection to database 'capbot_db' on server 'localhost'.
+2025-08-12 11:08:25.414 +07:00 [DBG] Creating DbCommand for 'ExecuteReader'.
+2025-08-12 11:08:25.414 +07:00 [DBG] Created DbCommand for 'ExecuteReader' (0ms).
+2025-08-12 11:08:25.414 +07:00 [DBG] Initialized DbCommand for 'ExecuteReader' (0ms).
+2025-08-12 11:08:25.414 +07:00 [DBG] Executing DbCommand [Parameters=[@__normalizedEmail_0='?' (Size = 4000)], CommandType='"Text"', CommandTimeout='30']
+SELECT TOP(2) [u].[Id], [u].[AccessFailedCount], [u].[ConcurrencyStamp], [u].[CreatedAt], [u].[DeletedAt], [u].[Email], [u].[EmailConfirmed], [u].[LastModifiedAt], [u].[LastModifiedBy], [u].[LockoutEnabled], [u].[LockoutEnd], [u].[NormalizedEmail], [u].[NormalizedUserName], [u].[PasswordHash], [u].[PhoneNumber], [u].[PhoneNumberConfirmed], [u].[SecurityStamp], [u].[TwoFactorEnabled], [u].[UserName]
+FROM [users] AS [u]
+WHERE [u].[NormalizedEmail] = @__normalizedEmail_0
+2025-08-12 11:08:25.415 +07:00 [INF] Executed DbCommand (1ms) [Parameters=[@__normalizedEmail_0='?' (Size = 4000)], CommandType='"Text"', CommandTimeout='30']
+SELECT TOP(2) [u].[Id], [u].[AccessFailedCount], [u].[ConcurrencyStamp], [u].[CreatedAt], [u].[DeletedAt], [u].[Email], [u].[EmailConfirmed], [u].[LastModifiedAt], [u].[LastModifiedBy], [u].[LockoutEnabled], [u].[LockoutEnd], [u].[NormalizedEmail], [u].[NormalizedUserName], [u].[PasswordHash], [u].[PhoneNumber], [u].[PhoneNumberConfirmed], [u].[SecurityStamp], [u].[TwoFactorEnabled], [u].[UserName]
+FROM [users] AS [u]
+WHERE [u].[NormalizedEmail] = @__normalizedEmail_0
+2025-08-12 11:08:25.415 +07:00 [DBG] Context 'MyDbContext' started tracking 'User' entity. Consider using 'DbContextOptionsBuilder.EnableSensitiveDataLogging' to see key values.
+2025-08-12 11:08:25.416 +07:00 [DBG] Closing data reader to 'capbot_db' on server 'localhost'.
+2025-08-12 11:08:25.416 +07:00 [DBG] A data reader for 'capbot_db' on server 'localhost' is being disposed after spending 0ms reading results.
+2025-08-12 11:08:25.416 +07:00 [DBG] Closing connection to database 'capbot_db' on server 'localhost'.
+2025-08-12 11:08:25.416 +07:00 [DBG] Closed connection to database 'capbot_db' on server 'localhost' (0ms).
+2025-08-12 11:08:25.416 +07:00 [DBG] Opening connection to database 'capbot_db' on server 'localhost'.
+2025-08-12 11:08:25.416 +07:00 [DBG] Opened connection to database 'capbot_db' on server 'localhost'.
+2025-08-12 11:08:25.417 +07:00 [DBG] Creating DbCommand for 'ExecuteReader'.
+2025-08-12 11:08:25.417 +07:00 [DBG] Created DbCommand for 'ExecuteReader' (0ms).
+2025-08-12 11:08:25.417 +07:00 [DBG] Initialized DbCommand for 'ExecuteReader' (0ms).
+2025-08-12 11:08:25.417 +07:00 [DBG] Executing DbCommand [Parameters=[@__normalizedEmail_0='?' (Size = 4000)], CommandType='"Text"', CommandTimeout='30']
+SELECT TOP(2) [u].[Id], [u].[AccessFailedCount], [u].[ConcurrencyStamp], [u].[CreatedAt], [u].[DeletedAt], [u].[Email], [u].[EmailConfirmed], [u].[LastModifiedAt], [u].[LastModifiedBy], [u].[LockoutEnabled], [u].[LockoutEnd], [u].[NormalizedEmail], [u].[NormalizedUserName], [u].[PasswordHash], [u].[PhoneNumber], [u].[PhoneNumberConfirmed], [u].[SecurityStamp], [u].[TwoFactorEnabled], [u].[UserName]
+FROM [users] AS [u]
+WHERE [u].[NormalizedEmail] = @__normalizedEmail_0
+2025-08-12 11:08:25.418 +07:00 [INF] Executed DbCommand (1ms) [Parameters=[@__normalizedEmail_0='?' (Size = 4000)], CommandType='"Text"', CommandTimeout='30']
+SELECT TOP(2) [u].[Id], [u].[AccessFailedCount], [u].[ConcurrencyStamp], [u].[CreatedAt], [u].[DeletedAt], [u].[Email], [u].[EmailConfirmed], [u].[LastModifiedAt], [u].[LastModifiedBy], [u].[LockoutEnabled], [u].[LockoutEnd], [u].[NormalizedEmail], [u].[NormalizedUserName], [u].[PasswordHash], [u].[PhoneNumber], [u].[PhoneNumberConfirmed], [u].[SecurityStamp], [u].[TwoFactorEnabled], [u].[UserName]
+FROM [users] AS [u]
+WHERE [u].[NormalizedEmail] = @__normalizedEmail_0
+2025-08-12 11:08:25.418 +07:00 [DBG] Context 'MyDbContext' started tracking 'User' entity. Consider using 'DbContextOptionsBuilder.EnableSensitiveDataLogging' to see key values.
+2025-08-12 11:08:25.418 +07:00 [DBG] Closing data reader to 'capbot_db' on server 'localhost'.
+2025-08-12 11:08:25.419 +07:00 [DBG] A data reader for 'capbot_db' on server 'localhost' is being disposed after spending 0ms reading results.
+2025-08-12 11:08:25.419 +07:00 [DBG] Closing connection to database 'capbot_db' on server 'localhost'.
+2025-08-12 11:08:25.419 +07:00 [DBG] Closed connection to database 'capbot_db' on server 'localhost' (0ms).
+2025-08-12 11:08:25.419 +07:00 [INF] Data seeding completed successfully
+2025-08-12 11:08:25.420 +07:00 [DBG] 'MyDbContext' disposed.
+2025-08-12 11:08:25.422 +07:00 [DBG] Disposing connection to database 'capbot_db' on server 'localhost'.
+2025-08-12 11:08:25.422 +07:00 [DBG] Disposed connection to database '' on server '' (0ms).
+2025-08-12 11:08:25.564 +07:00 [DBG] Registered model binder providers, in the following order: ["Microsoft.AspNetCore.Mvc.ModelBinding.Binders.BinderTypeModelBinderProvider","Microsoft.AspNetCore.Mvc.ModelBinding.Binders.ServicesModelBinderProvider","Microsoft.AspNetCore.Mvc.ModelBinding.Binders.BodyModelBinderProvider","Microsoft.AspNetCore.Mvc.ModelBinding.Binders.HeaderModelBinderProvider","Microsoft.AspNetCore.Mvc.ModelBinding.Binders.FloatingPointTypeModelBinderProvider","Microsoft.AspNetCore.Mvc.ModelBinding.Binders.EnumTypeModelBinderProvider","Microsoft.AspNetCore.Mvc.ModelBinding.Binders.DateTimeModelBinderProvider","Microsoft.AspNetCore.Mvc.ModelBinding.Binders.SimpleTypeModelBinderProvider","Microsoft.AspNetCore.Mvc.ModelBinding.Binders.TryParseModelBinderProvider","Microsoft.AspNetCore.Mvc.ModelBinding.Binders.CancellationTokenModelBinderProvider"]
+2025-08-12 11:08:25.636 +07:00 [DBG] Hosting starting
+2025-08-12 11:08:25.641 +07:00 [DBG] Reading data from file 'C:\Users\Admin\AppData\Local\ASP.NET\DataProtection-Keys\key-1d6bcff1-a155-4167-8a22-de35a5f05047.xml'.
+2025-08-12 11:08:25.643 +07:00 [DBG] Reading data from file 'C:\Users\Admin\AppData\Local\ASP.NET\DataProtection-Keys\key-2459dd29-32d5-4c49-ac9d-33896047bb78.xml'.
+2025-08-12 11:08:25.644 +07:00 [DBG] Reading data from file 'C:\Users\Admin\AppData\Local\ASP.NET\DataProtection-Keys\key-374624f1-e856-4617-8ae6-fe6a81ce6346.xml'.
+2025-08-12 11:08:25.646 +07:00 [DBG] Found key {1d6bcff1-a155-4167-8a22-de35a5f05047}.
+2025-08-12 11:08:25.649 +07:00 [DBG] Found key {2459dd29-32d5-4c49-ac9d-33896047bb78}.
+2025-08-12 11:08:25.650 +07:00 [DBG] Found key {374624f1-e856-4617-8ae6-fe6a81ce6346}.
+2025-08-12 11:08:25.654 +07:00 [DBG] Considering key {2459dd29-32d5-4c49-ac9d-33896047bb78} with expiration date 2025-11-03 12:40:53Z as default key.
+2025-08-12 11:08:25.656 +07:00 [DBG] Forwarded activator type request from Microsoft.AspNetCore.DataProtection.XmlEncryption.DpapiXmlDecryptor, Microsoft.AspNetCore.DataProtection, Version=8.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60 to Microsoft.AspNetCore.DataProtection.XmlEncryption.DpapiXmlDecryptor, Microsoft.AspNetCore.DataProtection, Culture=neutral, PublicKeyToken=adb9793829ddae60
+2025-08-12 11:08:25.657 +07:00 [DBG] Decrypting secret element using Windows DPAPI.
+2025-08-12 11:08:25.658 +07:00 [DBG] Forwarded activator type request from Microsoft.AspNetCore.DataProtection.AuthenticatedEncryption.ConfigurationModel.AuthenticatedEncryptorDescriptorDeserializer, Microsoft.AspNetCore.DataProtection, Version=8.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60 to Microsoft.AspNetCore.DataProtection.AuthenticatedEncryption.ConfigurationModel.AuthenticatedEncryptorDescriptorDeserializer, Microsoft.AspNetCore.DataProtection, Culture=neutral, PublicKeyToken=adb9793829ddae60
+2025-08-12 11:08:25.659 +07:00 [DBG] Opening CNG algorithm 'AES' from provider 'null' with chaining mode CBC.
+2025-08-12 11:08:25.661 +07:00 [DBG] Opening CNG algorithm 'SHA256' from provider 'null' with HMAC.
+2025-08-12 11:08:25.662 +07:00 [DBG] Using key {2459dd29-32d5-4c49-ac9d-33896047bb78} as the default key.
+2025-08-12 11:08:25.663 +07:00 [DBG] Key ring with default key {2459dd29-32d5-4c49-ac9d-33896047bb78} was loaded during application startup.
+2025-08-12 11:08:25.772 +07:00 [INF] Now listening on: https://localhost:7190
+2025-08-12 11:08:25.772 +07:00 [DBG] Loaded hosting startup assembly CapBot.api
+2025-08-12 11:08:25.772 +07:00 [DBG] Loaded hosting startup assembly Microsoft.WebTools.ApiEndpointDiscovery
+2025-08-12 11:08:25.773 +07:00 [DBG] Loaded hosting startup assembly Microsoft.AspNetCore.Watch.BrowserRefresh
+2025-08-12 11:08:25.773 +07:00 [DBG] Loaded hosting startup assembly Microsoft.WebTools.BrowserLink.Net
+2025-08-12 11:08:25.824 +07:00 [DBG] Connection id "0HNEPANHDVDK1" accepted.
+2025-08-12 11:08:25.825 +07:00 [DBG] Connection id "0HNEPANHDVDK1" started.
+2025-08-12 11:08:25.832 +07:00 [DBG] Connection id "0HNEPANHDVDK2" accepted.
+2025-08-12 11:08:25.832 +07:00 [DBG] Connection id "0HNEPANHDVDK2" started.
+2025-08-12 11:08:25.843 +07:00 [INF] Application started. Press Ctrl+C to shut down.
+2025-08-12 11:08:25.843 +07:00 [INF] Hosting environment: Development
+2025-08-12 11:08:25.844 +07:00 [INF] Content root path: C:\Users\Admin\Downloads\CBAI_API\CapBot.api
+2025-08-12 11:08:25.844 +07:00 [DBG] Hosting started
+2025-08-12 11:08:25.865 +07:00 [DBG] Connection id "0HNEPANHDVDK2" received FIN.
+2025-08-12 11:08:25.865 +07:00 [DBG] Connection id "0HNEPANHDVDK1" received FIN.
+2025-08-12 11:08:25.884 +07:00 [DBG] Failed to authenticate HTTPS connection.
+System.IO.IOException: Received an unexpected EOF or 0 bytes from the transport stream.
+   at System.Net.Security.SslStream.ReceiveHandshakeFrameAsync[TIOAdapter](CancellationToken cancellationToken)
+   at System.Net.Security.SslStream.ForceAuthenticationAsync[TIOAdapter](Boolean receiveFirst, Byte[] reAuthenticationData, CancellationToken cancellationToken)
+   at System.Net.Security.SslStream.ProcessAuthenticationWithTelemetryAsync(Boolean isAsync, CancellationToken cancellationToken)
+   at Microsoft.AspNetCore.Server.Kestrel.Https.Internal.HttpsConnectionMiddleware.OnConnectionAsync(ConnectionContext context)
+2025-08-12 11:08:25.884 +07:00 [DBG] Failed to authenticate HTTPS connection.
+System.IO.IOException: Received an unexpected EOF or 0 bytes from the transport stream.
+   at System.Net.Security.SslStream.ReceiveHandshakeFrameAsync[TIOAdapter](CancellationToken cancellationToken)
+   at System.Net.Security.SslStream.ForceAuthenticationAsync[TIOAdapter](Boolean receiveFirst, Byte[] reAuthenticationData, CancellationToken cancellationToken)
+   at System.Net.Security.SslStream.ProcessAuthenticationWithTelemetryAsync(Boolean isAsync, CancellationToken cancellationToken)
+   at Microsoft.AspNetCore.Server.Kestrel.Https.Internal.HttpsConnectionMiddleware.OnConnectionAsync(ConnectionContext context)
+2025-08-12 11:08:25.900 +07:00 [DBG] Connection id "0HNEPANHDVDK1" stopped.
+2025-08-12 11:08:25.900 +07:00 [DBG] Connection id "0HNEPANHDVDK2" stopped.
+2025-08-12 11:08:25.903 +07:00 [DBG] Connection id "0HNEPANHDVDK1" sending FIN because: "The Socket transport's send loop completed gracefully."
+2025-08-12 11:08:25.903 +07:00 [DBG] Connection id "0HNEPANHDVDK2" sending FIN because: "The Socket transport's send loop completed gracefully."
+2025-08-12 11:08:25.976 +07:00 [DBG] Connection id "0HNEPANHDVDK3" accepted.
+2025-08-12 11:08:25.977 +07:00 [DBG] Connection id "0HNEPANHDVDK3" started.
+2025-08-12 11:08:26.061 +07:00 [DBG] Connection 0HNEPANHDVDK3 established using the following protocol: "Tls13"
+2025-08-12 11:08:26.122 +07:00 [INF] Request starting HTTP/2 GET https://localhost:7190/index.html - null null
+2025-08-12 11:08:26.161 +07:00 [DBG] Wildcard detected, all requests with hosts will be allowed.
+2025-08-12 11:08:26.191 +07:00 [DBG] Response markup is scheduled to include Browser Link script injection.
+2025-08-12 11:08:26.193 +07:00 [DBG] Response markup is scheduled to include browser refresh script injection.
+2025-08-12 11:08:26.210 +07:00 [DBG] Response markup was updated to include Browser Link script injection.
+2025-08-12 11:08:26.211 +07:00 [DBG] Response markup was updated to include browser refresh script injection.
+2025-08-12 11:08:26.214 +07:00 [INF] Request finished HTTP/2 GET https://localhost:7190/index.html - 200 null text/html;charset=utf-8 95.8861ms
+2025-08-12 11:08:26.222 +07:00 [INF] Request starting HTTP/2 GET https://localhost:7190/_vs/browserLink - null null
+2025-08-12 11:08:26.222 +07:00 [INF] Request starting HTTP/2 GET https://localhost:7190/_framework/aspnetcore-browser-refresh.js - null null
+2025-08-12 11:08:26.229 +07:00 [INF] Request finished HTTP/2 GET https://localhost:7190/_framework/aspnetcore-browser-refresh.js - 200 13756 application/javascript; charset=utf-8 7.5734ms
+2025-08-12 11:08:26.264 +07:00 [INF] Request finished HTTP/2 GET https://localhost:7190/_vs/browserLink - 200 null text/javascript; charset=UTF-8 42.8526ms
+2025-08-12 11:08:26.286 +07:00 [INF] Request starting HTTP/2 GET https://localhost:7190/swagger/v1/swagger.json - null null
+2025-08-12 11:08:26.323 +07:00 [INF] Request finished HTTP/2 GET https://localhost:7190/swagger/v1/swagger.json - 200 null application/json;charset=utf-8 36.6602ms
+2025-08-12 11:08:31.955 +07:00 [INF] Application is shutting down...
+2025-08-12 11:08:31.957 +07:00 [DBG] Hosting stopping
+2025-08-12 11:08:31.999 +07:00 [DBG] Connection id "0HNEPANHDVDK3" is closing.
+2025-08-12 11:08:32.000 +07:00 [DBG] Connection id "0HNEPANHDVDK3" is closed. The last processed stream ID was 7.
+2025-08-12 11:08:32.004 +07:00 [DBG] Connection id "0HNEPANHDVDK3" received FIN.
+2025-08-12 11:08:32.006 +07:00 [DBG] Connection id "0HNEPANHDVDK3" sending FIN because: "The Socket transport's send loop completed gracefully."
+2025-08-12 11:08:32.013 +07:00 [DBG] The connection queue processing loop for 0HNEPANHDVDK3 completed.
+2025-08-12 11:08:32.016 +07:00 [DBG] Connection id "0HNEPANHDVDK3" stopped.
+2025-08-12 11:08:32.020 +07:00 [DBG] Hosting stopped
+2025-08-12 11:10:32.731 +07:00 [DBG] An 'IServiceProvider' was created for internal use by Entity Framework.
+2025-08-12 11:10:32.811 +07:00 [INF] User profile is available. Using 'C:\Users\Admin\AppData\Local\ASP.NET\DataProtection-Keys' as key repository and Windows DPAPI to encrypt keys at rest.
+2025-08-12 11:10:32.984 +07:00 [DBG] No relationship from 'ReviewerAssignment' to 'User' has been configured by convention because there are multiple properties on one entity type - {'AssignedByUser', 'Reviewer'} that could be matched with the properties on the other entity type - {'ReviewerAssignments'}. This message can be disregarded if explicit configuration has been specified in 'OnModelCreating'.
+2025-08-12 11:10:32.997 +07:00 [DBG] No relationship from 'SubmissionWorkflowLog' to 'WorkflowState' has been configured by convention because there are multiple properties on one entity type - {'FromState', 'ToState'} that could be matched with the properties on the other entity type - {'FromStateLogs', 'ToStateLogs'}. This message can be disregarded if explicit configuration has been specified in 'OnModelCreating'.
+2025-08-12 11:10:33.005 +07:00 [DBG] No relationship from 'User' to 'ReviewerAssignment' has been configured by convention because there are multiple properties on one entity type - {'ReviewerAssignments'} that could be matched with the properties on the other entity type - {'AssignedByUser', 'Reviewer'}. This message can be disregarded if explicit configuration has been specified in 'OnModelCreating'.
+2025-08-12 11:10:33.007 +07:00 [DBG] No relationship from 'WorkflowState' to 'SubmissionWorkflowLog' has been configured by convention because there are multiple properties on one entity type - {'FromStateLogs', 'ToStateLogs'} that could be matched with the properties on the other entity type - {'FromState', 'ToState'}. This message can be disregarded if explicit configuration has been specified in 'OnModelCreating'.
+2025-08-12 11:10:33.007 +07:00 [DBG] No relationship from 'WorkflowState' to 'WorkflowTransition' has been configured by convention because there are multiple properties on one entity type - {'FromTransitions', 'ToTransitions'} that could be matched with the properties on the other entity type - {'FromState', 'ToState'}. This message can be disregarded if explicit configuration has been specified in 'OnModelCreating'.
+2025-08-12 11:10:33.008 +07:00 [DBG] No relationship from 'WorkflowTransition' to 'WorkflowState' has been configured by convention because there are multiple properties on one entity type - {'FromState', 'ToState'} that could be matched with the properties on the other entity type - {'FromTransitions', 'ToTransitions'}. This message can be disregarded if explicit configuration has been specified in 'OnModelCreating'.
+2025-08-12 11:10:33.134 +07:00 [DBG] No relationship from 'ReviewerAssignment' to 'User' has been configured by convention because there are multiple properties on one entity type - {'AssignedByUser', 'Reviewer'} that could be matched with the properties on the other entity type - {'ReviewerAssignments'}. This message can be disregarded if explicit configuration has been specified in 'OnModelCreating'.
+2025-08-12 11:10:33.136 +07:00 [DBG] No relationship from 'User' to 'ReviewerAssignment' has been configured by convention because there are multiple properties on one entity type - {'ReviewerAssignments'} that could be matched with the properties on the other entity type - {'AssignedByUser', 'Reviewer'}. This message can be disregarded if explicit configuration has been specified in 'OnModelCreating'.
+2025-08-12 11:10:33.149 +07:00 [DBG] No relationship from 'WorkflowTransition' to 'WorkflowState' has been configured by convention because there are multiple properties on one entity type - {'FromState', 'ToState'} that could be matched with the properties on the other entity type - {'FromTransitions', 'ToTransitions'}. This message can be disregarded if explicit configuration has been specified in 'OnModelCreating'.
+2025-08-12 11:10:33.150 +07:00 [DBG] No relationship from 'WorkflowState' to 'SubmissionWorkflowLog' has been configured by convention because there are multiple properties on one entity type - {'FromStateLogs', 'ToStateLogs'} that could be matched with the properties on the other entity type - {'FromState', 'ToState'}. This message can be disregarded if explicit configuration has been specified in 'OnModelCreating'.
+2025-08-12 11:10:33.151 +07:00 [DBG] No relationship from 'WorkflowState' to 'WorkflowTransition' has been configured by convention because there are multiple properties on one entity type - {'FromTransitions', 'ToTransitions'} that could be matched with the properties on the other entity type - {'FromState', 'ToState'}. This message can be disregarded if explicit configuration has been specified in 'OnModelCreating'.
+2025-08-12 11:10:33.152 +07:00 [DBG] No relationship from 'WorkflowState' to 'SubmissionWorkflowLog' has been configured by convention because there are multiple properties on one entity type - {'FromStateLogs', 'ToStateLogs'} that could be matched with the properties on the other entity type - {'FromState', 'ToState'}. This message can be disregarded if explicit configuration has been specified in 'OnModelCreating'.
+2025-08-12 11:10:33.155 +07:00 [DBG] No relationship from 'SubmissionWorkflowLog' to 'WorkflowState' has been configured by convention because there are multiple properties on one entity type - {'FromState', 'ToState'} that could be matched with the properties on the other entity type - {'FromStateLogs', 'ToStateLogs'}. This message can be disregarded if explicit configuration has been specified in 'OnModelCreating'.
+2025-08-12 11:10:33.156 +07:00 [DBG] No relationship from 'WorkflowState' to 'SubmissionWorkflowLog' has been configured by convention because there are multiple properties on one entity type - {'FromStateLogs', 'ToStateLogs'} that could be matched with the properties on the other entity type - {'FromState', 'ToState'}. This message can be disregarded if explicit configuration has been specified in 'OnModelCreating'.
+2025-08-12 11:10:33.175 +07:00 [DBG] The index {'LecturerId'} was not created on entity type 'LecturerSkill' as the properties are already covered by the index {'LecturerId', 'SkillTag'}.
+2025-08-12 11:10:33.175 +07:00 [DBG] The index {'SemesterId'} was not created on entity type 'Phase' as the properties are already covered by the index {'SemesterId', 'PhaseTypeId'}.
+2025-08-12 11:10:33.176 +07:00 [DBG] The index {'AssignmentId'} was not created on entity type 'Review' as the properties are already covered by the index {'AssignmentId', 'Status'}.
+2025-08-12 11:10:33.176 +07:00 [DBG] The index {'ReviewId'} was not created on entity type 'ReviewComment' as the properties are already covered by the index {'ReviewId', 'SectionName'}.
+2025-08-12 11:10:33.176 +07:00 [DBG] The index {'ReviewId'} was not created on entity type 'ReviewCriteriaScore' as the properties are already covered by the index {'ReviewId', 'CriteriaId'}.
+2025-08-12 11:10:33.176 +07:00 [DBG] The index {'ReviewerId'} was not created on entity type 'ReviewerAssignment' as the properties are already covered by the index {'ReviewerId', 'Status'}.
+2025-08-12 11:10:33.176 +07:00 [DBG] The index {'SubmissionId'} was not created on entity type 'ReviewerAssignment' as the properties are already covered by the index {'SubmissionId', 'ReviewerId'}.
+2025-08-12 11:10:33.176 +07:00 [DBG] The index {'ReviewerId'} was not created on entity type 'ReviewerPerformance' as the properties are already covered by the index {'ReviewerId', 'SemesterId'}.
+2025-08-12 11:10:33.177 +07:00 [DBG] The index {'PhaseId'} was not created on entity type 'Submission' as the properties are already covered by the index {'PhaseId', 'Status'}.
+2025-08-12 11:10:33.177 +07:00 [DBG] The index {'PhaseId'} was not created on entity type 'Submission' as the properties are already covered by the index {'PhaseId', 'Status', 'SubmittedAt'}.
+2025-08-12 11:10:33.177 +07:00 [DBG] The index {'TopicVersionId'} was not created on entity type 'Submission' as the properties are already covered by the index {'TopicVersionId', 'PhaseId', 'SubmissionRound'}.
+2025-08-12 11:10:33.177 +07:00 [DBG] The index {'SubmissionId'} was not created on entity type 'SubmissionWorkflowLog' as the properties are already covered by the index {'SubmissionId', 'CreatedAt'}.
+2025-08-12 11:10:33.177 +07:00 [DBG] The index {'UserId'} was not created on entity type 'SystemNotification' as the properties are already covered by the index {'UserId', 'IsRead', 'CreatedAt'}.
+2025-08-12 11:10:33.177 +07:00 [DBG] The index {'SemesterId'} was not created on entity type 'Topic' as the properties are already covered by the index {'SemesterId', 'IsApproved'}.
+2025-08-12 11:10:33.177 +07:00 [DBG] The index {'SupervisorId'} was not created on entity type 'Topic' as the properties are already covered by the index {'SupervisorId', 'SemesterId'}.
+2025-08-12 11:10:33.177 +07:00 [DBG] The index {'TopicId'} was not created on entity type 'TopicVersion' as the properties are already covered by the index {'TopicId', 'Status'}.
+2025-08-12 11:10:33.177 +07:00 [DBG] The index {'TopicId'} was not created on entity type 'TopicVersion' as the properties are already covered by the index {'TopicId', 'VersionNumber'}.
+2025-08-12 11:10:33.178 +07:00 [DBG] The index {'UserId'} was not created on entity type 'UserRole' as the properties are already covered by the index {'UserId', 'RoleId'}.
+2025-08-12 11:10:33.178 +07:00 [DBG] The index {'UserId'} was not created on entity type 'UserToken' as the properties are already covered by the index {'UserId', 'LoginProvider', 'Name'}.
+2025-08-12 11:10:33.267 +07:00 [WRN] The 'ProficiencyLevels' property 'ProficiencyLevel' on entity type 'LecturerSkill' is configured with a database-generated default, but has no configured sentinel value. The database-generated default will always be used for inserts when the property has the value '0', since this is the CLR default for the 'ProficiencyLevels' type. Consider using a nullable type, using a nullable backing field, or setting the sentinel value for the property to ensure the database default is used when, and only when, appropriate. See https://aka.ms/efcore-docs-default-values for more information.
+2025-08-12 11:10:33.268 +07:00 [WRN] The 'ReviewRecommendations' property 'Recommendation' on entity type 'Review' is configured with a database-generated default, but has no configured sentinel value. The database-generated default will always be used for inserts when the property has the value '0', since this is the CLR default for the 'ReviewRecommendations' type. Consider using a nullable type, using a nullable backing field, or setting the sentinel value for the property to ensure the database default is used when, and only when, appropriate. See https://aka.ms/efcore-docs-default-values for more information.
+2025-08-12 11:10:33.269 +07:00 [WRN] The 'ReviewStatus' property 'Status' on entity type 'Review' is configured with a database-generated default, but has no configured sentinel value. The database-generated default will always be used for inserts when the property has the value '0', since this is the CLR default for the 'ReviewStatus' type. Consider using a nullable type, using a nullable backing field, or setting the sentinel value for the property to ensure the database default is used when, and only when, appropriate. See https://aka.ms/efcore-docs-default-values for more information.
+2025-08-12 11:10:33.269 +07:00 [WRN] The 'CommentTypes' property 'CommentType' on entity type 'ReviewComment' is configured with a database-generated default, but has no configured sentinel value. The database-generated default will always be used for inserts when the property has the value '0', since this is the CLR default for the 'CommentTypes' type. Consider using a nullable type, using a nullable backing field, or setting the sentinel value for the property to ensure the database default is used when, and only when, appropriate. See https://aka.ms/efcore-docs-default-values for more information.
+2025-08-12 11:10:33.270 +07:00 [WRN] The 'PriorityLevels' property 'Priority' on entity type 'ReviewComment' is configured with a database-generated default, but has no configured sentinel value. The database-generated default will always be used for inserts when the property has the value '0', since this is the CLR default for the 'PriorityLevels' type. Consider using a nullable type, using a nullable backing field, or setting the sentinel value for the property to ensure the database default is used when, and only when, appropriate. See https://aka.ms/efcore-docs-default-values for more information.
+2025-08-12 11:10:33.270 +07:00 [WRN] The 'AssignmentTypes' property 'AssignmentType' on entity type 'ReviewerAssignment' is configured with a database-generated default, but has no configured sentinel value. The database-generated default will always be used for inserts when the property has the value '0', since this is the CLR default for the 'AssignmentTypes' type. Consider using a nullable type, using a nullable backing field, or setting the sentinel value for the property to ensure the database default is used when, and only when, appropriate. See https://aka.ms/efcore-docs-default-values for more information.
+2025-08-12 11:10:33.270 +07:00 [WRN] The 'AssignmentStatus' property 'Status' on entity type 'ReviewerAssignment' is configured with a database-generated default, but has no configured sentinel value. The database-generated default will always be used for inserts when the property has the value '0', since this is the CLR default for the 'AssignmentStatus' type. Consider using a nullable type, using a nullable backing field, or setting the sentinel value for the property to ensure the database default is used when, and only when, appropriate. See https://aka.ms/efcore-docs-default-values for more information.
+2025-08-12 11:10:33.270 +07:00 [WRN] The 'AiCheckStatus' property 'AiCheckStatus' on entity type 'Submission' is configured with a database-generated default, but has no configured sentinel value. The database-generated default will always be used for inserts when the property has the value '0', since this is the CLR default for the 'AiCheckStatus' type. Consider using a nullable type, using a nullable backing field, or setting the sentinel value for the property to ensure the database default is used when, and only when, appropriate. See https://aka.ms/efcore-docs-default-values for more information.
+2025-08-12 11:10:33.271 +07:00 [WRN] The 'SubmissionStatus' property 'Status' on entity type 'Submission' is configured with a database-generated default, but has no configured sentinel value. The database-generated default will always be used for inserts when the property has the value '0', since this is the CLR default for the 'SubmissionStatus' type. Consider using a nullable type, using a nullable backing field, or setting the sentinel value for the property to ensure the database default is used when, and only when, appropriate. See https://aka.ms/efcore-docs-default-values for more information.
+2025-08-12 11:10:33.271 +07:00 [WRN] The 'NotificationTypes' property 'Type' on entity type 'SystemNotification' is configured with a database-generated default, but has no configured sentinel value. The database-generated default will always be used for inserts when the property has the value '0', since this is the CLR default for the 'NotificationTypes' type. Consider using a nullable type, using a nullable backing field, or setting the sentinel value for the property to ensure the database default is used when, and only when, appropriate. See https://aka.ms/efcore-docs-default-values for more information.
+2025-08-12 11:10:33.271 +07:00 [WRN] The 'TopicStatus' property 'Status' on entity type 'TopicVersion' is configured with a database-generated default, but has no configured sentinel value. The database-generated default will always be used for inserts when the property has the value '0', since this is the CLR default for the 'TopicStatus' type. Consider using a nullable type, using a nullable backing field, or setting the sentinel value for the property to ensure the database default is used when, and only when, appropriate. See https://aka.ms/efcore-docs-default-values for more information.
+2025-08-12 11:10:33.371 +07:00 [DBG] Entity Framework Core 8.0.16 initialized 'MyDbContext' using provider 'Microsoft.EntityFrameworkCore.SqlServer:8.0.13' with options: MigrationsAssembly=App.DAL 
+2025-08-12 11:10:33.451 +07:00 [DBG] Compiling query expression: 
+'DbSet<Role>()
+    .FirstOrDefault(r => r.NormalizedName == __normalizedName_0)'
+2025-08-12 11:10:33.550 +07:00 [DBG] Generated query execution expression: 
+'queryContext => ShapedQueryCompilingExpressionVisitor.SingleOrDefaultAsync<Role>(
+    asyncEnumerable: new SingleQueryingEnumerable<Role>(
+        (RelationalQueryContext)queryContext, 
+        RelationalCommandCache.QueryExpression(
+            Projection Mapping:
+                EmptyProjectionMember -> Dictionary<IProperty, int> { [Property: Role.Id (int) Required PK AfterSave:Throw ValueGenerated.OnAdd, 0], [Property: Role.ConcurrencyStamp (string), 1], [Property: Role.IsAdmin (bool) Required, 2], [Property: Role.Name (string), 3], [Property: Role.NormalizedName (string), 4] }
+            SELECT TOP(1) r.Id, r.ConcurrencyStamp, r.IsAdmin, r.Name, r.NormalizedName
+            FROM roles AS r
+            WHERE r.NormalizedName == @__normalizedName_0), 
+        null, 
+        Func<QueryContext, DbDataReader, ResultContext, SingleQueryResultCoordinator, Role>, 
+        App.DAL.Context.MyDbContext, 
+        False, 
+        False, 
+        True
+    ), 
+    cancellationToken: queryContext.CancellationToken)'
+2025-08-12 11:10:33.578 +07:00 [DBG] Creating DbConnection.
+2025-08-12 11:10:33.590 +07:00 [DBG] Created DbConnection. (10ms).
+2025-08-12 11:10:33.593 +07:00 [DBG] Opening connection to database 'capbot_db' on server 'localhost'.
+2025-08-12 11:10:33.792 +07:00 [DBG] Opened connection to database 'capbot_db' on server 'localhost'.
+2025-08-12 11:10:33.795 +07:00 [DBG] Creating DbCommand for 'ExecuteReader'.
+2025-08-12 11:10:33.799 +07:00 [DBG] Created DbCommand for 'ExecuteReader' (2ms).
+2025-08-12 11:10:33.803 +07:00 [DBG] Initialized DbCommand for 'ExecuteReader' (9ms).
+2025-08-12 11:10:33.808 +07:00 [DBG] Executing DbCommand [Parameters=[@__normalizedName_0='?' (Size = 4000)], CommandType='"Text"', CommandTimeout='30']
+SELECT TOP(1) [r].[Id], [r].[ConcurrencyStamp], [r].[IsAdmin], [r].[Name], [r].[NormalizedName]
+FROM [roles] AS [r]
+WHERE [r].[NormalizedName] = @__normalizedName_0
+2025-08-12 11:10:33.855 +07:00 [INF] Executed DbCommand (47ms) [Parameters=[@__normalizedName_0='?' (Size = 4000)], CommandType='"Text"', CommandTimeout='30']
+SELECT TOP(1) [r].[Id], [r].[ConcurrencyStamp], [r].[IsAdmin], [r].[Name], [r].[NormalizedName]
+FROM [roles] AS [r]
+WHERE [r].[NormalizedName] = @__normalizedName_0
+2025-08-12 11:10:33.882 +07:00 [DBG] Context 'MyDbContext' started tracking 'Role' entity. Consider using 'DbContextOptionsBuilder.EnableSensitiveDataLogging' to see key values.
+2025-08-12 11:10:33.898 +07:00 [DBG] Closing data reader to 'capbot_db' on server 'localhost'.
+2025-08-12 11:10:33.904 +07:00 [DBG] A data reader for 'capbot_db' on server 'localhost' is being disposed after spending 46ms reading results.
+2025-08-12 11:10:33.906 +07:00 [DBG] Closing connection to database 'capbot_db' on server 'localhost'.
+2025-08-12 11:10:33.910 +07:00 [DBG] Closed connection to database 'capbot_db' on server 'localhost' (3ms).
+2025-08-12 11:10:33.912 +07:00 [DBG] Opening connection to database 'capbot_db' on server 'localhost'.
+2025-08-12 11:10:33.913 +07:00 [DBG] Opened connection to database 'capbot_db' on server 'localhost'.
+2025-08-12 11:10:33.913 +07:00 [DBG] Creating DbCommand for 'ExecuteReader'.
+2025-08-12 11:10:33.914 +07:00 [DBG] Created DbCommand for 'ExecuteReader' (0ms).
+2025-08-12 11:10:33.914 +07:00 [DBG] Initialized DbCommand for 'ExecuteReader' (0ms).
+2025-08-12 11:10:33.915 +07:00 [DBG] Executing DbCommand [Parameters=[@__normalizedName_0='?' (Size = 4000)], CommandType='"Text"', CommandTimeout='30']
+SELECT TOP(1) [r].[Id], [r].[ConcurrencyStamp], [r].[IsAdmin], [r].[Name], [r].[NormalizedName]
+FROM [roles] AS [r]
+WHERE [r].[NormalizedName] = @__normalizedName_0
+2025-08-12 11:10:33.917 +07:00 [INF] Executed DbCommand (3ms) [Parameters=[@__normalizedName_0='?' (Size = 4000)], CommandType='"Text"', CommandTimeout='30']
+SELECT TOP(1) [r].[Id], [r].[ConcurrencyStamp], [r].[IsAdmin], [r].[Name], [r].[NormalizedName]
+FROM [roles] AS [r]
+WHERE [r].[NormalizedName] = @__normalizedName_0
+2025-08-12 11:10:33.918 +07:00 [DBG] Context 'MyDbContext' started tracking 'Role' entity. Consider using 'DbContextOptionsBuilder.EnableSensitiveDataLogging' to see key values.
+2025-08-12 11:10:33.919 +07:00 [DBG] Closing data reader to 'capbot_db' on server 'localhost'.
+2025-08-12 11:10:33.919 +07:00 [DBG] A data reader for 'capbot_db' on server 'localhost' is being disposed after spending 0ms reading results.
+2025-08-12 11:10:33.919 +07:00 [DBG] Closing connection to database 'capbot_db' on server 'localhost'.
+2025-08-12 11:10:33.919 +07:00 [DBG] Closed connection to database 'capbot_db' on server 'localhost' (0ms).
+2025-08-12 11:10:33.920 +07:00 [DBG] Opening connection to database 'capbot_db' on server 'localhost'.
+2025-08-12 11:10:33.920 +07:00 [DBG] Opened connection to database 'capbot_db' on server 'localhost'.
+2025-08-12 11:10:33.920 +07:00 [DBG] Creating DbCommand for 'ExecuteReader'.
+2025-08-12 11:10:33.920 +07:00 [DBG] Created DbCommand for 'ExecuteReader' (0ms).
+2025-08-12 11:10:33.920 +07:00 [DBG] Initialized DbCommand for 'ExecuteReader' (0ms).
+2025-08-12 11:10:33.920 +07:00 [DBG] Executing DbCommand [Parameters=[@__normalizedName_0='?' (Size = 4000)], CommandType='"Text"', CommandTimeout='30']
+SELECT TOP(1) [r].[Id], [r].[ConcurrencyStamp], [r].[IsAdmin], [r].[Name], [r].[NormalizedName]
+FROM [roles] AS [r]
+WHERE [r].[NormalizedName] = @__normalizedName_0
+2025-08-12 11:10:33.921 +07:00 [INF] Executed DbCommand (1ms) [Parameters=[@__normalizedName_0='?' (Size = 4000)], CommandType='"Text"', CommandTimeout='30']
+SELECT TOP(1) [r].[Id], [r].[ConcurrencyStamp], [r].[IsAdmin], [r].[Name], [r].[NormalizedName]
+FROM [roles] AS [r]
+WHERE [r].[NormalizedName] = @__normalizedName_0
+2025-08-12 11:10:33.922 +07:00 [DBG] Context 'MyDbContext' started tracking 'Role' entity. Consider using 'DbContextOptionsBuilder.EnableSensitiveDataLogging' to see key values.
+2025-08-12 11:10:33.923 +07:00 [DBG] Closing data reader to 'capbot_db' on server 'localhost'.
+2025-08-12 11:10:33.923 +07:00 [DBG] A data reader for 'capbot_db' on server 'localhost' is being disposed after spending 0ms reading results.
+2025-08-12 11:10:33.923 +07:00 [DBG] Closing connection to database 'capbot_db' on server 'localhost'.
+2025-08-12 11:10:33.923 +07:00 [DBG] Closed connection to database 'capbot_db' on server 'localhost' (0ms).
+2025-08-12 11:10:33.924 +07:00 [DBG] Opening connection to database 'capbot_db' on server 'localhost'.
+2025-08-12 11:10:33.924 +07:00 [DBG] Opened connection to database 'capbot_db' on server 'localhost'.
+2025-08-12 11:10:33.924 +07:00 [DBG] Creating DbCommand for 'ExecuteReader'.
+2025-08-12 11:10:33.924 +07:00 [DBG] Created DbCommand for 'ExecuteReader' (0ms).
+2025-08-12 11:10:33.924 +07:00 [DBG] Initialized DbCommand for 'ExecuteReader' (0ms).
+2025-08-12 11:10:33.924 +07:00 [DBG] Executing DbCommand [Parameters=[@__normalizedName_0='?' (Size = 4000)], CommandType='"Text"', CommandTimeout='30']
+SELECT TOP(1) [r].[Id], [r].[ConcurrencyStamp], [r].[IsAdmin], [r].[Name], [r].[NormalizedName]
+FROM [roles] AS [r]
+WHERE [r].[NormalizedName] = @__normalizedName_0
+2025-08-12 11:10:33.925 +07:00 [INF] Executed DbCommand (1ms) [Parameters=[@__normalizedName_0='?' (Size = 4000)], CommandType='"Text"', CommandTimeout='30']
+SELECT TOP(1) [r].[Id], [r].[ConcurrencyStamp], [r].[IsAdmin], [r].[Name], [r].[NormalizedName]
+FROM [roles] AS [r]
+WHERE [r].[NormalizedName] = @__normalizedName_0
+2025-08-12 11:10:33.926 +07:00 [DBG] Context 'MyDbContext' started tracking 'Role' entity. Consider using 'DbContextOptionsBuilder.EnableSensitiveDataLogging' to see key values.
+2025-08-12 11:10:33.926 +07:00 [DBG] Closing data reader to 'capbot_db' on server 'localhost'.
+2025-08-12 11:10:33.926 +07:00 [DBG] A data reader for 'capbot_db' on server 'localhost' is being disposed after spending 0ms reading results.
+2025-08-12 11:10:33.926 +07:00 [DBG] Closing connection to database 'capbot_db' on server 'localhost'.
+2025-08-12 11:10:33.927 +07:00 [DBG] Closed connection to database 'capbot_db' on server 'localhost' (0ms).
+2025-08-12 11:10:33.930 +07:00 [DBG] Compiling query expression: 
+'DbSet<User>()
+    .SingleOrDefault(u => u.NormalizedEmail == __normalizedEmail_0)'
+2025-08-12 11:10:33.934 +07:00 [DBG] Generated query execution expression: 
+'queryContext => ShapedQueryCompilingExpressionVisitor.SingleOrDefaultAsync<User>(
+    asyncEnumerable: new SingleQueryingEnumerable<User>(
+        (RelationalQueryContext)queryContext, 
+        RelationalCommandCache.QueryExpression(
+            Projection Mapping:
+                EmptyProjectionMember -> Dictionary<IProperty, int> { [Property: User.Id (int) Required PK AfterSave:Throw ValueGenerated.OnAdd, 0], [Property: User.AccessFailedCount (int) Required, 1], [Property: User.ConcurrencyStamp (string), 2], [Property: User.CreatedAt (DateTime) Required, 3], [Property: User.DeletedAt (DateTime?), 4], [Property: User.Email (string), 5], [Property: User.EmailConfirmed (bool) Required, 6], [Property: User.LastModifiedAt (DateTime) Required, 7], [Property: User.LastModifiedBy (string), 8], [Property: User.LockoutEnabled (bool) Required, 9], [Property: User.LockoutEnd (DateTimeOffset?), 10], [Property: User.NormalizedEmail (string), 11], [Property: User.NormalizedUserName (string), 12], [Property: User.PasswordHash (string), 13], [Property: User.PhoneNumber (string), 14], [Property: User.PhoneNumberConfirmed (bool) Required, 15], [Property: User.SecurityStamp (string), 16], [Property: User.TwoFactorEnabled (bool) Required, 17], [Property: User.UserName (string), 18] }
+            SELECT TOP(2) u.Id, u.AccessFailedCount, u.ConcurrencyStamp, u.CreatedAt, u.DeletedAt, u.Email, u.EmailConfirmed, u.LastModifiedAt, u.LastModifiedBy, u.LockoutEnabled, u.LockoutEnd, u.NormalizedEmail, u.NormalizedUserName, u.PasswordHash, u.PhoneNumber, u.PhoneNumberConfirmed, u.SecurityStamp, u.TwoFactorEnabled, u.UserName
+            FROM users AS u
+            WHERE u.NormalizedEmail == @__normalizedEmail_0), 
+        null, 
+        Func<QueryContext, DbDataReader, ResultContext, SingleQueryResultCoordinator, User>, 
+        App.DAL.Context.MyDbContext, 
+        False, 
+        False, 
+        True
+    ), 
+    cancellationToken: queryContext.CancellationToken)'
+2025-08-12 11:10:33.936 +07:00 [DBG] Opening connection to database 'capbot_db' on server 'localhost'.
+2025-08-12 11:10:33.937 +07:00 [DBG] Opened connection to database 'capbot_db' on server 'localhost'.
+2025-08-12 11:10:33.937 +07:00 [DBG] Creating DbCommand for 'ExecuteReader'.
+2025-08-12 11:10:33.937 +07:00 [DBG] Created DbCommand for 'ExecuteReader' (0ms).
+2025-08-12 11:10:33.937 +07:00 [DBG] Initialized DbCommand for 'ExecuteReader' (0ms).
+2025-08-12 11:10:33.938 +07:00 [DBG] Executing DbCommand [Parameters=[@__normalizedEmail_0='?' (Size = 4000)], CommandType='"Text"', CommandTimeout='30']
+SELECT TOP(2) [u].[Id], [u].[AccessFailedCount], [u].[ConcurrencyStamp], [u].[CreatedAt], [u].[DeletedAt], [u].[Email], [u].[EmailConfirmed], [u].[LastModifiedAt], [u].[LastModifiedBy], [u].[LockoutEnabled], [u].[LockoutEnd], [u].[NormalizedEmail], [u].[NormalizedUserName], [u].[PasswordHash], [u].[PhoneNumber], [u].[PhoneNumberConfirmed], [u].[SecurityStamp], [u].[TwoFactorEnabled], [u].[UserName]
+FROM [users] AS [u]
+WHERE [u].[NormalizedEmail] = @__normalizedEmail_0
+2025-08-12 11:10:33.945 +07:00 [INF] Executed DbCommand (7ms) [Parameters=[@__normalizedEmail_0='?' (Size = 4000)], CommandType='"Text"', CommandTimeout='30']
+SELECT TOP(2) [u].[Id], [u].[AccessFailedCount], [u].[ConcurrencyStamp], [u].[CreatedAt], [u].[DeletedAt], [u].[Email], [u].[EmailConfirmed], [u].[LastModifiedAt], [u].[LastModifiedBy], [u].[LockoutEnabled], [u].[LockoutEnd], [u].[NormalizedEmail], [u].[NormalizedUserName], [u].[PasswordHash], [u].[PhoneNumber], [u].[PhoneNumberConfirmed], [u].[SecurityStamp], [u].[TwoFactorEnabled], [u].[UserName]
+FROM [users] AS [u]
+WHERE [u].[NormalizedEmail] = @__normalizedEmail_0
+2025-08-12 11:10:33.975 +07:00 [DBG] Context 'MyDbContext' started tracking 'User' entity. Consider using 'DbContextOptionsBuilder.EnableSensitiveDataLogging' to see key values.
+2025-08-12 11:10:34.002 +07:00 [DBG] Closing data reader to 'capbot_db' on server 'localhost'.
+2025-08-12 11:10:34.002 +07:00 [DBG] A data reader for 'capbot_db' on server 'localhost' is being disposed after spending 56ms reading results.
+2025-08-12 11:10:34.002 +07:00 [DBG] Closing connection to database 'capbot_db' on server 'localhost'.
+2025-08-12 11:10:34.003 +07:00 [DBG] Closed connection to database 'capbot_db' on server 'localhost' (0ms).
+2025-08-12 11:10:34.005 +07:00 [INF] Admin user 'fptslayer@gmail.com' already exists
+2025-08-12 11:10:34.006 +07:00 [DBG] Opening connection to database 'capbot_db' on server 'localhost'.
+2025-08-12 11:10:34.007 +07:00 [DBG] Opened connection to database 'capbot_db' on server 'localhost'.
+2025-08-12 11:10:34.007 +07:00 [DBG] Creating DbCommand for 'ExecuteReader'.
+2025-08-12 11:10:34.007 +07:00 [DBG] Created DbCommand for 'ExecuteReader' (0ms).
+2025-08-12 11:10:34.008 +07:00 [DBG] Initialized DbCommand for 'ExecuteReader' (0ms).
+2025-08-12 11:10:34.008 +07:00 [DBG] Executing DbCommand [Parameters=[@__normalizedEmail_0='?' (Size = 4000)], CommandType='"Text"', CommandTimeout='30']
+SELECT TOP(2) [u].[Id], [u].[AccessFailedCount], [u].[ConcurrencyStamp], [u].[CreatedAt], [u].[DeletedAt], [u].[Email], [u].[EmailConfirmed], [u].[LastModifiedAt], [u].[LastModifiedBy], [u].[LockoutEnabled], [u].[LockoutEnd], [u].[NormalizedEmail], [u].[NormalizedUserName], [u].[PasswordHash], [u].[PhoneNumber], [u].[PhoneNumberConfirmed], [u].[SecurityStamp], [u].[TwoFactorEnabled], [u].[UserName]
+FROM [users] AS [u]
+WHERE [u].[NormalizedEmail] = @__normalizedEmail_0
+2025-08-12 11:10:34.009 +07:00 [INF] Executed DbCommand (1ms) [Parameters=[@__normalizedEmail_0='?' (Size = 4000)], CommandType='"Text"', CommandTimeout='30']
+SELECT TOP(2) [u].[Id], [u].[AccessFailedCount], [u].[ConcurrencyStamp], [u].[CreatedAt], [u].[DeletedAt], [u].[Email], [u].[EmailConfirmed], [u].[LastModifiedAt], [u].[LastModifiedBy], [u].[LockoutEnabled], [u].[LockoutEnd], [u].[NormalizedEmail], [u].[NormalizedUserName], [u].[PasswordHash], [u].[PhoneNumber], [u].[PhoneNumberConfirmed], [u].[SecurityStamp], [u].[TwoFactorEnabled], [u].[UserName]
+FROM [users] AS [u]
+WHERE [u].[NormalizedEmail] = @__normalizedEmail_0
+2025-08-12 11:10:34.010 +07:00 [DBG] Context 'MyDbContext' started tracking 'User' entity. Consider using 'DbContextOptionsBuilder.EnableSensitiveDataLogging' to see key values.
+2025-08-12 11:10:34.010 +07:00 [DBG] Closing data reader to 'capbot_db' on server 'localhost'.
+2025-08-12 11:10:34.010 +07:00 [DBG] A data reader for 'capbot_db' on server 'localhost' is being disposed after spending 0ms reading results.
+2025-08-12 11:10:34.011 +07:00 [DBG] Closing connection to database 'capbot_db' on server 'localhost'.
+2025-08-12 11:10:34.011 +07:00 [DBG] Closed connection to database 'capbot_db' on server 'localhost' (0ms).
+2025-08-12 11:10:34.011 +07:00 [INF] Sample moderator 'moderator@example.com' already exists
+2025-08-12 11:10:34.012 +07:00 [DBG] Opening connection to database 'capbot_db' on server 'localhost'.
+2025-08-12 11:10:34.012 +07:00 [DBG] Opened connection to database 'capbot_db' on server 'localhost'.
+2025-08-12 11:10:34.012 +07:00 [DBG] Creating DbCommand for 'ExecuteReader'.
+2025-08-12 11:10:34.012 +07:00 [DBG] Created DbCommand for 'ExecuteReader' (0ms).
+2025-08-12 11:10:34.012 +07:00 [DBG] Initialized DbCommand for 'ExecuteReader' (0ms).
+2025-08-12 11:10:34.012 +07:00 [DBG] Executing DbCommand [Parameters=[@__normalizedEmail_0='?' (Size = 4000)], CommandType='"Text"', CommandTimeout='30']
+SELECT TOP(2) [u].[Id], [u].[AccessFailedCount], [u].[ConcurrencyStamp], [u].[CreatedAt], [u].[DeletedAt], [u].[Email], [u].[EmailConfirmed], [u].[LastModifiedAt], [u].[LastModifiedBy], [u].[LockoutEnabled], [u].[LockoutEnd], [u].[NormalizedEmail], [u].[NormalizedUserName], [u].[PasswordHash], [u].[PhoneNumber], [u].[PhoneNumberConfirmed], [u].[SecurityStamp], [u].[TwoFactorEnabled], [u].[UserName]
+FROM [users] AS [u]
+WHERE [u].[NormalizedEmail] = @__normalizedEmail_0
+2025-08-12 11:10:34.014 +07:00 [INF] Executed DbCommand (1ms) [Parameters=[@__normalizedEmail_0='?' (Size = 4000)], CommandType='"Text"', CommandTimeout='30']
+SELECT TOP(2) [u].[Id], [u].[AccessFailedCount], [u].[ConcurrencyStamp], [u].[CreatedAt], [u].[DeletedAt], [u].[Email], [u].[EmailConfirmed], [u].[LastModifiedAt], [u].[LastModifiedBy], [u].[LockoutEnabled], [u].[LockoutEnd], [u].[NormalizedEmail], [u].[NormalizedUserName], [u].[PasswordHash], [u].[PhoneNumber], [u].[PhoneNumberConfirmed], [u].[SecurityStamp], [u].[TwoFactorEnabled], [u].[UserName]
+FROM [users] AS [u]
+WHERE [u].[NormalizedEmail] = @__normalizedEmail_0
+2025-08-12 11:10:34.014 +07:00 [DBG] Context 'MyDbContext' started tracking 'User' entity. Consider using 'DbContextOptionsBuilder.EnableSensitiveDataLogging' to see key values.
+2025-08-12 11:10:34.014 +07:00 [DBG] Closing data reader to 'capbot_db' on server 'localhost'.
+2025-08-12 11:10:34.014 +07:00 [DBG] A data reader for 'capbot_db' on server 'localhost' is being disposed after spending 0ms reading results.
+2025-08-12 11:10:34.015 +07:00 [DBG] Closing connection to database 'capbot_db' on server 'localhost'.
+2025-08-12 11:10:34.015 +07:00 [DBG] Closed connection to database 'capbot_db' on server 'localhost' (0ms).
+2025-08-12 11:10:34.015 +07:00 [DBG] Opening connection to database 'capbot_db' on server 'localhost'.
+2025-08-12 11:10:34.015 +07:00 [DBG] Opened connection to database 'capbot_db' on server 'localhost'.
+2025-08-12 11:10:34.015 +07:00 [DBG] Creating DbCommand for 'ExecuteReader'.
+2025-08-12 11:10:34.015 +07:00 [DBG] Created DbCommand for 'ExecuteReader' (0ms).
+2025-08-12 11:10:34.015 +07:00 [DBG] Initialized DbCommand for 'ExecuteReader' (0ms).
+2025-08-12 11:10:34.016 +07:00 [DBG] Executing DbCommand [Parameters=[@__normalizedEmail_0='?' (Size = 4000)], CommandType='"Text"', CommandTimeout='30']
+SELECT TOP(2) [u].[Id], [u].[AccessFailedCount], [u].[ConcurrencyStamp], [u].[CreatedAt], [u].[DeletedAt], [u].[Email], [u].[EmailConfirmed], [u].[LastModifiedAt], [u].[LastModifiedBy], [u].[LockoutEnabled], [u].[LockoutEnd], [u].[NormalizedEmail], [u].[NormalizedUserName], [u].[PasswordHash], [u].[PhoneNumber], [u].[PhoneNumberConfirmed], [u].[SecurityStamp], [u].[TwoFactorEnabled], [u].[UserName]
+FROM [users] AS [u]
+WHERE [u].[NormalizedEmail] = @__normalizedEmail_0
+2025-08-12 11:10:34.016 +07:00 [INF] Executed DbCommand (1ms) [Parameters=[@__normalizedEmail_0='?' (Size = 4000)], CommandType='"Text"', CommandTimeout='30']
+SELECT TOP(2) [u].[Id], [u].[AccessFailedCount], [u].[ConcurrencyStamp], [u].[CreatedAt], [u].[DeletedAt], [u].[Email], [u].[EmailConfirmed], [u].[LastModifiedAt], [u].[LastModifiedBy], [u].[LockoutEnabled], [u].[LockoutEnd], [u].[NormalizedEmail], [u].[NormalizedUserName], [u].[PasswordHash], [u].[PhoneNumber], [u].[PhoneNumberConfirmed], [u].[SecurityStamp], [u].[TwoFactorEnabled], [u].[UserName]
+FROM [users] AS [u]
+WHERE [u].[NormalizedEmail] = @__normalizedEmail_0
+2025-08-12 11:10:34.017 +07:00 [DBG] Context 'MyDbContext' started tracking 'User' entity. Consider using 'DbContextOptionsBuilder.EnableSensitiveDataLogging' to see key values.
+2025-08-12 11:10:34.017 +07:00 [DBG] Closing data reader to 'capbot_db' on server 'localhost'.
+2025-08-12 11:10:34.017 +07:00 [DBG] A data reader for 'capbot_db' on server 'localhost' is being disposed after spending 0ms reading results.
+2025-08-12 11:10:34.017 +07:00 [DBG] Closing connection to database 'capbot_db' on server 'localhost'.
+2025-08-12 11:10:34.018 +07:00 [DBG] Closed connection to database 'capbot_db' on server 'localhost' (0ms).
+2025-08-12 11:10:34.018 +07:00 [INF] Data seeding completed successfully
+2025-08-12 11:10:34.019 +07:00 [DBG] 'MyDbContext' disposed.
+2025-08-12 11:10:34.021 +07:00 [DBG] Disposing connection to database 'capbot_db' on server 'localhost'.
+2025-08-12 11:10:34.022 +07:00 [DBG] Disposed connection to database '' on server '' (1ms).
+2025-08-12 11:10:34.153 +07:00 [DBG] Registered model binder providers, in the following order: ["Microsoft.AspNetCore.Mvc.ModelBinding.Binders.BinderTypeModelBinderProvider","Microsoft.AspNetCore.Mvc.ModelBinding.Binders.ServicesModelBinderProvider","Microsoft.AspNetCore.Mvc.ModelBinding.Binders.BodyModelBinderProvider","Microsoft.AspNetCore.Mvc.ModelBinding.Binders.HeaderModelBinderProvider","Microsoft.AspNetCore.Mvc.ModelBinding.Binders.FloatingPointTypeModelBinderProvider","Microsoft.AspNetCore.Mvc.ModelBinding.Binders.EnumTypeModelBinderProvider","Microsoft.AspNetCore.Mvc.ModelBinding.Binders.DateTimeModelBinderProvider","Microsoft.AspNetCore.Mvc.ModelBinding.Binders.SimpleTypeModelBinderProvider","Microsoft.AspNetCore.Mvc.ModelBinding.Binders.TryParseModelBinderProvider","Microsoft.AspNetCore.Mvc.ModelBinding.Binders.CancellationTokenModelBinderProvider"]
+2025-08-12 11:10:34.227 +07:00 [DBG] Hosting starting
+2025-08-12 11:10:34.232 +07:00 [DBG] Reading data from file 'C:\Users\Admin\AppData\Local\ASP.NET\DataProtection-Keys\key-1d6bcff1-a155-4167-8a22-de35a5f05047.xml'.
+2025-08-12 11:10:34.235 +07:00 [DBG] Reading data from file 'C:\Users\Admin\AppData\Local\ASP.NET\DataProtection-Keys\key-2459dd29-32d5-4c49-ac9d-33896047bb78.xml'.
+2025-08-12 11:10:34.235 +07:00 [DBG] Reading data from file 'C:\Users\Admin\AppData\Local\ASP.NET\DataProtection-Keys\key-374624f1-e856-4617-8ae6-fe6a81ce6346.xml'.
+2025-08-12 11:10:34.238 +07:00 [DBG] Found key {1d6bcff1-a155-4167-8a22-de35a5f05047}.
+2025-08-12 11:10:34.242 +07:00 [DBG] Found key {2459dd29-32d5-4c49-ac9d-33896047bb78}.
+2025-08-12 11:10:34.243 +07:00 [DBG] Found key {374624f1-e856-4617-8ae6-fe6a81ce6346}.
+2025-08-12 11:10:34.250 +07:00 [DBG] Considering key {2459dd29-32d5-4c49-ac9d-33896047bb78} with expiration date 2025-11-03 12:40:53Z as default key.
+2025-08-12 11:10:34.252 +07:00 [DBG] Forwarded activator type request from Microsoft.AspNetCore.DataProtection.XmlEncryption.DpapiXmlDecryptor, Microsoft.AspNetCore.DataProtection, Version=8.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60 to Microsoft.AspNetCore.DataProtection.XmlEncryption.DpapiXmlDecryptor, Microsoft.AspNetCore.DataProtection, Culture=neutral, PublicKeyToken=adb9793829ddae60
+2025-08-12 11:10:34.253 +07:00 [DBG] Decrypting secret element using Windows DPAPI.
+2025-08-12 11:10:34.255 +07:00 [DBG] Forwarded activator type request from Microsoft.AspNetCore.DataProtection.AuthenticatedEncryption.ConfigurationModel.AuthenticatedEncryptorDescriptorDeserializer, Microsoft.AspNetCore.DataProtection, Version=8.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60 to Microsoft.AspNetCore.DataProtection.AuthenticatedEncryption.ConfigurationModel.AuthenticatedEncryptorDescriptorDeserializer, Microsoft.AspNetCore.DataProtection, Culture=neutral, PublicKeyToken=adb9793829ddae60
+2025-08-12 11:10:34.257 +07:00 [DBG] Opening CNG algorithm 'AES' from provider 'null' with chaining mode CBC.
+2025-08-12 11:10:34.258 +07:00 [DBG] Opening CNG algorithm 'SHA256' from provider 'null' with HMAC.
+2025-08-12 11:10:34.259 +07:00 [DBG] Using key {2459dd29-32d5-4c49-ac9d-33896047bb78} as the default key.
+2025-08-12 11:10:34.260 +07:00 [DBG] Key ring with default key {2459dd29-32d5-4c49-ac9d-33896047bb78} was loaded during application startup.
+2025-08-12 11:10:34.363 +07:00 [INF] Now listening on: https://localhost:7190
+2025-08-12 11:10:34.363 +07:00 [DBG] Loaded hosting startup assembly CapBot.api
+2025-08-12 11:10:34.364 +07:00 [DBG] Loaded hosting startup assembly Microsoft.WebTools.ApiEndpointDiscovery
+2025-08-12 11:10:34.364 +07:00 [DBG] Loaded hosting startup assembly Microsoft.AspNetCore.Watch.BrowserRefresh
+2025-08-12 11:10:34.364 +07:00 [DBG] Loaded hosting startup assembly Microsoft.WebTools.BrowserLink.Net
+2025-08-12 11:10:34.419 +07:00 [INF] Application started. Press Ctrl+C to shut down.
+2025-08-12 11:10:34.419 +07:00 [INF] Hosting environment: Development
+2025-08-12 11:10:34.420 +07:00 [INF] Content root path: C:\Users\Admin\Downloads\CBAI_API\CapBot.api
+2025-08-12 11:10:34.421 +07:00 [DBG] Hosting started
+2025-08-12 11:10:34.549 +07:00 [DBG] Connection id "0HNEPAONPJDV6" received FIN.
+2025-08-12 11:10:34.563 +07:00 [DBG] Connection id "0HNEPAONPJDV6" accepted.
+2025-08-12 11:10:34.570 +07:00 [DBG] Connection id "0HNEPAONPJDV6" started.
+2025-08-12 11:10:34.579 +07:00 [DBG] Failed to authenticate HTTPS connection.
+System.IO.IOException: Received an unexpected EOF or 0 bytes from the transport stream.
+   at System.Net.Security.SslStream.ReceiveHandshakeFrameAsync[TIOAdapter](CancellationToken cancellationToken)
+   at System.Net.Security.SslStream.ForceAuthenticationAsync[TIOAdapter](Boolean receiveFirst, Byte[] reAuthenticationData, CancellationToken cancellationToken)
+   at System.Net.Security.SslStream.ProcessAuthenticationWithTelemetryAsync(Boolean isAsync, CancellationToken cancellationToken)
+   at Microsoft.AspNetCore.Server.Kestrel.Https.Internal.HttpsConnectionMiddleware.OnConnectionAsync(ConnectionContext context)
+2025-08-12 11:10:34.588 +07:00 [DBG] Connection id "0HNEPAONPJDV6" stopped.
+2025-08-12 11:10:34.591 +07:00 [DBG] Connection id "0HNEPAONPJDV6" sending FIN because: "The Socket transport's send loop completed gracefully."
+2025-08-12 11:10:34.640 +07:00 [DBG] Connection id "0HNEPAONPJDV7" accepted.
+2025-08-12 11:10:34.641 +07:00 [DBG] Connection id "0HNEPAONPJDV7" started.
+2025-08-12 11:10:34.722 +07:00 [DBG] Connection 0HNEPAONPJDV7 established using the following protocol: "Tls13"
+2025-08-12 11:10:34.776 +07:00 [INF] Request starting HTTP/2 GET https://localhost:7190/index.html - null null
+2025-08-12 11:10:34.812 +07:00 [DBG] Wildcard detected, all requests with hosts will be allowed.
+2025-08-12 11:10:34.841 +07:00 [DBG] Response markup is scheduled to include Browser Link script injection.
+2025-08-12 11:10:34.842 +07:00 [DBG] Response markup is scheduled to include browser refresh script injection.
+2025-08-12 11:10:34.878 +07:00 [DBG] Response markup was updated to include Browser Link script injection.
+2025-08-12 11:10:34.878 +07:00 [INF] Request starting HTTP/2 GET https://localhost:7190/_framework/aspnetcore-browser-refresh.js - null null
+2025-08-12 11:10:34.878 +07:00 [INF] Request starting HTTP/2 GET https://localhost:7190/_vs/browserLink - null null
+2025-08-12 11:10:34.879 +07:00 [DBG] Response markup was updated to include browser refresh script injection.
+2025-08-12 11:10:34.886 +07:00 [INF] Request finished HTTP/2 GET https://localhost:7190/index.html - 200 null text/html;charset=utf-8 114.769ms
+2025-08-12 11:10:34.887 +07:00 [INF] Request finished HTTP/2 GET https://localhost:7190/_framework/aspnetcore-browser-refresh.js - 200 13756 application/javascript; charset=utf-8 8.7788ms
+2025-08-12 11:10:34.920 +07:00 [INF] Request finished HTTP/2 GET https://localhost:7190/_vs/browserLink - 200 null text/javascript; charset=UTF-8 41.8221ms
+2025-08-12 11:10:34.941 +07:00 [INF] Request starting HTTP/2 GET https://localhost:7190/swagger/v1/swagger.json - null null
+2025-08-12 11:10:34.967 +07:00 [INF] Request finished HTTP/2 GET https://localhost:7190/swagger/v1/swagger.json - 200 null application/json;charset=utf-8 25.8347ms
+2025-08-12 11:13:28.562 +07:00 [INF] Application is shutting down...
+2025-08-12 11:13:28.564 +07:00 [DBG] Hosting stopping
+2025-08-12 11:13:28.623 +07:00 [DBG] Connection id "0HNEPAONPJDV7" is closing.
+2025-08-12 11:13:28.624 +07:00 [DBG] Connection id "0HNEPAONPJDV7" is closed. The last processed stream ID was 7.
+2025-08-12 11:13:28.626 +07:00 [DBG] Connection id "0HNEPAONPJDV7" received FIN.
+2025-08-12 11:13:28.628 +07:00 [DBG] Connection id "0HNEPAONPJDV7" sending FIN because: "The Socket transport's send loop completed gracefully."
+2025-08-12 11:13:28.631 +07:00 [DBG] The connection queue processing loop for 0HNEPAONPJDV7 completed.
+2025-08-12 11:13:28.633 +07:00 [DBG] Connection id "0HNEPAONPJDV7" stopped.
+2025-08-12 11:13:28.639 +07:00 [DBG] Hosting stopped
+2025-08-12 11:17:15.051 +07:00 [DBG] An 'IServiceProvider' was created for internal use by Entity Framework.
+2025-08-12 11:17:15.138 +07:00 [INF] User profile is available. Using 'C:\Users\Admin\AppData\Local\ASP.NET\DataProtection-Keys' as key repository and Windows DPAPI to encrypt keys at rest.
+2025-08-12 11:17:15.315 +07:00 [DBG] No relationship from 'ReviewerAssignment' to 'User' has been configured by convention because there are multiple properties on one entity type - {'AssignedByUser', 'Reviewer'} that could be matched with the properties on the other entity type - {'ReviewerAssignments'}. This message can be disregarded if explicit configuration has been specified in 'OnModelCreating'.
+2025-08-12 11:17:15.335 +07:00 [DBG] No relationship from 'SubmissionWorkflowLog' to 'WorkflowState' has been configured by convention because there are multiple properties on one entity type - {'FromState', 'ToState'} that could be matched with the properties on the other entity type - {'FromStateLogs', 'ToStateLogs'}. This message can be disregarded if explicit configuration has been specified in 'OnModelCreating'.
+2025-08-12 11:17:15.344 +07:00 [DBG] No relationship from 'User' to 'ReviewerAssignment' has been configured by convention because there are multiple properties on one entity type - {'ReviewerAssignments'} that could be matched with the properties on the other entity type - {'AssignedByUser', 'Reviewer'}. This message can be disregarded if explicit configuration has been specified in 'OnModelCreating'.
+2025-08-12 11:17:15.346 +07:00 [DBG] No relationship from 'WorkflowState' to 'SubmissionWorkflowLog' has been configured by convention because there are multiple properties on one entity type - {'FromStateLogs', 'ToStateLogs'} that could be matched with the properties on the other entity type - {'FromState', 'ToState'}. This message can be disregarded if explicit configuration has been specified in 'OnModelCreating'.
+2025-08-12 11:17:15.346 +07:00 [DBG] No relationship from 'WorkflowState' to 'WorkflowTransition' has been configured by convention because there are multiple properties on one entity type - {'FromTransitions', 'ToTransitions'} that could be matched with the properties on the other entity type - {'FromState', 'ToState'}. This message can be disregarded if explicit configuration has been specified in 'OnModelCreating'.
+2025-08-12 11:17:15.347 +07:00 [DBG] No relationship from 'WorkflowTransition' to 'WorkflowState' has been configured by convention because there are multiple properties on one entity type - {'FromState', 'ToState'} that could be matched with the properties on the other entity type - {'FromTransitions', 'ToTransitions'}. This message can be disregarded if explicit configuration has been specified in 'OnModelCreating'.
+2025-08-12 11:17:15.475 +07:00 [DBG] No relationship from 'ReviewerAssignment' to 'User' has been configured by convention because there are multiple properties on one entity type - {'AssignedByUser', 'Reviewer'} that could be matched with the properties on the other entity type - {'ReviewerAssignments'}. This message can be disregarded if explicit configuration has been specified in 'OnModelCreating'.
+2025-08-12 11:17:15.477 +07:00 [DBG] No relationship from 'User' to 'ReviewerAssignment' has been configured by convention because there are multiple properties on one entity type - {'ReviewerAssignments'} that could be matched with the properties on the other entity type - {'AssignedByUser', 'Reviewer'}. This message can be disregarded if explicit configuration has been specified in 'OnModelCreating'.
+2025-08-12 11:17:15.492 +07:00 [DBG] No relationship from 'WorkflowTransition' to 'WorkflowState' has been configured by convention because there are multiple properties on one entity type - {'FromState', 'ToState'} that could be matched with the properties on the other entity type - {'FromTransitions', 'ToTransitions'}. This message can be disregarded if explicit configuration has been specified in 'OnModelCreating'.
+2025-08-12 11:17:15.492 +07:00 [DBG] No relationship from 'WorkflowState' to 'SubmissionWorkflowLog' has been configured by convention because there are multiple properties on one entity type - {'FromStateLogs', 'ToStateLogs'} that could be matched with the properties on the other entity type - {'FromState', 'ToState'}. This message can be disregarded if explicit configuration has been specified in 'OnModelCreating'.
+2025-08-12 11:17:15.492 +07:00 [DBG] No relationship from 'WorkflowState' to 'WorkflowTransition' has been configured by convention because there are multiple properties on one entity type - {'FromTransitions', 'ToTransitions'} that could be matched with the properties on the other entity type - {'FromState', 'ToState'}. This message can be disregarded if explicit configuration has been specified in 'OnModelCreating'.
+2025-08-12 11:17:15.493 +07:00 [DBG] No relationship from 'WorkflowState' to 'SubmissionWorkflowLog' has been configured by convention because there are multiple properties on one entity type - {'FromStateLogs', 'ToStateLogs'} that could be matched with the properties on the other entity type - {'FromState', 'ToState'}. This message can be disregarded if explicit configuration has been specified in 'OnModelCreating'.
+2025-08-12 11:17:15.498 +07:00 [DBG] No relationship from 'SubmissionWorkflowLog' to 'WorkflowState' has been configured by convention because there are multiple properties on one entity type - {'FromState', 'ToState'} that could be matched with the properties on the other entity type - {'FromStateLogs', 'ToStateLogs'}. This message can be disregarded if explicit configuration has been specified in 'OnModelCreating'.
+2025-08-12 11:17:15.498 +07:00 [DBG] No relationship from 'WorkflowState' to 'SubmissionWorkflowLog' has been configured by convention because there are multiple properties on one entity type - {'FromStateLogs', 'ToStateLogs'} that could be matched with the properties on the other entity type - {'FromState', 'ToState'}. This message can be disregarded if explicit configuration has been specified in 'OnModelCreating'.
+2025-08-12 11:17:15.523 +07:00 [DBG] The index {'LecturerId'} was not created on entity type 'LecturerSkill' as the properties are already covered by the index {'LecturerId', 'SkillTag'}.
+2025-08-12 11:17:15.524 +07:00 [DBG] The index {'SemesterId'} was not created on entity type 'Phase' as the properties are already covered by the index {'SemesterId', 'PhaseTypeId'}.
+2025-08-12 11:17:15.524 +07:00 [DBG] The index {'AssignmentId'} was not created on entity type 'Review' as the properties are already covered by the index {'AssignmentId', 'Status'}.
+2025-08-12 11:17:15.524 +07:00 [DBG] The index {'ReviewId'} was not created on entity type 'ReviewComment' as the properties are already covered by the index {'ReviewId', 'SectionName'}.
+2025-08-12 11:17:15.524 +07:00 [DBG] The index {'ReviewId'} was not created on entity type 'ReviewCriteriaScore' as the properties are already covered by the index {'ReviewId', 'CriteriaId'}.
+2025-08-12 11:17:15.525 +07:00 [DBG] The index {'ReviewerId'} was not created on entity type 'ReviewerAssignment' as the properties are already covered by the index {'ReviewerId', 'Status'}.
+2025-08-12 11:17:15.525 +07:00 [DBG] The index {'SubmissionId'} was not created on entity type 'ReviewerAssignment' as the properties are already covered by the index {'SubmissionId', 'ReviewerId'}.
+2025-08-12 11:17:15.525 +07:00 [DBG] The index {'ReviewerId'} was not created on entity type 'ReviewerPerformance' as the properties are already covered by the index {'ReviewerId', 'SemesterId'}.
+2025-08-12 11:17:15.525 +07:00 [DBG] The index {'PhaseId'} was not created on entity type 'Submission' as the properties are already covered by the index {'PhaseId', 'Status'}.
+2025-08-12 11:17:15.525 +07:00 [DBG] The index {'PhaseId'} was not created on entity type 'Submission' as the properties are already covered by the index {'PhaseId', 'Status', 'SubmittedAt'}.
+2025-08-12 11:17:15.525 +07:00 [DBG] The index {'TopicVersionId'} was not created on entity type 'Submission' as the properties are already covered by the index {'TopicVersionId', 'PhaseId', 'SubmissionRound'}.
+2025-08-12 11:17:15.526 +07:00 [DBG] The index {'SubmissionId'} was not created on entity type 'SubmissionWorkflowLog' as the properties are already covered by the index {'SubmissionId', 'CreatedAt'}.
+2025-08-12 11:17:15.526 +07:00 [DBG] The index {'UserId'} was not created on entity type 'SystemNotification' as the properties are already covered by the index {'UserId', 'IsRead', 'CreatedAt'}.
+2025-08-12 11:17:15.526 +07:00 [DBG] The index {'SemesterId'} was not created on entity type 'Topic' as the properties are already covered by the index {'SemesterId', 'IsApproved'}.
+2025-08-12 11:17:15.526 +07:00 [DBG] The index {'SupervisorId'} was not created on entity type 'Topic' as the properties are already covered by the index {'SupervisorId', 'SemesterId'}.
+2025-08-12 11:17:15.526 +07:00 [DBG] The index {'TopicId'} was not created on entity type 'TopicVersion' as the properties are already covered by the index {'TopicId', 'Status'}.
+2025-08-12 11:17:15.526 +07:00 [DBG] The index {'TopicId'} was not created on entity type 'TopicVersion' as the properties are already covered by the index {'TopicId', 'VersionNumber'}.
+2025-08-12 11:17:15.526 +07:00 [DBG] The index {'UserId'} was not created on entity type 'UserRole' as the properties are already covered by the index {'UserId', 'RoleId'}.
+2025-08-12 11:17:15.526 +07:00 [DBG] The index {'UserId'} was not created on entity type 'UserToken' as the properties are already covered by the index {'UserId', 'LoginProvider', 'Name'}.
+2025-08-12 11:17:15.630 +07:00 [WRN] The 'ProficiencyLevels' property 'ProficiencyLevel' on entity type 'LecturerSkill' is configured with a database-generated default, but has no configured sentinel value. The database-generated default will always be used for inserts when the property has the value '0', since this is the CLR default for the 'ProficiencyLevels' type. Consider using a nullable type, using a nullable backing field, or setting the sentinel value for the property to ensure the database default is used when, and only when, appropriate. See https://aka.ms/efcore-docs-default-values for more information.
+2025-08-12 11:17:15.631 +07:00 [WRN] The 'ReviewRecommendations' property 'Recommendation' on entity type 'Review' is configured with a database-generated default, but has no configured sentinel value. The database-generated default will always be used for inserts when the property has the value '0', since this is the CLR default for the 'ReviewRecommendations' type. Consider using a nullable type, using a nullable backing field, or setting the sentinel value for the property to ensure the database default is used when, and only when, appropriate. See https://aka.ms/efcore-docs-default-values for more information.
+2025-08-12 11:17:15.632 +07:00 [WRN] The 'ReviewStatus' property 'Status' on entity type 'Review' is configured with a database-generated default, but has no configured sentinel value. The database-generated default will always be used for inserts when the property has the value '0', since this is the CLR default for the 'ReviewStatus' type. Consider using a nullable type, using a nullable backing field, or setting the sentinel value for the property to ensure the database default is used when, and only when, appropriate. See https://aka.ms/efcore-docs-default-values for more information.
+2025-08-12 11:17:15.632 +07:00 [WRN] The 'CommentTypes' property 'CommentType' on entity type 'ReviewComment' is configured with a database-generated default, but has no configured sentinel value. The database-generated default will always be used for inserts when the property has the value '0', since this is the CLR default for the 'CommentTypes' type. Consider using a nullable type, using a nullable backing field, or setting the sentinel value for the property to ensure the database default is used when, and only when, appropriate. See https://aka.ms/efcore-docs-default-values for more information.
+2025-08-12 11:17:15.632 +07:00 [WRN] The 'PriorityLevels' property 'Priority' on entity type 'ReviewComment' is configured with a database-generated default, but has no configured sentinel value. The database-generated default will always be used for inserts when the property has the value '0', since this is the CLR default for the 'PriorityLevels' type. Consider using a nullable type, using a nullable backing field, or setting the sentinel value for the property to ensure the database default is used when, and only when, appropriate. See https://aka.ms/efcore-docs-default-values for more information.
+2025-08-12 11:17:15.633 +07:00 [WRN] The 'AssignmentTypes' property 'AssignmentType' on entity type 'ReviewerAssignment' is configured with a database-generated default, but has no configured sentinel value. The database-generated default will always be used for inserts when the property has the value '0', since this is the CLR default for the 'AssignmentTypes' type. Consider using a nullable type, using a nullable backing field, or setting the sentinel value for the property to ensure the database default is used when, and only when, appropriate. See https://aka.ms/efcore-docs-default-values for more information.
+2025-08-12 11:17:15.633 +07:00 [WRN] The 'AssignmentStatus' property 'Status' on entity type 'ReviewerAssignment' is configured with a database-generated default, but has no configured sentinel value. The database-generated default will always be used for inserts when the property has the value '0', since this is the CLR default for the 'AssignmentStatus' type. Consider using a nullable type, using a nullable backing field, or setting the sentinel value for the property to ensure the database default is used when, and only when, appropriate. See https://aka.ms/efcore-docs-default-values for more information.
+2025-08-12 11:17:15.634 +07:00 [WRN] The 'AiCheckStatus' property 'AiCheckStatus' on entity type 'Submission' is configured with a database-generated default, but has no configured sentinel value. The database-generated default will always be used for inserts when the property has the value '0', since this is the CLR default for the 'AiCheckStatus' type. Consider using a nullable type, using a nullable backing field, or setting the sentinel value for the property to ensure the database default is used when, and only when, appropriate. See https://aka.ms/efcore-docs-default-values for more information.
+2025-08-12 11:17:15.634 +07:00 [WRN] The 'SubmissionStatus' property 'Status' on entity type 'Submission' is configured with a database-generated default, but has no configured sentinel value. The database-generated default will always be used for inserts when the property has the value '0', since this is the CLR default for the 'SubmissionStatus' type. Consider using a nullable type, using a nullable backing field, or setting the sentinel value for the property to ensure the database default is used when, and only when, appropriate. See https://aka.ms/efcore-docs-default-values for more information.
+2025-08-12 11:17:15.635 +07:00 [WRN] The 'NotificationTypes' property 'Type' on entity type 'SystemNotification' is configured with a database-generated default, but has no configured sentinel value. The database-generated default will always be used for inserts when the property has the value '0', since this is the CLR default for the 'NotificationTypes' type. Consider using a nullable type, using a nullable backing field, or setting the sentinel value for the property to ensure the database default is used when, and only when, appropriate. See https://aka.ms/efcore-docs-default-values for more information.
+2025-08-12 11:17:15.635 +07:00 [WRN] The 'TopicStatus' property 'Status' on entity type 'TopicVersion' is configured with a database-generated default, but has no configured sentinel value. The database-generated default will always be used for inserts when the property has the value '0', since this is the CLR default for the 'TopicStatus' type. Consider using a nullable type, using a nullable backing field, or setting the sentinel value for the property to ensure the database default is used when, and only when, appropriate. See https://aka.ms/efcore-docs-default-values for more information.
+2025-08-12 11:17:15.729 +07:00 [DBG] Entity Framework Core 8.0.16 initialized 'MyDbContext' using provider 'Microsoft.EntityFrameworkCore.SqlServer:8.0.13' with options: MigrationsAssembly=App.DAL 
+2025-08-12 11:17:15.785 +07:00 [DBG] Compiling query expression: 
+'DbSet<Role>()
+    .FirstOrDefault(r => r.NormalizedName == __normalizedName_0)'
+2025-08-12 11:17:15.889 +07:00 [DBG] Generated query execution expression: 
+'queryContext => ShapedQueryCompilingExpressionVisitor.SingleOrDefaultAsync<Role>(
+    asyncEnumerable: new SingleQueryingEnumerable<Role>(
+        (RelationalQueryContext)queryContext, 
+        RelationalCommandCache.QueryExpression(
+            Projection Mapping:
+                EmptyProjectionMember -> Dictionary<IProperty, int> { [Property: Role.Id (int) Required PK AfterSave:Throw ValueGenerated.OnAdd, 0], [Property: Role.ConcurrencyStamp (string), 1], [Property: Role.IsAdmin (bool) Required, 2], [Property: Role.Name (string), 3], [Property: Role.NormalizedName (string), 4] }
+            SELECT TOP(1) r.Id, r.ConcurrencyStamp, r.IsAdmin, r.Name, r.NormalizedName
+            FROM roles AS r
+            WHERE r.NormalizedName == @__normalizedName_0), 
+        null, 
+        Func<QueryContext, DbDataReader, ResultContext, SingleQueryResultCoordinator, Role>, 
+        App.DAL.Context.MyDbContext, 
+        False, 
+        False, 
+        True
+    ), 
+    cancellationToken: queryContext.CancellationToken)'
+2025-08-12 11:17:15.913 +07:00 [DBG] Creating DbConnection.
+2025-08-12 11:17:15.925 +07:00 [DBG] Created DbConnection. (10ms).
+2025-08-12 11:17:15.928 +07:00 [DBG] Opening connection to database 'capbot_db' on server 'localhost'.
+2025-08-12 11:17:16.125 +07:00 [DBG] Opened connection to database 'capbot_db' on server 'localhost'.
+2025-08-12 11:17:16.128 +07:00 [DBG] Creating DbCommand for 'ExecuteReader'.
+2025-08-12 11:17:16.134 +07:00 [DBG] Created DbCommand for 'ExecuteReader' (4ms).
+2025-08-12 11:17:16.139 +07:00 [DBG] Initialized DbCommand for 'ExecuteReader' (11ms).
+2025-08-12 11:17:16.144 +07:00 [DBG] Executing DbCommand [Parameters=[@__normalizedName_0='?' (Size = 4000)], CommandType='"Text"', CommandTimeout='30']
+SELECT TOP(1) [r].[Id], [r].[ConcurrencyStamp], [r].[IsAdmin], [r].[Name], [r].[NormalizedName]
+FROM [roles] AS [r]
+WHERE [r].[NormalizedName] = @__normalizedName_0
+2025-08-12 11:17:16.201 +07:00 [INF] Executed DbCommand (57ms) [Parameters=[@__normalizedName_0='?' (Size = 4000)], CommandType='"Text"', CommandTimeout='30']
+SELECT TOP(1) [r].[Id], [r].[ConcurrencyStamp], [r].[IsAdmin], [r].[Name], [r].[NormalizedName]
+FROM [roles] AS [r]
+WHERE [r].[NormalizedName] = @__normalizedName_0
+2025-08-12 11:17:16.228 +07:00 [DBG] Context 'MyDbContext' started tracking 'Role' entity. Consider using 'DbContextOptionsBuilder.EnableSensitiveDataLogging' to see key values.
+2025-08-12 11:17:16.242 +07:00 [DBG] Closing data reader to 'capbot_db' on server 'localhost'.
+2025-08-12 11:17:16.247 +07:00 [DBG] A data reader for 'capbot_db' on server 'localhost' is being disposed after spending 42ms reading results.
+2025-08-12 11:17:16.249 +07:00 [DBG] Closing connection to database 'capbot_db' on server 'localhost'.
+2025-08-12 11:17:16.252 +07:00 [DBG] Closed connection to database 'capbot_db' on server 'localhost' (3ms).
+2025-08-12 11:17:16.260 +07:00 [DBG] Opening connection to database 'capbot_db' on server 'localhost'.
+2025-08-12 11:17:16.262 +07:00 [DBG] Opened connection to database 'capbot_db' on server 'localhost'.
+2025-08-12 11:17:16.263 +07:00 [DBG] Creating DbCommand for 'ExecuteReader'.
+2025-08-12 11:17:16.263 +07:00 [DBG] Created DbCommand for 'ExecuteReader' (0ms).
+2025-08-12 11:17:16.263 +07:00 [DBG] Initialized DbCommand for 'ExecuteReader' (0ms).
+2025-08-12 11:17:16.264 +07:00 [DBG] Executing DbCommand [Parameters=[@__normalizedName_0='?' (Size = 4000)], CommandType='"Text"', CommandTimeout='30']
+SELECT TOP(1) [r].[Id], [r].[ConcurrencyStamp], [r].[IsAdmin], [r].[Name], [r].[NormalizedName]
+FROM [roles] AS [r]
+WHERE [r].[NormalizedName] = @__normalizedName_0
+2025-08-12 11:17:16.268 +07:00 [INF] Executed DbCommand (4ms) [Parameters=[@__normalizedName_0='?' (Size = 4000)], CommandType='"Text"', CommandTimeout='30']
+SELECT TOP(1) [r].[Id], [r].[ConcurrencyStamp], [r].[IsAdmin], [r].[Name], [r].[NormalizedName]
+FROM [roles] AS [r]
+WHERE [r].[NormalizedName] = @__normalizedName_0
+2025-08-12 11:17:16.269 +07:00 [DBG] Context 'MyDbContext' started tracking 'Role' entity. Consider using 'DbContextOptionsBuilder.EnableSensitiveDataLogging' to see key values.
+2025-08-12 11:17:16.270 +07:00 [DBG] Closing data reader to 'capbot_db' on server 'localhost'.
+2025-08-12 11:17:16.270 +07:00 [DBG] A data reader for 'capbot_db' on server 'localhost' is being disposed after spending 1ms reading results.
+2025-08-12 11:17:16.271 +07:00 [DBG] Closing connection to database 'capbot_db' on server 'localhost'.
+2025-08-12 11:17:16.271 +07:00 [DBG] Closed connection to database 'capbot_db' on server 'localhost' (0ms).
+2025-08-12 11:17:16.271 +07:00 [DBG] Opening connection to database 'capbot_db' on server 'localhost'.
+2025-08-12 11:17:16.272 +07:00 [DBG] Opened connection to database 'capbot_db' on server 'localhost'.
+2025-08-12 11:17:16.272 +07:00 [DBG] Creating DbCommand for 'ExecuteReader'.
+2025-08-12 11:17:16.272 +07:00 [DBG] Created DbCommand for 'ExecuteReader' (0ms).
+2025-08-12 11:17:16.272 +07:00 [DBG] Initialized DbCommand for 'ExecuteReader' (0ms).
+2025-08-12 11:17:16.273 +07:00 [DBG] Executing DbCommand [Parameters=[@__normalizedName_0='?' (Size = 4000)], CommandType='"Text"', CommandTimeout='30']
+SELECT TOP(1) [r].[Id], [r].[ConcurrencyStamp], [r].[IsAdmin], [r].[Name], [r].[NormalizedName]
+FROM [roles] AS [r]
+WHERE [r].[NormalizedName] = @__normalizedName_0
+2025-08-12 11:17:16.274 +07:00 [INF] Executed DbCommand (2ms) [Parameters=[@__normalizedName_0='?' (Size = 4000)], CommandType='"Text"', CommandTimeout='30']
+SELECT TOP(1) [r].[Id], [r].[ConcurrencyStamp], [r].[IsAdmin], [r].[Name], [r].[NormalizedName]
+FROM [roles] AS [r]
+WHERE [r].[NormalizedName] = @__normalizedName_0
+2025-08-12 11:17:16.275 +07:00 [DBG] Context 'MyDbContext' started tracking 'Role' entity. Consider using 'DbContextOptionsBuilder.EnableSensitiveDataLogging' to see key values.
+2025-08-12 11:17:16.275 +07:00 [DBG] Closing data reader to 'capbot_db' on server 'localhost'.
+2025-08-12 11:17:16.276 +07:00 [DBG] A data reader for 'capbot_db' on server 'localhost' is being disposed after spending 0ms reading results.
+2025-08-12 11:17:16.276 +07:00 [DBG] Closing connection to database 'capbot_db' on server 'localhost'.
+2025-08-12 11:17:16.276 +07:00 [DBG] Closed connection to database 'capbot_db' on server 'localhost' (0ms).
+2025-08-12 11:17:16.276 +07:00 [DBG] Opening connection to database 'capbot_db' on server 'localhost'.
+2025-08-12 11:17:16.277 +07:00 [DBG] Opened connection to database 'capbot_db' on server 'localhost'.
+2025-08-12 11:17:16.277 +07:00 [DBG] Creating DbCommand for 'ExecuteReader'.
+2025-08-12 11:17:16.277 +07:00 [DBG] Created DbCommand for 'ExecuteReader' (0ms).
+2025-08-12 11:17:16.277 +07:00 [DBG] Initialized DbCommand for 'ExecuteReader' (0ms).
+2025-08-12 11:17:16.277 +07:00 [DBG] Executing DbCommand [Parameters=[@__normalizedName_0='?' (Size = 4000)], CommandType='"Text"', CommandTimeout='30']
+SELECT TOP(1) [r].[Id], [r].[ConcurrencyStamp], [r].[IsAdmin], [r].[Name], [r].[NormalizedName]
+FROM [roles] AS [r]
+WHERE [r].[NormalizedName] = @__normalizedName_0
+2025-08-12 11:17:16.279 +07:00 [INF] Executed DbCommand (1ms) [Parameters=[@__normalizedName_0='?' (Size = 4000)], CommandType='"Text"', CommandTimeout='30']
+SELECT TOP(1) [r].[Id], [r].[ConcurrencyStamp], [r].[IsAdmin], [r].[Name], [r].[NormalizedName]
+FROM [roles] AS [r]
+WHERE [r].[NormalizedName] = @__normalizedName_0
+2025-08-12 11:17:16.279 +07:00 [DBG] Context 'MyDbContext' started tracking 'Role' entity. Consider using 'DbContextOptionsBuilder.EnableSensitiveDataLogging' to see key values.
+2025-08-12 11:17:16.279 +07:00 [DBG] Closing data reader to 'capbot_db' on server 'localhost'.
+2025-08-12 11:17:16.280 +07:00 [DBG] A data reader for 'capbot_db' on server 'localhost' is being disposed after spending 0ms reading results.
+2025-08-12 11:17:16.280 +07:00 [DBG] Closing connection to database 'capbot_db' on server 'localhost'.
+2025-08-12 11:17:16.280 +07:00 [DBG] Closed connection to database 'capbot_db' on server 'localhost' (0ms).
+2025-08-12 11:17:16.284 +07:00 [DBG] Compiling query expression: 
+'DbSet<User>()
+    .SingleOrDefault(u => u.NormalizedEmail == __normalizedEmail_0)'
+2025-08-12 11:17:16.289 +07:00 [DBG] Generated query execution expression: 
+'queryContext => ShapedQueryCompilingExpressionVisitor.SingleOrDefaultAsync<User>(
+    asyncEnumerable: new SingleQueryingEnumerable<User>(
+        (RelationalQueryContext)queryContext, 
+        RelationalCommandCache.QueryExpression(
+            Projection Mapping:
+                EmptyProjectionMember -> Dictionary<IProperty, int> { [Property: User.Id (int) Required PK AfterSave:Throw ValueGenerated.OnAdd, 0], [Property: User.AccessFailedCount (int) Required, 1], [Property: User.ConcurrencyStamp (string), 2], [Property: User.CreatedAt (DateTime) Required, 3], [Property: User.DeletedAt (DateTime?), 4], [Property: User.Email (string), 5], [Property: User.EmailConfirmed (bool) Required, 6], [Property: User.LastModifiedAt (DateTime) Required, 7], [Property: User.LastModifiedBy (string), 8], [Property: User.LockoutEnabled (bool) Required, 9], [Property: User.LockoutEnd (DateTimeOffset?), 10], [Property: User.NormalizedEmail (string), 11], [Property: User.NormalizedUserName (string), 12], [Property: User.PasswordHash (string), 13], [Property: User.PhoneNumber (string), 14], [Property: User.PhoneNumberConfirmed (bool) Required, 15], [Property: User.SecurityStamp (string), 16], [Property: User.TwoFactorEnabled (bool) Required, 17], [Property: User.UserName (string), 18] }
+            SELECT TOP(2) u.Id, u.AccessFailedCount, u.ConcurrencyStamp, u.CreatedAt, u.DeletedAt, u.Email, u.EmailConfirmed, u.LastModifiedAt, u.LastModifiedBy, u.LockoutEnabled, u.LockoutEnd, u.NormalizedEmail, u.NormalizedUserName, u.PasswordHash, u.PhoneNumber, u.PhoneNumberConfirmed, u.SecurityStamp, u.TwoFactorEnabled, u.UserName
+            FROM users AS u
+            WHERE u.NormalizedEmail == @__normalizedEmail_0), 
+        null, 
+        Func<QueryContext, DbDataReader, ResultContext, SingleQueryResultCoordinator, User>, 
+        App.DAL.Context.MyDbContext, 
+        False, 
+        False, 
+        True
+    ), 
+    cancellationToken: queryContext.CancellationToken)'
+2025-08-12 11:17:16.291 +07:00 [DBG] Opening connection to database 'capbot_db' on server 'localhost'.
+2025-08-12 11:17:16.291 +07:00 [DBG] Opened connection to database 'capbot_db' on server 'localhost'.
+2025-08-12 11:17:16.291 +07:00 [DBG] Creating DbCommand for 'ExecuteReader'.
+2025-08-12 11:17:16.292 +07:00 [DBG] Created DbCommand for 'ExecuteReader' (0ms).
+2025-08-12 11:17:16.292 +07:00 [DBG] Initialized DbCommand for 'ExecuteReader' (0ms).
+2025-08-12 11:17:16.292 +07:00 [DBG] Executing DbCommand [Parameters=[@__normalizedEmail_0='?' (Size = 4000)], CommandType='"Text"', CommandTimeout='30']
+SELECT TOP(2) [u].[Id], [u].[AccessFailedCount], [u].[ConcurrencyStamp], [u].[CreatedAt], [u].[DeletedAt], [u].[Email], [u].[EmailConfirmed], [u].[LastModifiedAt], [u].[LastModifiedBy], [u].[LockoutEnabled], [u].[LockoutEnd], [u].[NormalizedEmail], [u].[NormalizedUserName], [u].[PasswordHash], [u].[PhoneNumber], [u].[PhoneNumberConfirmed], [u].[SecurityStamp], [u].[TwoFactorEnabled], [u].[UserName]
+FROM [users] AS [u]
+WHERE [u].[NormalizedEmail] = @__normalizedEmail_0
+2025-08-12 11:17:16.296 +07:00 [INF] Executed DbCommand (4ms) [Parameters=[@__normalizedEmail_0='?' (Size = 4000)], CommandType='"Text"', CommandTimeout='30']
+SELECT TOP(2) [u].[Id], [u].[AccessFailedCount], [u].[ConcurrencyStamp], [u].[CreatedAt], [u].[DeletedAt], [u].[Email], [u].[EmailConfirmed], [u].[LastModifiedAt], [u].[LastModifiedBy], [u].[LockoutEnabled], [u].[LockoutEnd], [u].[NormalizedEmail], [u].[NormalizedUserName], [u].[PasswordHash], [u].[PhoneNumber], [u].[PhoneNumberConfirmed], [u].[SecurityStamp], [u].[TwoFactorEnabled], [u].[UserName]
+FROM [users] AS [u]
+WHERE [u].[NormalizedEmail] = @__normalizedEmail_0
+2025-08-12 11:17:16.311 +07:00 [DBG] Context 'MyDbContext' started tracking 'User' entity. Consider using 'DbContextOptionsBuilder.EnableSensitiveDataLogging' to see key values.
+2025-08-12 11:17:16.330 +07:00 [DBG] Closing data reader to 'capbot_db' on server 'localhost'.
+2025-08-12 11:17:16.330 +07:00 [DBG] A data reader for 'capbot_db' on server 'localhost' is being disposed after spending 33ms reading results.
+2025-08-12 11:17:16.331 +07:00 [DBG] Closing connection to database 'capbot_db' on server 'localhost'.
+2025-08-12 11:17:16.331 +07:00 [DBG] Closed connection to database 'capbot_db' on server 'localhost' (0ms).
+2025-08-12 11:17:16.333 +07:00 [INF] Admin user 'fptslayer@gmail.com' already exists
+2025-08-12 11:17:16.335 +07:00 [DBG] Opening connection to database 'capbot_db' on server 'localhost'.
+2025-08-12 11:17:16.335 +07:00 [DBG] Opened connection to database 'capbot_db' on server 'localhost'.
+2025-08-12 11:17:16.335 +07:00 [DBG] Creating DbCommand for 'ExecuteReader'.
+2025-08-12 11:17:16.336 +07:00 [DBG] Created DbCommand for 'ExecuteReader' (0ms).
+2025-08-12 11:17:16.336 +07:00 [DBG] Initialized DbCommand for 'ExecuteReader' (0ms).
+2025-08-12 11:17:16.336 +07:00 [DBG] Executing DbCommand [Parameters=[@__normalizedEmail_0='?' (Size = 4000)], CommandType='"Text"', CommandTimeout='30']
+SELECT TOP(2) [u].[Id], [u].[AccessFailedCount], [u].[ConcurrencyStamp], [u].[CreatedAt], [u].[DeletedAt], [u].[Email], [u].[EmailConfirmed], [u].[LastModifiedAt], [u].[LastModifiedBy], [u].[LockoutEnabled], [u].[LockoutEnd], [u].[NormalizedEmail], [u].[NormalizedUserName], [u].[PasswordHash], [u].[PhoneNumber], [u].[PhoneNumberConfirmed], [u].[SecurityStamp], [u].[TwoFactorEnabled], [u].[UserName]
+FROM [users] AS [u]
+WHERE [u].[NormalizedEmail] = @__normalizedEmail_0
+2025-08-12 11:17:16.338 +07:00 [INF] Executed DbCommand (1ms) [Parameters=[@__normalizedEmail_0='?' (Size = 4000)], CommandType='"Text"', CommandTimeout='30']
+SELECT TOP(2) [u].[Id], [u].[AccessFailedCount], [u].[ConcurrencyStamp], [u].[CreatedAt], [u].[DeletedAt], [u].[Email], [u].[EmailConfirmed], [u].[LastModifiedAt], [u].[LastModifiedBy], [u].[LockoutEnabled], [u].[LockoutEnd], [u].[NormalizedEmail], [u].[NormalizedUserName], [u].[PasswordHash], [u].[PhoneNumber], [u].[PhoneNumberConfirmed], [u].[SecurityStamp], [u].[TwoFactorEnabled], [u].[UserName]
+FROM [users] AS [u]
+WHERE [u].[NormalizedEmail] = @__normalizedEmail_0
+2025-08-12 11:17:16.338 +07:00 [DBG] Context 'MyDbContext' started tracking 'User' entity. Consider using 'DbContextOptionsBuilder.EnableSensitiveDataLogging' to see key values.
+2025-08-12 11:17:16.338 +07:00 [DBG] Closing data reader to 'capbot_db' on server 'localhost'.
+2025-08-12 11:17:16.339 +07:00 [DBG] A data reader for 'capbot_db' on server 'localhost' is being disposed after spending 0ms reading results.
+2025-08-12 11:17:16.339 +07:00 [DBG] Closing connection to database 'capbot_db' on server 'localhost'.
+2025-08-12 11:17:16.339 +07:00 [DBG] Closed connection to database 'capbot_db' on server 'localhost' (0ms).
+2025-08-12 11:17:16.340 +07:00 [INF] Sample moderator 'moderator@example.com' already exists
+2025-08-12 11:17:16.340 +07:00 [DBG] Opening connection to database 'capbot_db' on server 'localhost'.
+2025-08-12 11:17:16.340 +07:00 [DBG] Opened connection to database 'capbot_db' on server 'localhost'.
+2025-08-12 11:17:16.341 +07:00 [DBG] Creating DbCommand for 'ExecuteReader'.
+2025-08-12 11:17:16.341 +07:00 [DBG] Created DbCommand for 'ExecuteReader' (0ms).
+2025-08-12 11:17:16.341 +07:00 [DBG] Initialized DbCommand for 'ExecuteReader' (0ms).
+2025-08-12 11:17:16.341 +07:00 [DBG] Executing DbCommand [Parameters=[@__normalizedEmail_0='?' (Size = 4000)], CommandType='"Text"', CommandTimeout='30']
+SELECT TOP(2) [u].[Id], [u].[AccessFailedCount], [u].[ConcurrencyStamp], [u].[CreatedAt], [u].[DeletedAt], [u].[Email], [u].[EmailConfirmed], [u].[LastModifiedAt], [u].[LastModifiedBy], [u].[LockoutEnabled], [u].[LockoutEnd], [u].[NormalizedEmail], [u].[NormalizedUserName], [u].[PasswordHash], [u].[PhoneNumber], [u].[PhoneNumberConfirmed], [u].[SecurityStamp], [u].[TwoFactorEnabled], [u].[UserName]
+FROM [users] AS [u]
+WHERE [u].[NormalizedEmail] = @__normalizedEmail_0
+2025-08-12 11:17:16.343 +07:00 [INF] Executed DbCommand (1ms) [Parameters=[@__normalizedEmail_0='?' (Size = 4000)], CommandType='"Text"', CommandTimeout='30']
+SELECT TOP(2) [u].[Id], [u].[AccessFailedCount], [u].[ConcurrencyStamp], [u].[CreatedAt], [u].[DeletedAt], [u].[Email], [u].[EmailConfirmed], [u].[LastModifiedAt], [u].[LastModifiedBy], [u].[LockoutEnabled], [u].[LockoutEnd], [u].[NormalizedEmail], [u].[NormalizedUserName], [u].[PasswordHash], [u].[PhoneNumber], [u].[PhoneNumberConfirmed], [u].[SecurityStamp], [u].[TwoFactorEnabled], [u].[UserName]
+FROM [users] AS [u]
+WHERE [u].[NormalizedEmail] = @__normalizedEmail_0
+2025-08-12 11:17:16.344 +07:00 [DBG] Context 'MyDbContext' started tracking 'User' entity. Consider using 'DbContextOptionsBuilder.EnableSensitiveDataLogging' to see key values.
+2025-08-12 11:17:16.344 +07:00 [DBG] Closing data reader to 'capbot_db' on server 'localhost'.
+2025-08-12 11:17:16.344 +07:00 [DBG] A data reader for 'capbot_db' on server 'localhost' is being disposed after spending 0ms reading results.
+2025-08-12 11:17:16.345 +07:00 [DBG] Closing connection to database 'capbot_db' on server 'localhost'.
+2025-08-12 11:17:16.345 +07:00 [DBG] Closed connection to database 'capbot_db' on server 'localhost' (0ms).
+2025-08-12 11:17:16.345 +07:00 [DBG] Opening connection to database 'capbot_db' on server 'localhost'.
+2025-08-12 11:17:16.346 +07:00 [DBG] Opened connection to database 'capbot_db' on server 'localhost'.
+2025-08-12 11:17:16.346 +07:00 [DBG] Creating DbCommand for 'ExecuteReader'.
+2025-08-12 11:17:16.346 +07:00 [DBG] Created DbCommand for 'ExecuteReader' (0ms).
+2025-08-12 11:17:16.346 +07:00 [DBG] Initialized DbCommand for 'ExecuteReader' (0ms).
+2025-08-12 11:17:16.347 +07:00 [DBG] Executing DbCommand [Parameters=[@__normalizedEmail_0='?' (Size = 4000)], CommandType='"Text"', CommandTimeout='30']
+SELECT TOP(2) [u].[Id], [u].[AccessFailedCount], [u].[ConcurrencyStamp], [u].[CreatedAt], [u].[DeletedAt], [u].[Email], [u].[EmailConfirmed], [u].[LastModifiedAt], [u].[LastModifiedBy], [u].[LockoutEnabled], [u].[LockoutEnd], [u].[NormalizedEmail], [u].[NormalizedUserName], [u].[PasswordHash], [u].[PhoneNumber], [u].[PhoneNumberConfirmed], [u].[SecurityStamp], [u].[TwoFactorEnabled], [u].[UserName]
+FROM [users] AS [u]
+WHERE [u].[NormalizedEmail] = @__normalizedEmail_0
+2025-08-12 11:17:16.348 +07:00 [INF] Executed DbCommand (1ms) [Parameters=[@__normalizedEmail_0='?' (Size = 4000)], CommandType='"Text"', CommandTimeout='30']
+SELECT TOP(2) [u].[Id], [u].[AccessFailedCount], [u].[ConcurrencyStamp], [u].[CreatedAt], [u].[DeletedAt], [u].[Email], [u].[EmailConfirmed], [u].[LastModifiedAt], [u].[LastModifiedBy], [u].[LockoutEnabled], [u].[LockoutEnd], [u].[NormalizedEmail], [u].[NormalizedUserName], [u].[PasswordHash], [u].[PhoneNumber], [u].[PhoneNumberConfirmed], [u].[SecurityStamp], [u].[TwoFactorEnabled], [u].[UserName]
+FROM [users] AS [u]
+WHERE [u].[NormalizedEmail] = @__normalizedEmail_0
+2025-08-12 11:17:16.348 +07:00 [DBG] Context 'MyDbContext' started tracking 'User' entity. Consider using 'DbContextOptionsBuilder.EnableSensitiveDataLogging' to see key values.
+2025-08-12 11:17:16.348 +07:00 [DBG] Closing data reader to 'capbot_db' on server 'localhost'.
+2025-08-12 11:17:16.348 +07:00 [DBG] A data reader for 'capbot_db' on server 'localhost' is being disposed after spending 0ms reading results.
+2025-08-12 11:17:16.349 +07:00 [DBG] Closing connection to database 'capbot_db' on server 'localhost'.
+2025-08-12 11:17:16.349 +07:00 [DBG] Closed connection to database 'capbot_db' on server 'localhost' (0ms).
+2025-08-12 11:17:16.349 +07:00 [INF] Data seeding completed successfully
+2025-08-12 11:17:16.351 +07:00 [DBG] 'MyDbContext' disposed.
+2025-08-12 11:17:16.353 +07:00 [DBG] Disposing connection to database 'capbot_db' on server 'localhost'.
+2025-08-12 11:17:16.356 +07:00 [DBG] Disposed connection to database '' on server '' (2ms).
+2025-08-12 11:17:16.504 +07:00 [DBG] Registered model binder providers, in the following order: ["Microsoft.AspNetCore.Mvc.ModelBinding.Binders.BinderTypeModelBinderProvider","Microsoft.AspNetCore.Mvc.ModelBinding.Binders.ServicesModelBinderProvider","Microsoft.AspNetCore.Mvc.ModelBinding.Binders.BodyModelBinderProvider","Microsoft.AspNetCore.Mvc.ModelBinding.Binders.HeaderModelBinderProvider","Microsoft.AspNetCore.Mvc.ModelBinding.Binders.FloatingPointTypeModelBinderProvider","Microsoft.AspNetCore.Mvc.ModelBinding.Binders.EnumTypeModelBinderProvider","Microsoft.AspNetCore.Mvc.ModelBinding.Binders.DateTimeModelBinderProvider","Microsoft.AspNetCore.Mvc.ModelBinding.Binders.SimpleTypeModelBinderProvider","Microsoft.AspNetCore.Mvc.ModelBinding.Binders.TryParseModelBinderProvider","Microsoft.AspNetCore.Mvc.ModelBinding.Binders.CancellationTokenModelBinderProvider"]
+2025-08-12 11:17:16.571 +07:00 [DBG] Hosting starting
+2025-08-12 11:17:16.576 +07:00 [DBG] Reading data from file 'C:\Users\Admin\AppData\Local\ASP.NET\DataProtection-Keys\key-1d6bcff1-a155-4167-8a22-de35a5f05047.xml'.
+2025-08-12 11:17:16.578 +07:00 [DBG] Reading data from file 'C:\Users\Admin\AppData\Local\ASP.NET\DataProtection-Keys\key-2459dd29-32d5-4c49-ac9d-33896047bb78.xml'.
+2025-08-12 11:17:16.579 +07:00 [DBG] Reading data from file 'C:\Users\Admin\AppData\Local\ASP.NET\DataProtection-Keys\key-374624f1-e856-4617-8ae6-fe6a81ce6346.xml'.
+2025-08-12 11:17:16.582 +07:00 [DBG] Found key {1d6bcff1-a155-4167-8a22-de35a5f05047}.
+2025-08-12 11:17:16.586 +07:00 [DBG] Found key {2459dd29-32d5-4c49-ac9d-33896047bb78}.
+2025-08-12 11:17:16.587 +07:00 [DBG] Found key {374624f1-e856-4617-8ae6-fe6a81ce6346}.
+2025-08-12 11:17:16.591 +07:00 [DBG] Considering key {2459dd29-32d5-4c49-ac9d-33896047bb78} with expiration date 2025-11-03 12:40:53Z as default key.
+2025-08-12 11:17:16.595 +07:00 [DBG] Forwarded activator type request from Microsoft.AspNetCore.DataProtection.XmlEncryption.DpapiXmlDecryptor, Microsoft.AspNetCore.DataProtection, Version=8.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60 to Microsoft.AspNetCore.DataProtection.XmlEncryption.DpapiXmlDecryptor, Microsoft.AspNetCore.DataProtection, Culture=neutral, PublicKeyToken=adb9793829ddae60
+2025-08-12 11:17:16.596 +07:00 [DBG] Decrypting secret element using Windows DPAPI.
+2025-08-12 11:17:16.600 +07:00 [DBG] Forwarded activator type request from Microsoft.AspNetCore.DataProtection.AuthenticatedEncryption.ConfigurationModel.AuthenticatedEncryptorDescriptorDeserializer, Microsoft.AspNetCore.DataProtection, Version=8.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60 to Microsoft.AspNetCore.DataProtection.AuthenticatedEncryption.ConfigurationModel.AuthenticatedEncryptorDescriptorDeserializer, Microsoft.AspNetCore.DataProtection, Culture=neutral, PublicKeyToken=adb9793829ddae60
+2025-08-12 11:17:16.603 +07:00 [DBG] Opening CNG algorithm 'AES' from provider 'null' with chaining mode CBC.
+2025-08-12 11:17:16.604 +07:00 [DBG] Opening CNG algorithm 'SHA256' from provider 'null' with HMAC.
+2025-08-12 11:17:16.605 +07:00 [DBG] Using key {2459dd29-32d5-4c49-ac9d-33896047bb78} as the default key.
+2025-08-12 11:17:16.606 +07:00 [DBG] Key ring with default key {2459dd29-32d5-4c49-ac9d-33896047bb78} was loaded during application startup.
+2025-08-12 11:17:16.706 +07:00 [INF] Now listening on: https://localhost:7190
+2025-08-12 11:17:16.706 +07:00 [DBG] Loaded hosting startup assembly CapBot.api
+2025-08-12 11:17:16.707 +07:00 [DBG] Loaded hosting startup assembly Microsoft.WebTools.ApiEndpointDiscovery
+2025-08-12 11:17:16.707 +07:00 [DBG] Loaded hosting startup assembly Microsoft.AspNetCore.Watch.BrowserRefresh
+2025-08-12 11:17:16.707 +07:00 [DBG] Loaded hosting startup assembly Microsoft.WebTools.BrowserLink.Net
+2025-08-12 11:17:16.765 +07:00 [INF] Application started. Press Ctrl+C to shut down.
+2025-08-12 11:17:16.765 +07:00 [INF] Hosting environment: Development
+2025-08-12 11:17:16.766 +07:00 [INF] Content root path: C:\Users\Admin\Downloads\CBAI_API\CapBot.api
+2025-08-12 11:17:16.766 +07:00 [DBG] Hosting started
+2025-08-12 11:17:16.831 +07:00 [DBG] Connection id "0HNEPASFM248R" received FIN.
+2025-08-12 11:17:16.844 +07:00 [DBG] Connection id "0HNEPASFM248R" accepted.
+2025-08-12 11:17:16.845 +07:00 [DBG] Connection id "0HNEPASFM248R" started.
+2025-08-12 11:17:16.866 +07:00 [DBG] Failed to authenticate HTTPS connection.
+System.IO.IOException: Received an unexpected EOF or 0 bytes from the transport stream.
+   at System.Net.Security.SslStream.ReceiveHandshakeFrameAsync[TIOAdapter](CancellationToken cancellationToken)
+   at System.Net.Security.SslStream.ForceAuthenticationAsync[TIOAdapter](Boolean receiveFirst, Byte[] reAuthenticationData, CancellationToken cancellationToken)
+   at System.Net.Security.SslStream.ProcessAuthenticationWithTelemetryAsync(Boolean isAsync, CancellationToken cancellationToken)
+   at Microsoft.AspNetCore.Server.Kestrel.Https.Internal.HttpsConnectionMiddleware.OnConnectionAsync(ConnectionContext context)
+2025-08-12 11:17:16.880 +07:00 [DBG] Connection id "0HNEPASFM248R" stopped.
+2025-08-12 11:17:16.884 +07:00 [DBG] Connection id "0HNEPASFM248R" sending FIN because: "The Socket transport's send loop completed gracefully."
+2025-08-12 11:17:16.923 +07:00 [DBG] Connection id "0HNEPASFM248S" accepted.
+2025-08-12 11:17:16.923 +07:00 [DBG] Connection id "0HNEPASFM248S" started.
+2025-08-12 11:17:16.997 +07:00 [DBG] Connection 0HNEPASFM248S established using the following protocol: "Tls13"
+2025-08-12 11:17:17.057 +07:00 [INF] Request starting HTTP/2 GET https://localhost:7190/index.html - null null
+2025-08-12 11:17:17.091 +07:00 [DBG] Wildcard detected, all requests with hosts will be allowed.
+2025-08-12 11:17:17.119 +07:00 [DBG] Response markup is scheduled to include Browser Link script injection.
+2025-08-12 11:17:17.121 +07:00 [DBG] Response markup is scheduled to include browser refresh script injection.
+2025-08-12 11:17:17.140 +07:00 [DBG] Response markup was updated to include Browser Link script injection.
+2025-08-12 11:17:17.141 +07:00 [DBG] Response markup was updated to include browser refresh script injection.
+2025-08-12 11:17:17.146 +07:00 [INF] Request starting HTTP/2 GET https://localhost:7190/_framework/aspnetcore-browser-refresh.js - null null
+2025-08-12 11:17:17.146 +07:00 [INF] Request starting HTTP/2 GET https://localhost:7190/_vs/browserLink - null null
+2025-08-12 11:17:17.146 +07:00 [INF] Request finished HTTP/2 GET https://localhost:7190/index.html - 200 null text/html;charset=utf-8 92.9715ms
+2025-08-12 11:17:17.157 +07:00 [INF] Request finished HTTP/2 GET https://localhost:7190/_framework/aspnetcore-browser-refresh.js - 200 13756 application/javascript; charset=utf-8 10.5044ms
+2025-08-12 11:17:17.191 +07:00 [INF] Request finished HTTP/2 GET https://localhost:7190/_vs/browserLink - 200 null text/javascript; charset=UTF-8 45.0991ms
+2025-08-12 11:17:17.214 +07:00 [INF] Request starting HTTP/2 GET https://localhost:7190/swagger/v1/swagger.json - null null
+2025-08-12 11:17:17.243 +07:00 [INF] Request finished HTTP/2 GET https://localhost:7190/swagger/v1/swagger.json - 200 null application/json;charset=utf-8 29.0731ms
+2025-08-12 11:17:55.363 +07:00 [INF] Application is shutting down...
+2025-08-12 11:17:55.365 +07:00 [DBG] Hosting stopping
+2025-08-12 11:17:55.393 +07:00 [DBG] Connection id "0HNEPASFM248S" is closing.
+2025-08-12 11:17:55.395 +07:00 [DBG] Connection id "0HNEPASFM248S" is closed. The last processed stream ID was 7.
+2025-08-12 11:17:55.397 +07:00 [DBG] Connection id "0HNEPASFM248S" received FIN.
+2025-08-12 11:17:55.399 +07:00 [DBG] Connection id "0HNEPASFM248S" sending FIN because: "The Socket transport's send loop completed gracefully."
+2025-08-12 11:17:55.421 +07:00 [DBG] The connection queue processing loop for 0HNEPASFM248S completed.
+2025-08-12 11:17:55.423 +07:00 [DBG] Connection id "0HNEPASFM248S" stopped.
+2025-08-12 11:17:55.428 +07:00 [DBG] Hosting stopped

--- a/CapBot.api/ServiceConfiguration/ServiceConfig.cs
+++ b/CapBot.api/ServiceConfiguration/ServiceConfig.cs
@@ -57,5 +57,6 @@ public class ServiceConfig
         services.AddScoped<IReviewerAssignmentService, ReviewerAssignmentService>();
 
         services.AddScoped<ISkillMatchingService, SkillMatchingService>();
+        services.AddScoped<IPerformanceMatchingService, PerformanceMatchingService>();
     }
 }

--- a/CapBot.api/ServiceConfiguration/ServiceConfig.cs
+++ b/CapBot.api/ServiceConfiguration/ServiceConfig.cs
@@ -25,6 +25,7 @@ public class ServiceConfig
 
         //register service
         services.AddScoped<IAuthService, AuthService>();
+        services.AddScoped<IAccountService, AccountService>();
 
         //SignalR Service
         services.AddSignalR();

--- a/CapBot.api/work-flow.md
+++ b/CapBot.api/work-flow.md
@@ -1,0 +1,247 @@
+﻿# 📊 WORKFLOW CỦA HỆ THỐNG TOPIC MANAGEMENT
+
+## 🏗️ KIẾN TRÚC TỔNG QUAN
+
+```mermaid
+graph TB
+    subgraph "ENTITIES"
+        TC[TopicCategory]
+        S[Semester]
+        T[Topic]
+        TV[TopicVersion]
+        SUB[Submission]
+        P[Phase]
+    end
+
+    subgraph "RELATIONSHIPS"
+        TC -->|1:N| T
+        S -->|1:N| T
+        T -->|1:N| TV
+        TV -->|1:N| SUB
+        S -->|1:N| P
+        SUB -->|N:1| P
+    end
+```
+
+## 🔄 WORKFLOW CHI TIẾT
+
+### 1. **SETUP PHASE - Chuẩn bị hệ thống**
+
+```mermaid
+graph LR
+    A[Admin tạo TopicCategory] --> B[Admin tạo Semester]
+    B --> C[Hệ thống sẵn sàng]
+```
+
+**APIs:**
+
+- `POST /api/topic-category/create` (Admin only)
+- `POST /api/semester/create` (Admin only)
+
+---
+
+### 2. **TOPIC CREATION WORKFLOW - Tạo chủ đề**
+
+```mermaid
+sequenceDiagram
+    participant S as Supervisor
+    participant API as Topic API
+    participant DB as Database
+
+    S->>API: POST /api/topic/create
+    API->>DB: Validate Category & Semester
+    API->>DB: Create Topic (IsApproved=false)
+    API->>DB: Create TopicVersion v1 (Status=Draft)
+    DB-->>API: Success
+    API-->>S: Created Topic + Version
+```
+
+**Quy trình:**
+
+1. Supervisor tạo Topic với thông tin cơ bản
+2. Hệ thống tự động tạo TopicVersion đầu tiên (v1) với status `Draft`
+3. Topic được tạo với `IsApproved = false`
+
+---
+
+### 3. **TOPIC VERSION LIFECYCLE - Vòng đời phiên bản**
+
+```mermaid
+stateDiagram-v2
+    [*] --> Draft: Create Version
+    Draft --> Submitted: Submit for Review
+    Submitted --> Approved: Admin/Reviewer Approve
+    Submitted --> Rejected: Admin/Reviewer Reject
+    Submitted --> RevisionRequired: Need Changes
+    RevisionRequired --> Draft: Create New Version
+    Approved --> [*]: Final State
+    Rejected --> [*]: Final State
+    Draft --> [*]: Delete (Draft only)
+```
+
+**Status Flow:**
+
+- **Draft**: Supervisor có thể edit/update/delete
+- **Submitted**: Chờ review, không thể edit
+- **Approved**: Được phê duyệt, không thể thay đổi
+- **Rejected**: Bị từ chối, có thể tạo version mới
+- **RevisionRequired**: Cần chỉnh sửa, có thể tạo version mới
+
+---
+
+### 4. **DETAILED API WORKFLOW**
+
+#### 🎯 **A. Supervisor Workflow**
+
+```mermaid
+graph TD
+    A[Supervisor Login] --> B[Create Topic]
+    B --> C[Topic Created with Version 1 Draft]
+    C --> D[Edit Version if needed]
+    D --> E[Submit Version for Review]
+    E --> F{Review Result}
+    F -->|Approved| G[Topic Approved]
+    F -->|Rejected| H[Create New Version]
+    F -->|Revision Required| H
+    H --> D
+```
+
+**APIs cho Supervisor:**
+
+- `POST /api/topic/create` - Tạo topic mới
+- `GET /api/topic/my-topics` - Xem topics của mình
+- `PUT /api/topic/update` - Cập nhật thông tin cơ bản topic
+- `POST /api/topic-version/create` - Tạo version mới
+- `PUT /api/topic-version/update` - Cập nhật version (chỉ Draft)
+- `POST /api/topic-version/submit` - Submit version để review
+- `DELETE /api/topic-version/delete/{id}` - Xóa version Draft
+
+#### 🎯 **B. Admin/Reviewer Workflow**
+
+```mermaid
+graph TD
+    A[Admin/Reviewer Login] --> B[View Submitted Versions]
+    B --> C[Review Version Details]
+    C --> D{Decision}
+    D -->|Approve| E[Set Status = Approved]
+    D -->|Reject| F[Set Status = Rejected]
+    D -->|Need Changes| G[Set Status = RevisionRequired]
+    E --> H[Approve Topic if needed]
+```
+
+**APIs cho Admin/Reviewer:**
+
+- `GET /api/topic/list` - Xem tất cả topics
+- `GET /api/topic-version/history/{topicId}` - Xem lịch sử versions
+- `POST /api/topic-version/review` - Review version
+- `POST /api/topic/approve/{id}` - Approve topic
+- `DELETE /api/topic/delete/{id}` - Xóa topic (Admin only)
+
+#### 🎯 **C. Student/Public Workflow**
+
+```mermaid
+graph TD
+    A[User Login] --> B[Browse Topics]
+    B --> C[Filter by Semester/Category]
+    C --> D[View Topic Details]
+    D --> E[View Current Version]
+```
+
+**APIs cho Users:**
+
+- `GET /api/topic/list` - Xem danh sách topics
+- `GET /api/topic/detail/{id}` - Xem chi tiết topic
+- `GET /api/topic-version/detail/{id}` - Xem chi tiết version
+
+---
+
+### 5. **BUSINESS RULES & PERMISSIONS**
+
+#### 📋 **Permission Matrix**
+
+| Action         | Supervisor           | Admin | Reviewer | Student |
+| -------------- | -------------------- | ----- | -------- | ------- |
+| Create Topic   | ✅ (own)             | ✅    | ❌       | ❌      |
+| Update Topic   | ✅ (own)             | ✅    | ❌       | ❌      |
+| Delete Topic   | ❌                   | ✅    | ❌       | ❌      |
+| Approve Topic  | ❌                   | ✅    | ✅       | ❌      |
+| Create Version | ✅ (own topic)       | ❌    | ❌       | ❌      |
+| Update Version | ✅ (own, Draft only) | ❌    | ❌       | ❌      |
+| Submit Version | ✅ (own)             | ❌    | ❌       | ❌      |
+| Review Version | ❌                   | ✅    | ✅       | ❌      |
+| View Topics    | ✅                   | ✅    | ✅       | ✅      |
+
+#### 🔒 **Business Rules**
+
+1. **Topic Creation**: Tự động tạo Version 1 với status Draft
+2. **Version Editing**: Chỉ Draft versions có thể edit
+3. **Version Submission**: Chỉ Draft versions có thể submit
+4. **Version Review**: Chỉ Submitted versions có thể review
+5. **Version Deletion**: Chỉ Draft versions có thể delete
+6. **Topic Approval**: Admin có thể approve topic bất kỳ lúc nào
+7. **Version Numbering**: Tự động increment (1, 2, 3, ...)
+
+---
+
+### 6. **API ENDPOINTS SUMMARY**
+
+#### 🏷️ **Topic Management**
+
+```
+POST   /api/topic/create              # Tạo topic mới
+GET    /api/topic/list                # Danh sách topics với paging
+GET    /api/topic/detail/{id}         # Chi tiết topic
+PUT    /api/topic/update              # Cập nhật topic
+DELETE /api/topic/delete/{id}         # Xóa topic (Admin)
+POST   /api/topic/approve/{id}        # Approve topic (Admin)
+GET    /api/topic/my-topics           # Topics của supervisor
+```
+
+#### 📝 **Topic Version Management**
+
+```
+POST   /api/topic-version/create      # Tạo version mới
+PUT    /api/topic-version/update      # Cập nhật version
+GET    /api/topic-version/history/{topicId}  # Lịch sử versions
+GET    /api/topic-version/detail/{id} # Chi tiết version
+POST   /api/topic-version/submit      # Submit version
+POST   /api/topic-version/review      # Review version
+DELETE /api/topic-version/delete/{id} # Xóa version
+```
+
+#### 📂 **Topic Category Management**
+
+```
+POST   /api/topic-category/create     # Tạo category (Admin)
+GET    /api/topic-category/all        # Danh sách categories
+PUT    /api/topic-category/update     # Cập nhật category (Admin)
+DELETE /api/topic-category/delete/{id} # Xóa category (Admin)
+```
+
+---
+
+### 7. **INTEGRATION POINTS**
+
+#### 🔗 **Related Systems**
+
+- **Semester Management**: Topics thuộc về Semesters
+- **User Management**: Supervisor, Admin, Reviewer roles
+- **Submission System**: TopicVersions có Submissions
+- **Phase Management**: Submissions thuộc về Phases
+- **Review System**: Versions được review qua workflow
+
+#### 📊 **Data Flow**
+
+```
+TopicCategory → Topic → TopicVersion → Submission → Review
+      ↑           ↑         ↑            ↑          ↑
+   (Admin)   (Supervisor) (Supervisor) (Student) (Reviewer)
+```
+
+Workflow này đảm bảo:
+
+- **Tính nhất quán**: Mỗi Topic có ít nhất 1 Version
+- **Kiểm soát chất lượng**: Workflow approval rõ ràng
+- **Phân quyền rõ ràng**: Mỗi role có permissions phù hợp
+- **Truy xuất nguồn gốc**: Audit trail đầy đủ
+- **Tính linh hoạt**: Có thể tạo nhiều versions để cải thiện


### PR DESCRIPTION
This pull request refactors the reviewer auto-assignment logic to prioritize performance-based matching over skill-based matching. The main changes introduce a new `PerformanceMatchingService` that calculates reviewer scores based on reliability, efficiency, consistency, and workload, and updates the reviewer assignment workflow to use these scores for recommending and assigning reviewers.

**Performance-based reviewer assignment:**

* Added new `PerformanceMatchingService` (`App.BLL/Implementations/PerformanceMatchingService.cs`) that calculates overall reviewer performance scores and finds best-performing reviewers based on reliability, efficiency, consistency, and workload metrics.
* Updated `ReviewerAssignmentService` to use `PerformanceMatchingService` for auto-assigning reviewers and recommending reviewers, replacing previous skill-based logic. This includes changes to constructor dependency injection and method calls. [[1]](diffhunk://#diff-26e0313dd9fea37043069b6c831b98b26bc09a79286c9ddbf56e8b054f861d54R21-R30) [[2]](diffhunk://#diff-26e0313dd9fea37043069b6c831b98b26bc09a79286c9ddbf56e8b054f861d54L606-R620) [[3]](diffhunk://#diff-26e0313dd9fea37043069b6c831b98b26bc09a79286c9ddbf56e8b054f861d54L708-R716)

**Assignment workflow and messaging updates:**

* Changed assignment result messages and warnings to clarify that assignments are now based on performance rather than skill matching. [[1]](diffhunk://#diff-26e0313dd9fea37043069b6c831b98b26bc09a79286c9ddbf56e8b054f861d54L628-R629) [[2]](diffhunk://#diff-26e0313dd9fea37043069b6c831b98b26bc09a79286c9ddbf56e8b054f861d54L638-R639) [[3]](diffhunk://#diff-26e0313dd9fea37043069b6c831b98b26bc09a79286c9ddbf56e8b054f861d54L684-R687)
* Updated assignment details to use performance scores and added notes about performance-based assignment in reviewer assignment records.

**Skill matching service adjustments:**

* Modified `SkillMatchingService` to always extract topic skill tags from the submission and removed reliance on skill tags from the DTO, as skill-based assignment is now secondary. [[1]](diffhunk://#diff-ce5d47d8638f12e71c54f278202f4503632659b3a71edc0efe8b8a0f1e2f986bR112-R117) [[2]](diffhunk://#diff-ce5d47d8638f12e71c54f278202f4503632659b3a71edc0efe8b8a0f1e2f986bL174-R174)

**Other:**

* Added new `AccountService` implementation for retrieving user roles (not directly related to reviewer assignment changes).