### PR TITLE
Fix: error 500 when review with score = 100

### DIFF
--- a/App.DAL/Context/MyDbContext.cs
+++ b/App.DAL/Context/MyDbContext.cs
@@ -424,7 +424,7 @@ public partial class MyDbContext : IdentityDbContext<User, Role, int, UserClaim,
             entity.ToTable("review_criteria_scores");
             entity.HasKey(e => e.Id);
             entity.Property(e => e.Id).ValueGeneratedOnAdd();
-            entity.Property(e => e.Score).HasPrecision(4, 2).IsRequired();
+            entity.Property(e => e.Score).HasPrecision(6, 2).IsRequired();
             entity.Property(e => e.CreatedAt).HasDefaultValueSql("CURRENT_TIMESTAMP");
 
             entity.HasOne(d => d.Review)

--- a/App.DAL/Migrations/20250926230845_FixScoreInReviewCriteriaScore.Designer.cs
+++ b/App.DAL/Migrations/20250926230845_FixScoreInReviewCriteriaScore.Designer.cs
@@ -4,6 +4,7 @@ using App.DAL.Context;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace App.DAL.Migrations
 {
     [DbContext(typeof(MyDbContext))]
-    partial class MyDbContextModelSnapshot : ModelSnapshot
+    [Migration("20250926230845_FixScoreInReviewCriteriaScore")]
+    partial class FixScoreInReviewCriteriaScore
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/App.DAL/Migrations/20250926230845_FixScoreInReviewCriteriaScore.cs
+++ b/App.DAL/Migrations/20250926230845_FixScoreInReviewCriteriaScore.cs
@@ -1,0 +1,44 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace App.DAL.Migrations
+{
+    /// <inheritdoc />
+    public partial class FixScoreInReviewCriteriaScore : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+
+            migrationBuilder.AlterColumn<decimal>(
+                name: "Score",
+                table: "review_criteria_scores",
+                type: "decimal(6,2)",
+                precision: 6,
+                scale: 2,
+                nullable: false,
+                oldClrType: typeof(decimal),
+                oldType: "decimal(4,2)",
+                oldPrecision: 4,
+                oldScale: 2);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            
+            migrationBuilder.AlterColumn<decimal>(
+                name: "Score",
+                table: "review_criteria_scores",
+                type: "decimal(4,2)",
+                precision: 4,
+                scale: 2,
+                nullable: false,
+                oldClrType: typeof(decimal),
+                oldType: "decimal(6,2)",
+                oldPrecision: 6,
+                oldScale: 2);
+        }
+    }
+}

--- a/CapBot.api/Logs/log20250927.txt
+++ b/CapBot.api/Logs/log20250927.txt
@@ -9928,3 +9928,1258 @@ WHERE [e].[EntityId] = @__p_0 AND [e].[EntityType] = 2 AND [e].[IsPrimary] = CAS
 2025-09-27 04:41:07.659 +07:00 [DBG] Ending HttpMessageHandler cleanup cycle after 0.0031ms - processed: 0 items - remaining: 1 items
 2025-09-27 04:41:17.674 +07:00 [DBG] Starting HttpMessageHandler cleanup cycle with 1 items
 2025-09-27 04:41:17.675 +07:00 [DBG] Ending HttpMessageHandler cleanup cycle after 0.0058ms - processed: 0 items - remaining: 1 items
+2025-09-27 06:07:15.665 +07:00 [DBG] An 'IServiceProvider' was created for internal use by Entity Framework.
+2025-09-27 06:07:15.874 +07:00 [DBG] No relationship from 'ReviewerAssignment' to 'User' has been configured by convention because there are multiple properties on one entity type - {'AssignedByUser', 'Reviewer'} that could be matched with the properties on the other entity type - {'ReviewerAssignments'}. This message can be disregarded if explicit configuration has been specified in 'OnModelCreating'.
+2025-09-27 06:07:15.893 +07:00 [DBG] No relationship from 'SubmissionWorkflowLog' to 'WorkflowState' has been configured by convention because there are multiple properties on one entity type - {'FromState', 'ToState'} that could be matched with the properties on the other entity type - {'FromStateLogs', 'ToStateLogs'}. This message can be disregarded if explicit configuration has been specified in 'OnModelCreating'.
+2025-09-27 06:07:15.905 +07:00 [DBG] No relationship from 'User' to 'ReviewerAssignment' has been configured by convention because there are multiple properties on one entity type - {'ReviewerAssignments'} that could be matched with the properties on the other entity type - {'AssignedByUser', 'Reviewer'}. This message can be disregarded if explicit configuration has been specified in 'OnModelCreating'.
+2025-09-27 06:07:15.907 +07:00 [DBG] No relationship from 'WorkflowState' to 'SubmissionWorkflowLog' has been configured by convention because there are multiple properties on one entity type - {'FromStateLogs', 'ToStateLogs'} that could be matched with the properties on the other entity type - {'FromState', 'ToState'}. This message can be disregarded if explicit configuration has been specified in 'OnModelCreating'.
+2025-09-27 06:07:15.907 +07:00 [DBG] No relationship from 'WorkflowState' to 'WorkflowTransition' has been configured by convention because there are multiple properties on one entity type - {'FromTransitions', 'ToTransitions'} that could be matched with the properties on the other entity type - {'FromState', 'ToState'}. This message can be disregarded if explicit configuration has been specified in 'OnModelCreating'.
+2025-09-27 06:07:15.908 +07:00 [DBG] No relationship from 'WorkflowTransition' to 'WorkflowState' has been configured by convention because there are multiple properties on one entity type - {'FromState', 'ToState'} that could be matched with the properties on the other entity type - {'FromTransitions', 'ToTransitions'}. This message can be disregarded if explicit configuration has been specified in 'OnModelCreating'.
+2025-09-27 06:07:16.072 +07:00 [DBG] No relationship from 'ReviewerAssignment' to 'User' has been configured by convention because there are multiple properties on one entity type - {'AssignedByUser', 'Reviewer'} that could be matched with the properties on the other entity type - {'ReviewerAssignments'}. This message can be disregarded if explicit configuration has been specified in 'OnModelCreating'.
+2025-09-27 06:07:16.073 +07:00 [DBG] No relationship from 'User' to 'ReviewerAssignment' has been configured by convention because there are multiple properties on one entity type - {'ReviewerAssignments'} that could be matched with the properties on the other entity type - {'AssignedByUser', 'Reviewer'}. This message can be disregarded if explicit configuration has been specified in 'OnModelCreating'.
+2025-09-27 06:07:16.089 +07:00 [DBG] No relationship from 'WorkflowTransition' to 'WorkflowState' has been configured by convention because there are multiple properties on one entity type - {'FromState', 'ToState'} that could be matched with the properties on the other entity type - {'FromTransitions', 'ToTransitions'}. This message can be disregarded if explicit configuration has been specified in 'OnModelCreating'.
+2025-09-27 06:07:16.090 +07:00 [DBG] No relationship from 'WorkflowState' to 'SubmissionWorkflowLog' has been configured by convention because there are multiple properties on one entity type - {'FromStateLogs', 'ToStateLogs'} that could be matched with the properties on the other entity type - {'FromState', 'ToState'}. This message can be disregarded if explicit configuration has been specified in 'OnModelCreating'.
+2025-09-27 06:07:16.091 +07:00 [DBG] No relationship from 'WorkflowState' to 'WorkflowTransition' has been configured by convention because there are multiple properties on one entity type - {'FromTransitions', 'ToTransitions'} that could be matched with the properties on the other entity type - {'FromState', 'ToState'}. This message can be disregarded if explicit configuration has been specified in 'OnModelCreating'.
+2025-09-27 06:07:16.093 +07:00 [DBG] No relationship from 'WorkflowState' to 'SubmissionWorkflowLog' has been configured by convention because there are multiple properties on one entity type - {'FromStateLogs', 'ToStateLogs'} that could be matched with the properties on the other entity type - {'FromState', 'ToState'}. This message can be disregarded if explicit configuration has been specified in 'OnModelCreating'.
+2025-09-27 06:07:16.096 +07:00 [DBG] No relationship from 'SubmissionWorkflowLog' to 'WorkflowState' has been configured by convention because there are multiple properties on one entity type - {'FromState', 'ToState'} that could be matched with the properties on the other entity type - {'FromStateLogs', 'ToStateLogs'}. This message can be disregarded if explicit configuration has been specified in 'OnModelCreating'.
+2025-09-27 06:07:16.097 +07:00 [DBG] No relationship from 'WorkflowState' to 'SubmissionWorkflowLog' has been configured by convention because there are multiple properties on one entity type - {'FromStateLogs', 'ToStateLogs'} that could be matched with the properties on the other entity type - {'FromState', 'ToState'}. This message can be disregarded if explicit configuration has been specified in 'OnModelCreating'.
+2025-09-27 06:07:16.143 +07:00 [DBG] The index {'LecturerId'} was not created on entity type 'LecturerSkill' as the properties are already covered by the index {'LecturerId', 'SkillTag'}.
+2025-09-27 06:07:16.144 +07:00 [DBG] The index {'SemesterId'} was not created on entity type 'Phase' as the properties are already covered by the index {'SemesterId', 'PhaseTypeId'}.
+2025-09-27 06:07:16.144 +07:00 [DBG] The index {'AssignmentId'} was not created on entity type 'Review' as the properties are already covered by the index {'AssignmentId', 'Status'}.
+2025-09-27 06:07:16.145 +07:00 [DBG] The index {'ReviewId'} was not created on entity type 'ReviewComment' as the properties are already covered by the index {'ReviewId', 'SectionName'}.
+2025-09-27 06:07:16.145 +07:00 [DBG] The index {'ReviewId'} was not created on entity type 'ReviewCriteriaScore' as the properties are already covered by the index {'ReviewId', 'CriteriaId'}.
+2025-09-27 06:07:16.145 +07:00 [DBG] The index {'ReviewerId'} was not created on entity type 'ReviewerAssignment' as the properties are already covered by the index {'ReviewerId', 'Status'}.
+2025-09-27 06:07:16.146 +07:00 [DBG] The index {'SubmissionId'} was not created on entity type 'ReviewerAssignment' as the properties are already covered by the index {'SubmissionId', 'ReviewerId'}.
+2025-09-27 06:07:16.146 +07:00 [DBG] The index {'ReviewerId'} was not created on entity type 'ReviewerPerformance' as the properties are already covered by the index {'ReviewerId', 'SemesterId'}.
+2025-09-27 06:07:16.147 +07:00 [DBG] The index {'PhaseId'} was not created on entity type 'Submission' as the properties are already covered by the index {'PhaseId', 'Status'}.
+2025-09-27 06:07:16.147 +07:00 [DBG] The index {'PhaseId'} was not created on entity type 'Submission' as the properties are already covered by the index {'PhaseId', 'Status', 'SubmittedAt'}.
+2025-09-27 06:07:16.147 +07:00 [DBG] The index {'TopicId'} was not created on entity type 'Submission' as the properties are already covered by the index {'TopicId', 'PhaseId', 'SubmissionRound'}.
+2025-09-27 06:07:16.148 +07:00 [DBG] The index {'SubmissionId'} was not created on entity type 'SubmissionWorkflowLog' as the properties are already covered by the index {'SubmissionId', 'CreatedAt'}.
+2025-09-27 06:07:16.149 +07:00 [DBG] The index {'UserId'} was not created on entity type 'SystemNotification' as the properties are already covered by the index {'UserId', 'IsRead', 'CreatedAt'}.
+2025-09-27 06:07:16.150 +07:00 [DBG] The index {'SemesterId'} was not created on entity type 'Topic' as the properties are already covered by the index {'SemesterId', 'IsApproved'}.
+2025-09-27 06:07:16.151 +07:00 [DBG] The index {'SupervisorId'} was not created on entity type 'Topic' as the properties are already covered by the index {'SupervisorId', 'SemesterId'}.
+2025-09-27 06:07:16.151 +07:00 [DBG] The index {'TopicId'} was not created on entity type 'TopicVersion' as the properties are already covered by the index {'TopicId', 'Status'}.
+2025-09-27 06:07:16.152 +07:00 [DBG] The index {'TopicId'} was not created on entity type 'TopicVersion' as the properties are already covered by the index {'TopicId', 'VersionNumber'}.
+2025-09-27 06:07:16.152 +07:00 [DBG] The index {'UserId'} was not created on entity type 'UserRole' as the properties are already covered by the index {'UserId', 'RoleId'}.
+2025-09-27 06:07:16.153 +07:00 [DBG] The index {'UserId'} was not created on entity type 'UserToken' as the properties are already covered by the index {'UserId', 'LoginProvider', 'Name'}.
+2025-09-27 06:07:16.291 +07:00 [WRN] The 'ProficiencyLevels' property 'ProficiencyLevel' on entity type 'LecturerSkill' is configured with a database-generated default, but has no configured sentinel value. The database-generated default will always be used for inserts when the property has the value '0', since this is the CLR default for the 'ProficiencyLevels' type. Consider using a nullable type, using a nullable backing field, or setting the sentinel value for the property to ensure the database default is used when, and only when, appropriate. See https://aka.ms/efcore-docs-default-values for more information.
+2025-09-27 06:07:16.291 +07:00 [WRN] The 'ReviewRecommendations' property 'Recommendation' on entity type 'Review' is configured with a database-generated default, but has no configured sentinel value. The database-generated default will always be used for inserts when the property has the value '0', since this is the CLR default for the 'ReviewRecommendations' type. Consider using a nullable type, using a nullable backing field, or setting the sentinel value for the property to ensure the database default is used when, and only when, appropriate. See https://aka.ms/efcore-docs-default-values for more information.
+2025-09-27 06:07:16.292 +07:00 [WRN] The 'ReviewStatus' property 'Status' on entity type 'Review' is configured with a database-generated default, but has no configured sentinel value. The database-generated default will always be used for inserts when the property has the value '0', since this is the CLR default for the 'ReviewStatus' type. Consider using a nullable type, using a nullable backing field, or setting the sentinel value for the property to ensure the database default is used when, and only when, appropriate. See https://aka.ms/efcore-docs-default-values for more information.
+2025-09-27 06:07:16.293 +07:00 [WRN] The 'CommentTypes' property 'CommentType' on entity type 'ReviewComment' is configured with a database-generated default, but has no configured sentinel value. The database-generated default will always be used for inserts when the property has the value '0', since this is the CLR default for the 'CommentTypes' type. Consider using a nullable type, using a nullable backing field, or setting the sentinel value for the property to ensure the database default is used when, and only when, appropriate. See https://aka.ms/efcore-docs-default-values for more information.
+2025-09-27 06:07:16.293 +07:00 [WRN] The 'PriorityLevels' property 'Priority' on entity type 'ReviewComment' is configured with a database-generated default, but has no configured sentinel value. The database-generated default will always be used for inserts when the property has the value '0', since this is the CLR default for the 'PriorityLevels' type. Consider using a nullable type, using a nullable backing field, or setting the sentinel value for the property to ensure the database default is used when, and only when, appropriate. See https://aka.ms/efcore-docs-default-values for more information.
+2025-09-27 06:07:16.294 +07:00 [WRN] The 'AssignmentTypes' property 'AssignmentType' on entity type 'ReviewerAssignment' is configured with a database-generated default, but has no configured sentinel value. The database-generated default will always be used for inserts when the property has the value '0', since this is the CLR default for the 'AssignmentTypes' type. Consider using a nullable type, using a nullable backing field, or setting the sentinel value for the property to ensure the database default is used when, and only when, appropriate. See https://aka.ms/efcore-docs-default-values for more information.
+2025-09-27 06:07:16.294 +07:00 [WRN] The 'AssignmentStatus' property 'Status' on entity type 'ReviewerAssignment' is configured with a database-generated default, but has no configured sentinel value. The database-generated default will always be used for inserts when the property has the value '0', since this is the CLR default for the 'AssignmentStatus' type. Consider using a nullable type, using a nullable backing field, or setting the sentinel value for the property to ensure the database default is used when, and only when, appropriate. See https://aka.ms/efcore-docs-default-values for more information.
+2025-09-27 06:07:16.295 +07:00 [WRN] The 'AiCheckStatus' property 'AiCheckStatus' on entity type 'Submission' is configured with a database-generated default, but has no configured sentinel value. The database-generated default will always be used for inserts when the property has the value '0', since this is the CLR default for the 'AiCheckStatus' type. Consider using a nullable type, using a nullable backing field, or setting the sentinel value for the property to ensure the database default is used when, and only when, appropriate. See https://aka.ms/efcore-docs-default-values for more information.
+2025-09-27 06:07:16.295 +07:00 [WRN] The 'SubmissionStatus' property 'Status' on entity type 'Submission' is configured with a database-generated default, but has no configured sentinel value. The database-generated default will always be used for inserts when the property has the value '0', since this is the CLR default for the 'SubmissionStatus' type. Consider using a nullable type, using a nullable backing field, or setting the sentinel value for the property to ensure the database default is used when, and only when, appropriate. See https://aka.ms/efcore-docs-default-values for more information.
+2025-09-27 06:07:16.296 +07:00 [WRN] The 'NotificationTypes' property 'Type' on entity type 'SystemNotification' is configured with a database-generated default, but has no configured sentinel value. The database-generated default will always be used for inserts when the property has the value '0', since this is the CLR default for the 'NotificationTypes' type. Consider using a nullable type, using a nullable backing field, or setting the sentinel value for the property to ensure the database default is used when, and only when, appropriate. See https://aka.ms/efcore-docs-default-values for more information.
+2025-09-27 06:07:16.296 +07:00 [WRN] The 'TopicStatus' property 'Status' on entity type 'TopicVersion' is configured with a database-generated default, but has no configured sentinel value. The database-generated default will always be used for inserts when the property has the value '0', since this is the CLR default for the 'TopicStatus' type. Consider using a nullable type, using a nullable backing field, or setting the sentinel value for the property to ensure the database default is used when, and only when, appropriate. See https://aka.ms/efcore-docs-default-values for more information.
+2025-09-27 06:07:16.439 +07:00 [DBG] Entity Framework Core 8.0.16 initialized 'MyDbContext' using provider 'Microsoft.EntityFrameworkCore.SqlServer:8.0.13' with options: MigrationsAssembly=App.DAL 
+2025-09-27 06:07:16.451 +07:00 [DBG] Creating DbConnection.
+2025-09-27 06:07:16.477 +07:00 [DBG] Created DbConnection. (23ms).
+2025-09-27 06:07:16.481 +07:00 [DBG] Migrating using database 'capbot_db' on server 'localhost'.
+2025-09-27 06:07:16.489 +07:00 [DBG] Opening connection to database 'capbot_db' on server 'localhost'.
+2025-09-27 06:07:16.601 +07:00 [DBG] Opened connection to database 'capbot_db' on server 'localhost'.
+2025-09-27 06:07:16.606 +07:00 [DBG] Creating DbCommand for 'ExecuteNonQuery'.
+2025-09-27 06:07:16.610 +07:00 [DBG] Created DbCommand for 'ExecuteNonQuery' (4ms).
+2025-09-27 06:07:16.612 +07:00 [DBG] Initialized DbCommand for 'ExecuteNonQuery' (8ms).
+2025-09-27 06:07:16.616 +07:00 [DBG] Executing DbCommand [Parameters=[], CommandType='"Text"', CommandTimeout='30']
+SELECT 1
+2025-09-27 06:07:16.634 +07:00 [INF] Executed DbCommand (16ms) [Parameters=[], CommandType='"Text"', CommandTimeout='30']
+SELECT 1
+2025-09-27 06:07:16.636 +07:00 [DBG] Closing connection to database 'capbot_db' on server 'localhost'.
+2025-09-27 06:07:16.641 +07:00 [DBG] Closed connection to database 'capbot_db' on server 'localhost' (2ms).
+2025-09-27 06:07:16.643 +07:00 [DBG] Creating DbCommand for 'ExecuteScalar'.
+2025-09-27 06:07:16.643 +07:00 [DBG] Created DbCommand for 'ExecuteScalar' (0ms).
+2025-09-27 06:07:16.644 +07:00 [DBG] Initialized DbCommand for 'ExecuteScalar' (0ms).
+2025-09-27 06:07:16.644 +07:00 [DBG] Opening connection to database 'capbot_db' on server 'localhost'.
+2025-09-27 06:07:16.644 +07:00 [DBG] Opened connection to database 'capbot_db' on server 'localhost'.
+2025-09-27 06:07:16.645 +07:00 [DBG] Executing DbCommand [Parameters=[], CommandType='"Text"', CommandTimeout='30']
+SELECT OBJECT_ID(N'[__EFMigrationsHistory]');
+2025-09-27 06:07:16.657 +07:00 [INF] Executed DbCommand (12ms) [Parameters=[], CommandType='"Text"', CommandTimeout='30']
+SELECT OBJECT_ID(N'[__EFMigrationsHistory]');
+2025-09-27 06:07:16.658 +07:00 [DBG] Closing connection to database 'capbot_db' on server 'localhost'.
+2025-09-27 06:07:16.658 +07:00 [DBG] Closed connection to database 'capbot_db' on server 'localhost' (0ms).
+2025-09-27 06:07:16.659 +07:00 [DBG] Opening connection to database 'capbot_db' on server 'localhost'.
+2025-09-27 06:07:16.659 +07:00 [DBG] Opened connection to database 'capbot_db' on server 'localhost'.
+2025-09-27 06:07:16.659 +07:00 [DBG] Creating DbCommand for 'ExecuteNonQuery'.
+2025-09-27 06:07:16.660 +07:00 [DBG] Created DbCommand for 'ExecuteNonQuery' (0ms).
+2025-09-27 06:07:16.660 +07:00 [DBG] Initialized DbCommand for 'ExecuteNonQuery' (0ms).
+2025-09-27 06:07:16.660 +07:00 [DBG] Executing DbCommand [Parameters=[], CommandType='"Text"', CommandTimeout='30']
+SELECT 1
+2025-09-27 06:07:16.662 +07:00 [INF] Executed DbCommand (2ms) [Parameters=[], CommandType='"Text"', CommandTimeout='30']
+SELECT 1
+2025-09-27 06:07:16.663 +07:00 [DBG] Closing connection to database 'capbot_db' on server 'localhost'.
+2025-09-27 06:07:16.663 +07:00 [DBG] Closed connection to database 'capbot_db' on server 'localhost' (0ms).
+2025-09-27 06:07:16.664 +07:00 [DBG] Creating DbCommand for 'ExecuteScalar'.
+2025-09-27 06:07:16.664 +07:00 [DBG] Created DbCommand for 'ExecuteScalar' (0ms).
+2025-09-27 06:07:16.664 +07:00 [DBG] Initialized DbCommand for 'ExecuteScalar' (0ms).
+2025-09-27 06:07:16.664 +07:00 [DBG] Opening connection to database 'capbot_db' on server 'localhost'.
+2025-09-27 06:07:16.665 +07:00 [DBG] Opened connection to database 'capbot_db' on server 'localhost'.
+2025-09-27 06:07:16.665 +07:00 [DBG] Executing DbCommand [Parameters=[], CommandType='"Text"', CommandTimeout='30']
+SELECT OBJECT_ID(N'[__EFMigrationsHistory]');
+2025-09-27 06:07:16.666 +07:00 [INF] Executed DbCommand (1ms) [Parameters=[], CommandType='"Text"', CommandTimeout='30']
+SELECT OBJECT_ID(N'[__EFMigrationsHistory]');
+2025-09-27 06:07:16.666 +07:00 [DBG] Closing connection to database 'capbot_db' on server 'localhost'.
+2025-09-27 06:07:16.667 +07:00 [DBG] Closed connection to database 'capbot_db' on server 'localhost' (0ms).
+2025-09-27 06:07:16.676 +07:00 [DBG] Opening connection to database 'capbot_db' on server 'localhost'.
+2025-09-27 06:07:16.677 +07:00 [DBG] Opened connection to database 'capbot_db' on server 'localhost'.
+2025-09-27 06:07:16.677 +07:00 [DBG] Creating DbCommand for 'ExecuteReader'.
+2025-09-27 06:07:16.678 +07:00 [DBG] Created DbCommand for 'ExecuteReader' (0ms).
+2025-09-27 06:07:16.678 +07:00 [DBG] Initialized DbCommand for 'ExecuteReader' (0ms).
+2025-09-27 06:07:16.678 +07:00 [DBG] Executing DbCommand [Parameters=[], CommandType='"Text"', CommandTimeout='30']
+SELECT [MigrationId], [ProductVersion]
+FROM [__EFMigrationsHistory]
+ORDER BY [MigrationId];
+2025-09-27 06:07:16.684 +07:00 [INF] Executed DbCommand (6ms) [Parameters=[], CommandType='"Text"', CommandTimeout='30']
+SELECT [MigrationId], [ProductVersion]
+FROM [__EFMigrationsHistory]
+ORDER BY [MigrationId];
+2025-09-27 06:07:16.685 +07:00 [DBG] Closing data reader to 'capbot_db' on server 'localhost'.
+2025-09-27 06:07:16.686 +07:00 [DBG] A data reader for 'capbot_db' on server 'localhost' is being disposed after spending 1ms reading results.
+2025-09-27 06:07:16.687 +07:00 [DBG] Closing connection to database 'capbot_db' on server 'localhost'.
+2025-09-27 06:07:16.687 +07:00 [DBG] Closed connection to database 'capbot_db' on server 'localhost' (0ms).
+2025-09-27 06:07:16.693 +07:00 [INF] Applying migration '20250926211516_AddPotentialDuplicateToTopicAndTopicVersion'.
+2025-09-27 06:07:16.760 +07:00 [DBG] Opening connection to database 'capbot_db' on server 'localhost'.
+2025-09-27 06:07:16.760 +07:00 [DBG] Opened connection to database 'capbot_db' on server 'localhost'.
+2025-09-27 06:07:16.762 +07:00 [DBG] Beginning transaction with isolation level 'Unspecified'.
+2025-09-27 06:07:16.766 +07:00 [DBG] Began transaction with isolation level 'ReadCommitted'.
+2025-09-27 06:07:16.767 +07:00 [DBG] Creating DbCommand for 'ExecuteNonQuery'.
+2025-09-27 06:07:16.767 +07:00 [DBG] Created DbCommand for 'ExecuteNonQuery' (0ms).
+2025-09-27 06:07:16.768 +07:00 [DBG] Initialized DbCommand for 'ExecuteNonQuery' (1ms).
+2025-09-27 06:07:16.768 +07:00 [DBG] Executing DbCommand [Parameters=[], CommandType='"Text"', CommandTimeout='30']
+ALTER TABLE [topics] ADD [PotentialDuplicate] nvarchar(max) NULL;
+2025-09-27 06:07:16.779 +07:00 [INF] Executed DbCommand (11ms) [Parameters=[], CommandType='"Text"', CommandTimeout='30']
+ALTER TABLE [topics] ADD [PotentialDuplicate] nvarchar(max) NULL;
+2025-09-27 06:07:16.780 +07:00 [DBG] Creating DbCommand for 'ExecuteNonQuery'.
+2025-09-27 06:07:16.780 +07:00 [DBG] Created DbCommand for 'ExecuteNonQuery' (0ms).
+2025-09-27 06:07:16.781 +07:00 [DBG] Initialized DbCommand for 'ExecuteNonQuery' (0ms).
+2025-09-27 06:07:16.781 +07:00 [DBG] Executing DbCommand [Parameters=[], CommandType='"Text"', CommandTimeout='30']
+ALTER TABLE [topic_versions] ADD [PotentialDuplicate] nvarchar(max) NULL;
+2025-09-27 06:07:16.785 +07:00 [INF] Executed DbCommand (4ms) [Parameters=[], CommandType='"Text"', CommandTimeout='30']
+ALTER TABLE [topic_versions] ADD [PotentialDuplicate] nvarchar(max) NULL;
+2025-09-27 06:07:16.785 +07:00 [DBG] Creating DbCommand for 'ExecuteNonQuery'.
+2025-09-27 06:07:16.785 +07:00 [DBG] Created DbCommand for 'ExecuteNonQuery' (0ms).
+2025-09-27 06:07:16.786 +07:00 [DBG] Initialized DbCommand for 'ExecuteNonQuery' (0ms).
+2025-09-27 06:07:16.786 +07:00 [DBG] Executing DbCommand [Parameters=[], CommandType='"Text"', CommandTimeout='30']
+INSERT INTO [__EFMigrationsHistory] ([MigrationId], [ProductVersion])
+VALUES (N'20250926211516_AddPotentialDuplicateToTopicAndTopicVersion', N'8.0.16');
+2025-09-27 06:07:16.789 +07:00 [INF] Executed DbCommand (3ms) [Parameters=[], CommandType='"Text"', CommandTimeout='30']
+INSERT INTO [__EFMigrationsHistory] ([MigrationId], [ProductVersion])
+VALUES (N'20250926211516_AddPotentialDuplicateToTopicAndTopicVersion', N'8.0.16');
+2025-09-27 06:07:16.790 +07:00 [DBG] Committing transaction.
+2025-09-27 06:07:16.792 +07:00 [DBG] Committed transaction.
+2025-09-27 06:07:16.794 +07:00 [DBG] Disposing transaction.
+2025-09-27 06:07:16.794 +07:00 [DBG] Closing connection to database 'capbot_db' on server 'localhost'.
+2025-09-27 06:07:16.794 +07:00 [DBG] Closed connection to database 'capbot_db' on server 'localhost' (0ms).
+2025-09-27 06:07:16.795 +07:00 [DBG] 'MyDbContext' disposed.
+2025-09-27 06:07:16.796 +07:00 [DBG] Disposing connection to database 'capbot_db' on server 'localhost'.
+2025-09-27 06:07:16.797 +07:00 [DBG] Disposed connection to database '' on server '' (0ms).
+2025-09-27 06:07:25.557 +07:00 [DBG] An 'IServiceProvider' was created for internal use by Entity Framework.
+2025-09-27 06:07:25.761 +07:00 [DBG] No relationship from 'ReviewerAssignment' to 'User' has been configured by convention because there are multiple properties on one entity type - {'AssignedByUser', 'Reviewer'} that could be matched with the properties on the other entity type - {'ReviewerAssignments'}. This message can be disregarded if explicit configuration has been specified in 'OnModelCreating'.
+2025-09-27 06:07:25.776 +07:00 [DBG] No relationship from 'SubmissionWorkflowLog' to 'WorkflowState' has been configured by convention because there are multiple properties on one entity type - {'FromState', 'ToState'} that could be matched with the properties on the other entity type - {'FromStateLogs', 'ToStateLogs'}. This message can be disregarded if explicit configuration has been specified in 'OnModelCreating'.
+2025-09-27 06:07:25.792 +07:00 [DBG] No relationship from 'User' to 'ReviewerAssignment' has been configured by convention because there are multiple properties on one entity type - {'ReviewerAssignments'} that could be matched with the properties on the other entity type - {'AssignedByUser', 'Reviewer'}. This message can be disregarded if explicit configuration has been specified in 'OnModelCreating'.
+2025-09-27 06:07:25.793 +07:00 [DBG] No relationship from 'WorkflowState' to 'SubmissionWorkflowLog' has been configured by convention because there are multiple properties on one entity type - {'FromStateLogs', 'ToStateLogs'} that could be matched with the properties on the other entity type - {'FromState', 'ToState'}. This message can be disregarded if explicit configuration has been specified in 'OnModelCreating'.
+2025-09-27 06:07:25.794 +07:00 [DBG] No relationship from 'WorkflowState' to 'WorkflowTransition' has been configured by convention because there are multiple properties on one entity type - {'FromTransitions', 'ToTransitions'} that could be matched with the properties on the other entity type - {'FromState', 'ToState'}. This message can be disregarded if explicit configuration has been specified in 'OnModelCreating'.
+2025-09-27 06:07:25.795 +07:00 [DBG] No relationship from 'WorkflowTransition' to 'WorkflowState' has been configured by convention because there are multiple properties on one entity type - {'FromState', 'ToState'} that could be matched with the properties on the other entity type - {'FromTransitions', 'ToTransitions'}. This message can be disregarded if explicit configuration has been specified in 'OnModelCreating'.
+2025-09-27 06:07:25.971 +07:00 [DBG] No relationship from 'ReviewerAssignment' to 'User' has been configured by convention because there are multiple properties on one entity type - {'AssignedByUser', 'Reviewer'} that could be matched with the properties on the other entity type - {'ReviewerAssignments'}. This message can be disregarded if explicit configuration has been specified in 'OnModelCreating'.
+2025-09-27 06:07:25.972 +07:00 [DBG] No relationship from 'User' to 'ReviewerAssignment' has been configured by convention because there are multiple properties on one entity type - {'ReviewerAssignments'} that could be matched with the properties on the other entity type - {'AssignedByUser', 'Reviewer'}. This message can be disregarded if explicit configuration has been specified in 'OnModelCreating'.
+2025-09-27 06:07:25.999 +07:00 [DBG] No relationship from 'WorkflowTransition' to 'WorkflowState' has been configured by convention because there are multiple properties on one entity type - {'FromState', 'ToState'} that could be matched with the properties on the other entity type - {'FromTransitions', 'ToTransitions'}. This message can be disregarded if explicit configuration has been specified in 'OnModelCreating'.
+2025-09-27 06:07:26.001 +07:00 [DBG] No relationship from 'WorkflowState' to 'SubmissionWorkflowLog' has been configured by convention because there are multiple properties on one entity type - {'FromStateLogs', 'ToStateLogs'} that could be matched with the properties on the other entity type - {'FromState', 'ToState'}. This message can be disregarded if explicit configuration has been specified in 'OnModelCreating'.
+2025-09-27 06:07:26.002 +07:00 [DBG] No relationship from 'WorkflowState' to 'WorkflowTransition' has been configured by convention because there are multiple properties on one entity type - {'FromTransitions', 'ToTransitions'} that could be matched with the properties on the other entity type - {'FromState', 'ToState'}. This message can be disregarded if explicit configuration has been specified in 'OnModelCreating'.
+2025-09-27 06:07:26.006 +07:00 [DBG] No relationship from 'WorkflowState' to 'SubmissionWorkflowLog' has been configured by convention because there are multiple properties on one entity type - {'FromStateLogs', 'ToStateLogs'} that could be matched with the properties on the other entity type - {'FromState', 'ToState'}. This message can be disregarded if explicit configuration has been specified in 'OnModelCreating'.
+2025-09-27 06:07:26.021 +07:00 [DBG] No relationship from 'SubmissionWorkflowLog' to 'WorkflowState' has been configured by convention because there are multiple properties on one entity type - {'FromState', 'ToState'} that could be matched with the properties on the other entity type - {'FromStateLogs', 'ToStateLogs'}. This message can be disregarded if explicit configuration has been specified in 'OnModelCreating'.
+2025-09-27 06:07:26.022 +07:00 [DBG] No relationship from 'WorkflowState' to 'SubmissionWorkflowLog' has been configured by convention because there are multiple properties on one entity type - {'FromStateLogs', 'ToStateLogs'} that could be matched with the properties on the other entity type - {'FromState', 'ToState'}. This message can be disregarded if explicit configuration has been specified in 'OnModelCreating'.
+2025-09-27 06:07:26.062 +07:00 [DBG] The index {'LecturerId'} was not created on entity type 'LecturerSkill' as the properties are already covered by the index {'LecturerId', 'SkillTag'}.
+2025-09-27 06:07:26.063 +07:00 [DBG] The index {'SemesterId'} was not created on entity type 'Phase' as the properties are already covered by the index {'SemesterId', 'PhaseTypeId'}.
+2025-09-27 06:07:26.063 +07:00 [DBG] The index {'AssignmentId'} was not created on entity type 'Review' as the properties are already covered by the index {'AssignmentId', 'Status'}.
+2025-09-27 06:07:26.063 +07:00 [DBG] The index {'ReviewId'} was not created on entity type 'ReviewComment' as the properties are already covered by the index {'ReviewId', 'SectionName'}.
+2025-09-27 06:07:26.064 +07:00 [DBG] The index {'ReviewId'} was not created on entity type 'ReviewCriteriaScore' as the properties are already covered by the index {'ReviewId', 'CriteriaId'}.
+2025-09-27 06:07:26.064 +07:00 [DBG] The index {'ReviewerId'} was not created on entity type 'ReviewerAssignment' as the properties are already covered by the index {'ReviewerId', 'Status'}.
+2025-09-27 06:07:26.064 +07:00 [DBG] The index {'SubmissionId'} was not created on entity type 'ReviewerAssignment' as the properties are already covered by the index {'SubmissionId', 'ReviewerId'}.
+2025-09-27 06:07:26.064 +07:00 [DBG] The index {'ReviewerId'} was not created on entity type 'ReviewerPerformance' as the properties are already covered by the index {'ReviewerId', 'SemesterId'}.
+2025-09-27 06:07:26.064 +07:00 [DBG] The index {'PhaseId'} was not created on entity type 'Submission' as the properties are already covered by the index {'PhaseId', 'Status'}.
+2025-09-27 06:07:26.064 +07:00 [DBG] The index {'PhaseId'} was not created on entity type 'Submission' as the properties are already covered by the index {'PhaseId', 'Status', 'SubmittedAt'}.
+2025-09-27 06:07:26.064 +07:00 [DBG] The index {'TopicId'} was not created on entity type 'Submission' as the properties are already covered by the index {'TopicId', 'PhaseId', 'SubmissionRound'}.
+2025-09-27 06:07:26.065 +07:00 [DBG] The index {'SubmissionId'} was not created on entity type 'SubmissionWorkflowLog' as the properties are already covered by the index {'SubmissionId', 'CreatedAt'}.
+2025-09-27 06:07:26.065 +07:00 [DBG] The index {'UserId'} was not created on entity type 'SystemNotification' as the properties are already covered by the index {'UserId', 'IsRead', 'CreatedAt'}.
+2025-09-27 06:07:26.065 +07:00 [DBG] The index {'SemesterId'} was not created on entity type 'Topic' as the properties are already covered by the index {'SemesterId', 'IsApproved'}.
+2025-09-27 06:07:26.065 +07:00 [DBG] The index {'SupervisorId'} was not created on entity type 'Topic' as the properties are already covered by the index {'SupervisorId', 'SemesterId'}.
+2025-09-27 06:07:26.065 +07:00 [DBG] The index {'TopicId'} was not created on entity type 'TopicVersion' as the properties are already covered by the index {'TopicId', 'Status'}.
+2025-09-27 06:07:26.066 +07:00 [DBG] The index {'TopicId'} was not created on entity type 'TopicVersion' as the properties are already covered by the index {'TopicId', 'VersionNumber'}.
+2025-09-27 06:07:26.066 +07:00 [DBG] The index {'UserId'} was not created on entity type 'UserRole' as the properties are already covered by the index {'UserId', 'RoleId'}.
+2025-09-27 06:07:26.066 +07:00 [DBG] The index {'UserId'} was not created on entity type 'UserToken' as the properties are already covered by the index {'UserId', 'LoginProvider', 'Name'}.
+2025-09-27 06:07:26.189 +07:00 [WRN] The 'ProficiencyLevels' property 'ProficiencyLevel' on entity type 'LecturerSkill' is configured with a database-generated default, but has no configured sentinel value. The database-generated default will always be used for inserts when the property has the value '0', since this is the CLR default for the 'ProficiencyLevels' type. Consider using a nullable type, using a nullable backing field, or setting the sentinel value for the property to ensure the database default is used when, and only when, appropriate. See https://aka.ms/efcore-docs-default-values for more information.
+2025-09-27 06:07:26.190 +07:00 [WRN] The 'ReviewRecommendations' property 'Recommendation' on entity type 'Review' is configured with a database-generated default, but has no configured sentinel value. The database-generated default will always be used for inserts when the property has the value '0', since this is the CLR default for the 'ReviewRecommendations' type. Consider using a nullable type, using a nullable backing field, or setting the sentinel value for the property to ensure the database default is used when, and only when, appropriate. See https://aka.ms/efcore-docs-default-values for more information.
+2025-09-27 06:07:26.191 +07:00 [WRN] The 'ReviewStatus' property 'Status' on entity type 'Review' is configured with a database-generated default, but has no configured sentinel value. The database-generated default will always be used for inserts when the property has the value '0', since this is the CLR default for the 'ReviewStatus' type. Consider using a nullable type, using a nullable backing field, or setting the sentinel value for the property to ensure the database default is used when, and only when, appropriate. See https://aka.ms/efcore-docs-default-values for more information.
+2025-09-27 06:07:26.192 +07:00 [WRN] The 'CommentTypes' property 'CommentType' on entity type 'ReviewComment' is configured with a database-generated default, but has no configured sentinel value. The database-generated default will always be used for inserts when the property has the value '0', since this is the CLR default for the 'CommentTypes' type. Consider using a nullable type, using a nullable backing field, or setting the sentinel value for the property to ensure the database default is used when, and only when, appropriate. See https://aka.ms/efcore-docs-default-values for more information.
+2025-09-27 06:07:26.193 +07:00 [WRN] The 'PriorityLevels' property 'Priority' on entity type 'ReviewComment' is configured with a database-generated default, but has no configured sentinel value. The database-generated default will always be used for inserts when the property has the value '0', since this is the CLR default for the 'PriorityLevels' type. Consider using a nullable type, using a nullable backing field, or setting the sentinel value for the property to ensure the database default is used when, and only when, appropriate. See https://aka.ms/efcore-docs-default-values for more information.
+2025-09-27 06:07:26.193 +07:00 [WRN] The 'AssignmentTypes' property 'AssignmentType' on entity type 'ReviewerAssignment' is configured with a database-generated default, but has no configured sentinel value. The database-generated default will always be used for inserts when the property has the value '0', since this is the CLR default for the 'AssignmentTypes' type. Consider using a nullable type, using a nullable backing field, or setting the sentinel value for the property to ensure the database default is used when, and only when, appropriate. See https://aka.ms/efcore-docs-default-values for more information.
+2025-09-27 06:07:26.194 +07:00 [WRN] The 'AssignmentStatus' property 'Status' on entity type 'ReviewerAssignment' is configured with a database-generated default, but has no configured sentinel value. The database-generated default will always be used for inserts when the property has the value '0', since this is the CLR default for the 'AssignmentStatus' type. Consider using a nullable type, using a nullable backing field, or setting the sentinel value for the property to ensure the database default is used when, and only when, appropriate. See https://aka.ms/efcore-docs-default-values for more information.
+2025-09-27 06:07:26.195 +07:00 [WRN] The 'AiCheckStatus' property 'AiCheckStatus' on entity type 'Submission' is configured with a database-generated default, but has no configured sentinel value. The database-generated default will always be used for inserts when the property has the value '0', since this is the CLR default for the 'AiCheckStatus' type. Consider using a nullable type, using a nullable backing field, or setting the sentinel value for the property to ensure the database default is used when, and only when, appropriate. See https://aka.ms/efcore-docs-default-values for more information.
+2025-09-27 06:07:26.195 +07:00 [WRN] The 'SubmissionStatus' property 'Status' on entity type 'Submission' is configured with a database-generated default, but has no configured sentinel value. The database-generated default will always be used for inserts when the property has the value '0', since this is the CLR default for the 'SubmissionStatus' type. Consider using a nullable type, using a nullable backing field, or setting the sentinel value for the property to ensure the database default is used when, and only when, appropriate. See https://aka.ms/efcore-docs-default-values for more information.
+2025-09-27 06:07:26.196 +07:00 [WRN] The 'NotificationTypes' property 'Type' on entity type 'SystemNotification' is configured with a database-generated default, but has no configured sentinel value. The database-generated default will always be used for inserts when the property has the value '0', since this is the CLR default for the 'NotificationTypes' type. Consider using a nullable type, using a nullable backing field, or setting the sentinel value for the property to ensure the database default is used when, and only when, appropriate. See https://aka.ms/efcore-docs-default-values for more information.
+2025-09-27 06:07:26.197 +07:00 [WRN] The 'TopicStatus' property 'Status' on entity type 'TopicVersion' is configured with a database-generated default, but has no configured sentinel value. The database-generated default will always be used for inserts when the property has the value '0', since this is the CLR default for the 'TopicStatus' type. Consider using a nullable type, using a nullable backing field, or setting the sentinel value for the property to ensure the database default is used when, and only when, appropriate. See https://aka.ms/efcore-docs-default-values for more information.
+2025-09-27 06:07:26.337 +07:00 [DBG] Entity Framework Core 8.0.16 initialized 'MyDbContext' using provider 'Microsoft.EntityFrameworkCore.SqlServer:8.0.13' with options: MigrationsAssembly=App.DAL 
+2025-09-27 06:07:26.354 +07:00 [DBG] Creating DbConnection.
+2025-09-27 06:07:26.381 +07:00 [DBG] Created DbConnection. (24ms).
+2025-09-27 06:07:26.385 +07:00 [DBG] Migrating using database 'capbot_db' on server 'localhost'.
+2025-09-27 06:07:26.390 +07:00 [DBG] Opening connection to database 'capbot_db' on server 'localhost'.
+2025-09-27 06:07:26.536 +07:00 [DBG] Opened connection to database 'capbot_db' on server 'localhost'.
+2025-09-27 06:07:26.547 +07:00 [DBG] Creating DbCommand for 'ExecuteNonQuery'.
+2025-09-27 06:07:26.555 +07:00 [DBG] Created DbCommand for 'ExecuteNonQuery' (7ms).
+2025-09-27 06:07:26.557 +07:00 [DBG] Initialized DbCommand for 'ExecuteNonQuery' (13ms).
+2025-09-27 06:07:26.564 +07:00 [DBG] Executing DbCommand [Parameters=[], CommandType='"Text"', CommandTimeout='30']
+SELECT 1
+2025-09-27 06:07:26.583 +07:00 [INF] Executed DbCommand (21ms) [Parameters=[], CommandType='"Text"', CommandTimeout='30']
+SELECT 1
+2025-09-27 06:07:26.586 +07:00 [DBG] Closing connection to database 'capbot_db' on server 'localhost'.
+2025-09-27 06:07:26.594 +07:00 [DBG] Closed connection to database 'capbot_db' on server 'localhost' (5ms).
+2025-09-27 06:07:26.597 +07:00 [DBG] Creating DbCommand for 'ExecuteScalar'.
+2025-09-27 06:07:26.597 +07:00 [DBG] Created DbCommand for 'ExecuteScalar' (0ms).
+2025-09-27 06:07:26.597 +07:00 [DBG] Initialized DbCommand for 'ExecuteScalar' (0ms).
+2025-09-27 06:07:26.597 +07:00 [DBG] Opening connection to database 'capbot_db' on server 'localhost'.
+2025-09-27 06:07:26.598 +07:00 [DBG] Opened connection to database 'capbot_db' on server 'localhost'.
+2025-09-27 06:07:26.598 +07:00 [DBG] Executing DbCommand [Parameters=[], CommandType='"Text"', CommandTimeout='30']
+SELECT OBJECT_ID(N'[__EFMigrationsHistory]');
+2025-09-27 06:07:26.608 +07:00 [INF] Executed DbCommand (9ms) [Parameters=[], CommandType='"Text"', CommandTimeout='30']
+SELECT OBJECT_ID(N'[__EFMigrationsHistory]');
+2025-09-27 06:07:26.608 +07:00 [DBG] Closing connection to database 'capbot_db' on server 'localhost'.
+2025-09-27 06:07:26.608 +07:00 [DBG] Closed connection to database 'capbot_db' on server 'localhost' (0ms).
+2025-09-27 06:07:26.609 +07:00 [DBG] Opening connection to database 'capbot_db' on server 'localhost'.
+2025-09-27 06:07:26.610 +07:00 [DBG] Opened connection to database 'capbot_db' on server 'localhost'.
+2025-09-27 06:07:26.610 +07:00 [DBG] Creating DbCommand for 'ExecuteNonQuery'.
+2025-09-27 06:07:26.610 +07:00 [DBG] Created DbCommand for 'ExecuteNonQuery' (0ms).
+2025-09-27 06:07:26.610 +07:00 [DBG] Initialized DbCommand for 'ExecuteNonQuery' (0ms).
+2025-09-27 06:07:26.610 +07:00 [DBG] Executing DbCommand [Parameters=[], CommandType='"Text"', CommandTimeout='30']
+SELECT 1
+2025-09-27 06:07:26.612 +07:00 [INF] Executed DbCommand (1ms) [Parameters=[], CommandType='"Text"', CommandTimeout='30']
+SELECT 1
+2025-09-27 06:07:26.612 +07:00 [DBG] Closing connection to database 'capbot_db' on server 'localhost'.
+2025-09-27 06:07:26.612 +07:00 [DBG] Closed connection to database 'capbot_db' on server 'localhost' (0ms).
+2025-09-27 06:07:26.612 +07:00 [DBG] Creating DbCommand for 'ExecuteScalar'.
+2025-09-27 06:07:26.612 +07:00 [DBG] Created DbCommand for 'ExecuteScalar' (0ms).
+2025-09-27 06:07:26.612 +07:00 [DBG] Initialized DbCommand for 'ExecuteScalar' (0ms).
+2025-09-27 06:07:26.613 +07:00 [DBG] Opening connection to database 'capbot_db' on server 'localhost'.
+2025-09-27 06:07:26.613 +07:00 [DBG] Opened connection to database 'capbot_db' on server 'localhost'.
+2025-09-27 06:07:26.613 +07:00 [DBG] Executing DbCommand [Parameters=[], CommandType='"Text"', CommandTimeout='30']
+SELECT OBJECT_ID(N'[__EFMigrationsHistory]');
+2025-09-27 06:07:26.615 +07:00 [INF] Executed DbCommand (2ms) [Parameters=[], CommandType='"Text"', CommandTimeout='30']
+SELECT OBJECT_ID(N'[__EFMigrationsHistory]');
+2025-09-27 06:07:26.615 +07:00 [DBG] Closing connection to database 'capbot_db' on server 'localhost'.
+2025-09-27 06:07:26.615 +07:00 [DBG] Closed connection to database 'capbot_db' on server 'localhost' (0ms).
+2025-09-27 06:07:26.626 +07:00 [DBG] Opening connection to database 'capbot_db' on server 'localhost'.
+2025-09-27 06:07:26.626 +07:00 [DBG] Opened connection to database 'capbot_db' on server 'localhost'.
+2025-09-27 06:07:26.626 +07:00 [DBG] Creating DbCommand for 'ExecuteReader'.
+2025-09-27 06:07:26.626 +07:00 [DBG] Created DbCommand for 'ExecuteReader' (0ms).
+2025-09-27 06:07:26.627 +07:00 [DBG] Initialized DbCommand for 'ExecuteReader' (0ms).
+2025-09-27 06:07:26.627 +07:00 [DBG] Executing DbCommand [Parameters=[], CommandType='"Text"', CommandTimeout='30']
+SELECT [MigrationId], [ProductVersion]
+FROM [__EFMigrationsHistory]
+ORDER BY [MigrationId];
+2025-09-27 06:07:26.629 +07:00 [INF] Executed DbCommand (2ms) [Parameters=[], CommandType='"Text"', CommandTimeout='30']
+SELECT [MigrationId], [ProductVersion]
+FROM [__EFMigrationsHistory]
+ORDER BY [MigrationId];
+2025-09-27 06:07:26.631 +07:00 [DBG] Closing data reader to 'capbot_db' on server 'localhost'.
+2025-09-27 06:07:26.632 +07:00 [DBG] A data reader for 'capbot_db' on server 'localhost' is being disposed after spending 1ms reading results.
+2025-09-27 06:07:26.633 +07:00 [DBG] Closing connection to database 'capbot_db' on server 'localhost'.
+2025-09-27 06:07:26.633 +07:00 [DBG] Closed connection to database 'capbot_db' on server 'localhost' (0ms).
+2025-09-27 06:07:26.640 +07:00 [INF] No migrations were applied. The database is already up to date.
+2025-09-27 06:07:26.641 +07:00 [DBG] 'MyDbContext' disposed.
+2025-09-27 06:07:26.642 +07:00 [DBG] Disposing connection to database 'capbot_db' on server 'localhost'.
+2025-09-27 06:07:26.643 +07:00 [DBG] Disposed connection to database '' on server '' (0ms).
+2025-09-27 06:08:44.275 +07:00 [DBG] An 'IServiceProvider' was created for internal use by Entity Framework.
+2025-09-27 06:08:44.486 +07:00 [DBG] No relationship from 'ReviewerAssignment' to 'User' has been configured by convention because there are multiple properties on one entity type - {'AssignedByUser', 'Reviewer'} that could be matched with the properties on the other entity type - {'ReviewerAssignments'}. This message can be disregarded if explicit configuration has been specified in 'OnModelCreating'.
+2025-09-27 06:08:44.510 +07:00 [DBG] No relationship from 'SubmissionWorkflowLog' to 'WorkflowState' has been configured by convention because there are multiple properties on one entity type - {'FromState', 'ToState'} that could be matched with the properties on the other entity type - {'FromStateLogs', 'ToStateLogs'}. This message can be disregarded if explicit configuration has been specified in 'OnModelCreating'.
+2025-09-27 06:08:44.519 +07:00 [DBG] No relationship from 'User' to 'ReviewerAssignment' has been configured by convention because there are multiple properties on one entity type - {'ReviewerAssignments'} that could be matched with the properties on the other entity type - {'AssignedByUser', 'Reviewer'}. This message can be disregarded if explicit configuration has been specified in 'OnModelCreating'.
+2025-09-27 06:08:44.521 +07:00 [DBG] No relationship from 'WorkflowState' to 'SubmissionWorkflowLog' has been configured by convention because there are multiple properties on one entity type - {'FromStateLogs', 'ToStateLogs'} that could be matched with the properties on the other entity type - {'FromState', 'ToState'}. This message can be disregarded if explicit configuration has been specified in 'OnModelCreating'.
+2025-09-27 06:08:44.521 +07:00 [DBG] No relationship from 'WorkflowState' to 'WorkflowTransition' has been configured by convention because there are multiple properties on one entity type - {'FromTransitions', 'ToTransitions'} that could be matched with the properties on the other entity type - {'FromState', 'ToState'}. This message can be disregarded if explicit configuration has been specified in 'OnModelCreating'.
+2025-09-27 06:08:44.522 +07:00 [DBG] No relationship from 'WorkflowTransition' to 'WorkflowState' has been configured by convention because there are multiple properties on one entity type - {'FromState', 'ToState'} that could be matched with the properties on the other entity type - {'FromTransitions', 'ToTransitions'}. This message can be disregarded if explicit configuration has been specified in 'OnModelCreating'.
+2025-09-27 06:08:44.686 +07:00 [DBG] No relationship from 'ReviewerAssignment' to 'User' has been configured by convention because there are multiple properties on one entity type - {'AssignedByUser', 'Reviewer'} that could be matched with the properties on the other entity type - {'ReviewerAssignments'}. This message can be disregarded if explicit configuration has been specified in 'OnModelCreating'.
+2025-09-27 06:08:44.688 +07:00 [DBG] No relationship from 'User' to 'ReviewerAssignment' has been configured by convention because there are multiple properties on one entity type - {'ReviewerAssignments'} that could be matched with the properties on the other entity type - {'AssignedByUser', 'Reviewer'}. This message can be disregarded if explicit configuration has been specified in 'OnModelCreating'.
+2025-09-27 06:08:44.721 +07:00 [DBG] No relationship from 'WorkflowTransition' to 'WorkflowState' has been configured by convention because there are multiple properties on one entity type - {'FromState', 'ToState'} that could be matched with the properties on the other entity type - {'FromTransitions', 'ToTransitions'}. This message can be disregarded if explicit configuration has been specified in 'OnModelCreating'.
+2025-09-27 06:08:44.722 +07:00 [DBG] No relationship from 'WorkflowState' to 'SubmissionWorkflowLog' has been configured by convention because there are multiple properties on one entity type - {'FromStateLogs', 'ToStateLogs'} that could be matched with the properties on the other entity type - {'FromState', 'ToState'}. This message can be disregarded if explicit configuration has been specified in 'OnModelCreating'.
+2025-09-27 06:08:44.724 +07:00 [DBG] No relationship from 'WorkflowState' to 'WorkflowTransition' has been configured by convention because there are multiple properties on one entity type - {'FromTransitions', 'ToTransitions'} that could be matched with the properties on the other entity type - {'FromState', 'ToState'}. This message can be disregarded if explicit configuration has been specified in 'OnModelCreating'.
+2025-09-27 06:08:44.727 +07:00 [DBG] No relationship from 'WorkflowState' to 'SubmissionWorkflowLog' has been configured by convention because there are multiple properties on one entity type - {'FromStateLogs', 'ToStateLogs'} that could be matched with the properties on the other entity type - {'FromState', 'ToState'}. This message can be disregarded if explicit configuration has been specified in 'OnModelCreating'.
+2025-09-27 06:08:44.737 +07:00 [DBG] No relationship from 'SubmissionWorkflowLog' to 'WorkflowState' has been configured by convention because there are multiple properties on one entity type - {'FromState', 'ToState'} that could be matched with the properties on the other entity type - {'FromStateLogs', 'ToStateLogs'}. This message can be disregarded if explicit configuration has been specified in 'OnModelCreating'.
+2025-09-27 06:08:44.737 +07:00 [DBG] No relationship from 'WorkflowState' to 'SubmissionWorkflowLog' has been configured by convention because there are multiple properties on one entity type - {'FromStateLogs', 'ToStateLogs'} that could be matched with the properties on the other entity type - {'FromState', 'ToState'}. This message can be disregarded if explicit configuration has been specified in 'OnModelCreating'.
+2025-09-27 06:08:44.771 +07:00 [DBG] The index {'LecturerId'} was not created on entity type 'LecturerSkill' as the properties are already covered by the index {'LecturerId', 'SkillTag'}.
+2025-09-27 06:08:44.771 +07:00 [DBG] The index {'SemesterId'} was not created on entity type 'Phase' as the properties are already covered by the index {'SemesterId', 'PhaseTypeId'}.
+2025-09-27 06:08:44.772 +07:00 [DBG] The index {'AssignmentId'} was not created on entity type 'Review' as the properties are already covered by the index {'AssignmentId', 'Status'}.
+2025-09-27 06:08:44.772 +07:00 [DBG] The index {'ReviewId'} was not created on entity type 'ReviewComment' as the properties are already covered by the index {'ReviewId', 'SectionName'}.
+2025-09-27 06:08:44.773 +07:00 [DBG] The index {'ReviewId'} was not created on entity type 'ReviewCriteriaScore' as the properties are already covered by the index {'ReviewId', 'CriteriaId'}.
+2025-09-27 06:08:44.773 +07:00 [DBG] The index {'ReviewerId'} was not created on entity type 'ReviewerAssignment' as the properties are already covered by the index {'ReviewerId', 'Status'}.
+2025-09-27 06:08:44.774 +07:00 [DBG] The index {'SubmissionId'} was not created on entity type 'ReviewerAssignment' as the properties are already covered by the index {'SubmissionId', 'ReviewerId'}.
+2025-09-27 06:08:44.775 +07:00 [DBG] The index {'ReviewerId'} was not created on entity type 'ReviewerPerformance' as the properties are already covered by the index {'ReviewerId', 'SemesterId'}.
+2025-09-27 06:08:44.775 +07:00 [DBG] The index {'PhaseId'} was not created on entity type 'Submission' as the properties are already covered by the index {'PhaseId', 'Status'}.
+2025-09-27 06:08:44.776 +07:00 [DBG] The index {'PhaseId'} was not created on entity type 'Submission' as the properties are already covered by the index {'PhaseId', 'Status', 'SubmittedAt'}.
+2025-09-27 06:08:44.776 +07:00 [DBG] The index {'TopicId'} was not created on entity type 'Submission' as the properties are already covered by the index {'TopicId', 'PhaseId', 'SubmissionRound'}.
+2025-09-27 06:08:44.777 +07:00 [DBG] The index {'SubmissionId'} was not created on entity type 'SubmissionWorkflowLog' as the properties are already covered by the index {'SubmissionId', 'CreatedAt'}.
+2025-09-27 06:08:44.777 +07:00 [DBG] The index {'UserId'} was not created on entity type 'SystemNotification' as the properties are already covered by the index {'UserId', 'IsRead', 'CreatedAt'}.
+2025-09-27 06:08:44.777 +07:00 [DBG] The index {'SemesterId'} was not created on entity type 'Topic' as the properties are already covered by the index {'SemesterId', 'IsApproved'}.
+2025-09-27 06:08:44.778 +07:00 [DBG] The index {'SupervisorId'} was not created on entity type 'Topic' as the properties are already covered by the index {'SupervisorId', 'SemesterId'}.
+2025-09-27 06:08:44.778 +07:00 [DBG] The index {'TopicId'} was not created on entity type 'TopicVersion' as the properties are already covered by the index {'TopicId', 'Status'}.
+2025-09-27 06:08:44.778 +07:00 [DBG] The index {'TopicId'} was not created on entity type 'TopicVersion' as the properties are already covered by the index {'TopicId', 'VersionNumber'}.
+2025-09-27 06:08:44.778 +07:00 [DBG] The index {'UserId'} was not created on entity type 'UserRole' as the properties are already covered by the index {'UserId', 'RoleId'}.
+2025-09-27 06:08:44.778 +07:00 [DBG] The index {'UserId'} was not created on entity type 'UserToken' as the properties are already covered by the index {'UserId', 'LoginProvider', 'Name'}.
+2025-09-27 06:08:44.903 +07:00 [WRN] The 'ProficiencyLevels' property 'ProficiencyLevel' on entity type 'LecturerSkill' is configured with a database-generated default, but has no configured sentinel value. The database-generated default will always be used for inserts when the property has the value '0', since this is the CLR default for the 'ProficiencyLevels' type. Consider using a nullable type, using a nullable backing field, or setting the sentinel value for the property to ensure the database default is used when, and only when, appropriate. See https://aka.ms/efcore-docs-default-values for more information.
+2025-09-27 06:08:44.904 +07:00 [WRN] The 'ReviewRecommendations' property 'Recommendation' on entity type 'Review' is configured with a database-generated default, but has no configured sentinel value. The database-generated default will always be used for inserts when the property has the value '0', since this is the CLR default for the 'ReviewRecommendations' type. Consider using a nullable type, using a nullable backing field, or setting the sentinel value for the property to ensure the database default is used when, and only when, appropriate. See https://aka.ms/efcore-docs-default-values for more information.
+2025-09-27 06:08:44.905 +07:00 [WRN] The 'ReviewStatus' property 'Status' on entity type 'Review' is configured with a database-generated default, but has no configured sentinel value. The database-generated default will always be used for inserts when the property has the value '0', since this is the CLR default for the 'ReviewStatus' type. Consider using a nullable type, using a nullable backing field, or setting the sentinel value for the property to ensure the database default is used when, and only when, appropriate. See https://aka.ms/efcore-docs-default-values for more information.
+2025-09-27 06:08:44.906 +07:00 [WRN] The 'CommentTypes' property 'CommentType' on entity type 'ReviewComment' is configured with a database-generated default, but has no configured sentinel value. The database-generated default will always be used for inserts when the property has the value '0', since this is the CLR default for the 'CommentTypes' type. Consider using a nullable type, using a nullable backing field, or setting the sentinel value for the property to ensure the database default is used when, and only when, appropriate. See https://aka.ms/efcore-docs-default-values for more information.
+2025-09-27 06:08:44.906 +07:00 [WRN] The 'PriorityLevels' property 'Priority' on entity type 'ReviewComment' is configured with a database-generated default, but has no configured sentinel value. The database-generated default will always be used for inserts when the property has the value '0', since this is the CLR default for the 'PriorityLevels' type. Consider using a nullable type, using a nullable backing field, or setting the sentinel value for the property to ensure the database default is used when, and only when, appropriate. See https://aka.ms/efcore-docs-default-values for more information.
+2025-09-27 06:08:44.906 +07:00 [WRN] The 'AssignmentTypes' property 'AssignmentType' on entity type 'ReviewerAssignment' is configured with a database-generated default, but has no configured sentinel value. The database-generated default will always be used for inserts when the property has the value '0', since this is the CLR default for the 'AssignmentTypes' type. Consider using a nullable type, using a nullable backing field, or setting the sentinel value for the property to ensure the database default is used when, and only when, appropriate. See https://aka.ms/efcore-docs-default-values for more information.
+2025-09-27 06:08:44.907 +07:00 [WRN] The 'AssignmentStatus' property 'Status' on entity type 'ReviewerAssignment' is configured with a database-generated default, but has no configured sentinel value. The database-generated default will always be used for inserts when the property has the value '0', since this is the CLR default for the 'AssignmentStatus' type. Consider using a nullable type, using a nullable backing field, or setting the sentinel value for the property to ensure the database default is used when, and only when, appropriate. See https://aka.ms/efcore-docs-default-values for more information.
+2025-09-27 06:08:44.907 +07:00 [WRN] The 'AiCheckStatus' property 'AiCheckStatus' on entity type 'Submission' is configured with a database-generated default, but has no configured sentinel value. The database-generated default will always be used for inserts when the property has the value '0', since this is the CLR default for the 'AiCheckStatus' type. Consider using a nullable type, using a nullable backing field, or setting the sentinel value for the property to ensure the database default is used when, and only when, appropriate. See https://aka.ms/efcore-docs-default-values for more information.
+2025-09-27 06:08:44.907 +07:00 [WRN] The 'SubmissionStatus' property 'Status' on entity type 'Submission' is configured with a database-generated default, but has no configured sentinel value. The database-generated default will always be used for inserts when the property has the value '0', since this is the CLR default for the 'SubmissionStatus' type. Consider using a nullable type, using a nullable backing field, or setting the sentinel value for the property to ensure the database default is used when, and only when, appropriate. See https://aka.ms/efcore-docs-default-values for more information.
+2025-09-27 06:08:44.908 +07:00 [WRN] The 'NotificationTypes' property 'Type' on entity type 'SystemNotification' is configured with a database-generated default, but has no configured sentinel value. The database-generated default will always be used for inserts when the property has the value '0', since this is the CLR default for the 'NotificationTypes' type. Consider using a nullable type, using a nullable backing field, or setting the sentinel value for the property to ensure the database default is used when, and only when, appropriate. See https://aka.ms/efcore-docs-default-values for more information.
+2025-09-27 06:08:44.908 +07:00 [WRN] The 'TopicStatus' property 'Status' on entity type 'TopicVersion' is configured with a database-generated default, but has no configured sentinel value. The database-generated default will always be used for inserts when the property has the value '0', since this is the CLR default for the 'TopicStatus' type. Consider using a nullable type, using a nullable backing field, or setting the sentinel value for the property to ensure the database default is used when, and only when, appropriate. See https://aka.ms/efcore-docs-default-values for more information.
+2025-09-27 06:08:45.055 +07:00 [DBG] Entity Framework Core 8.0.16 initialized 'MyDbContext' using provider 'Microsoft.EntityFrameworkCore.SqlServer:8.0.13' with options: MigrationsAssembly=App.DAL 
+2025-09-27 06:08:45.070 +07:00 [DBG] No relationship from 'ReviewerAssignment' to 'User' has been configured by convention because there are multiple properties on one entity type - {'AssignedByUser', 'Reviewer'} that could be matched with the properties on the other entity type - {'ReviewerAssignments'}. This message can be disregarded if explicit configuration has been specified in 'OnModelCreating'.
+2025-09-27 06:08:45.076 +07:00 [DBG] No relationship from 'SubmissionWorkflowLog' to 'WorkflowState' has been configured by convention because there are multiple properties on one entity type - {'FromState', 'ToState'} that could be matched with the properties on the other entity type - {'FromStateLogs', 'ToStateLogs'}. This message can be disregarded if explicit configuration has been specified in 'OnModelCreating'.
+2025-09-27 06:08:45.085 +07:00 [DBG] No relationship from 'User' to 'ReviewerAssignment' has been configured by convention because there are multiple properties on one entity type - {'ReviewerAssignments'} that could be matched with the properties on the other entity type - {'AssignedByUser', 'Reviewer'}. This message can be disregarded if explicit configuration has been specified in 'OnModelCreating'.
+2025-09-27 06:08:45.088 +07:00 [DBG] No relationship from 'WorkflowState' to 'SubmissionWorkflowLog' has been configured by convention because there are multiple properties on one entity type - {'FromStateLogs', 'ToStateLogs'} that could be matched with the properties on the other entity type - {'FromState', 'ToState'}. This message can be disregarded if explicit configuration has been specified in 'OnModelCreating'.
+2025-09-27 06:08:45.088 +07:00 [DBG] No relationship from 'WorkflowState' to 'WorkflowTransition' has been configured by convention because there are multiple properties on one entity type - {'FromTransitions', 'ToTransitions'} that could be matched with the properties on the other entity type - {'FromState', 'ToState'}. This message can be disregarded if explicit configuration has been specified in 'OnModelCreating'.
+2025-09-27 06:08:45.089 +07:00 [DBG] No relationship from 'WorkflowTransition' to 'WorkflowState' has been configured by convention because there are multiple properties on one entity type - {'FromState', 'ToState'} that could be matched with the properties on the other entity type - {'FromTransitions', 'ToTransitions'}. This message can be disregarded if explicit configuration has been specified in 'OnModelCreating'.
+2025-09-27 06:08:45.156 +07:00 [DBG] No relationship from 'ReviewerAssignment' to 'User' has been configured by convention because there are multiple properties on one entity type - {'AssignedByUser', 'Reviewer'} that could be matched with the properties on the other entity type - {'ReviewerAssignments'}. This message can be disregarded if explicit configuration has been specified in 'OnModelCreating'.
+2025-09-27 06:08:45.157 +07:00 [DBG] No relationship from 'User' to 'ReviewerAssignment' has been configured by convention because there are multiple properties on one entity type - {'ReviewerAssignments'} that could be matched with the properties on the other entity type - {'AssignedByUser', 'Reviewer'}. This message can be disregarded if explicit configuration has been specified in 'OnModelCreating'.
+2025-09-27 06:08:45.162 +07:00 [DBG] No relationship from 'WorkflowTransition' to 'WorkflowState' has been configured by convention because there are multiple properties on one entity type - {'FromState', 'ToState'} that could be matched with the properties on the other entity type - {'FromTransitions', 'ToTransitions'}. This message can be disregarded if explicit configuration has been specified in 'OnModelCreating'.
+2025-09-27 06:08:45.162 +07:00 [DBG] No relationship from 'WorkflowState' to 'SubmissionWorkflowLog' has been configured by convention because there are multiple properties on one entity type - {'FromStateLogs', 'ToStateLogs'} that could be matched with the properties on the other entity type - {'FromState', 'ToState'}. This message can be disregarded if explicit configuration has been specified in 'OnModelCreating'.
+2025-09-27 06:08:45.163 +07:00 [DBG] No relationship from 'WorkflowState' to 'WorkflowTransition' has been configured by convention because there are multiple properties on one entity type - {'FromTransitions', 'ToTransitions'} that could be matched with the properties on the other entity type - {'FromState', 'ToState'}. This message can be disregarded if explicit configuration has been specified in 'OnModelCreating'.
+2025-09-27 06:08:45.164 +07:00 [DBG] No relationship from 'WorkflowState' to 'SubmissionWorkflowLog' has been configured by convention because there are multiple properties on one entity type - {'FromStateLogs', 'ToStateLogs'} that could be matched with the properties on the other entity type - {'FromState', 'ToState'}. This message can be disregarded if explicit configuration has been specified in 'OnModelCreating'.
+2025-09-27 06:08:45.166 +07:00 [DBG] No relationship from 'SubmissionWorkflowLog' to 'WorkflowState' has been configured by convention because there are multiple properties on one entity type - {'FromState', 'ToState'} that could be matched with the properties on the other entity type - {'FromStateLogs', 'ToStateLogs'}. This message can be disregarded if explicit configuration has been specified in 'OnModelCreating'.
+2025-09-27 06:08:45.167 +07:00 [DBG] No relationship from 'WorkflowState' to 'SubmissionWorkflowLog' has been configured by convention because there are multiple properties on one entity type - {'FromStateLogs', 'ToStateLogs'} that could be matched with the properties on the other entity type - {'FromState', 'ToState'}. This message can be disregarded if explicit configuration has been specified in 'OnModelCreating'.
+2025-09-27 06:08:45.208 +07:00 [DBG] The index {'LecturerId'} was not created on entity type 'LecturerSkill' as the properties are already covered by the index {'LecturerId', 'SkillTag'}.
+2025-09-27 06:08:45.209 +07:00 [DBG] The index {'SemesterId'} was not created on entity type 'Phase' as the properties are already covered by the index {'SemesterId', 'PhaseTypeId'}.
+2025-09-27 06:08:45.210 +07:00 [DBG] The index {'AssignmentId'} was not created on entity type 'Review' as the properties are already covered by the index {'AssignmentId', 'Status'}.
+2025-09-27 06:08:45.210 +07:00 [DBG] The index {'ReviewId'} was not created on entity type 'ReviewComment' as the properties are already covered by the index {'ReviewId', 'SectionName'}.
+2025-09-27 06:08:45.211 +07:00 [DBG] The index {'ReviewId'} was not created on entity type 'ReviewCriteriaScore' as the properties are already covered by the index {'ReviewId', 'CriteriaId'}.
+2025-09-27 06:08:45.212 +07:00 [DBG] The index {'ReviewerId'} was not created on entity type 'ReviewerAssignment' as the properties are already covered by the index {'ReviewerId', 'Status'}.
+2025-09-27 06:08:45.212 +07:00 [DBG] The index {'SubmissionId'} was not created on entity type 'ReviewerAssignment' as the properties are already covered by the index {'SubmissionId', 'ReviewerId'}.
+2025-09-27 06:08:45.212 +07:00 [DBG] The index {'ReviewerId'} was not created on entity type 'ReviewerPerformance' as the properties are already covered by the index {'ReviewerId', 'SemesterId'}.
+2025-09-27 06:08:45.213 +07:00 [DBG] The index {'PhaseId'} was not created on entity type 'Submission' as the properties are already covered by the index {'PhaseId', 'Status'}.
+2025-09-27 06:08:45.213 +07:00 [DBG] The index {'PhaseId'} was not created on entity type 'Submission' as the properties are already covered by the index {'PhaseId', 'Status', 'SubmittedAt'}.
+2025-09-27 06:08:45.213 +07:00 [DBG] The index {'TopicId'} was not created on entity type 'Submission' as the properties are already covered by the index {'TopicId', 'PhaseId', 'SubmissionRound'}.
+2025-09-27 06:08:45.213 +07:00 [DBG] The index {'SubmissionId'} was not created on entity type 'SubmissionWorkflowLog' as the properties are already covered by the index {'SubmissionId', 'CreatedAt'}.
+2025-09-27 06:08:45.214 +07:00 [DBG] The index {'UserId'} was not created on entity type 'SystemNotification' as the properties are already covered by the index {'UserId', 'IsRead', 'CreatedAt'}.
+2025-09-27 06:08:45.214 +07:00 [DBG] The index {'SemesterId'} was not created on entity type 'Topic' as the properties are already covered by the index {'SemesterId', 'IsApproved'}.
+2025-09-27 06:08:45.214 +07:00 [DBG] The index {'SupervisorId'} was not created on entity type 'Topic' as the properties are already covered by the index {'SupervisorId', 'SemesterId'}.
+2025-09-27 06:08:45.214 +07:00 [DBG] The index {'TopicId'} was not created on entity type 'TopicVersion' as the properties are already covered by the index {'TopicId', 'Status'}.
+2025-09-27 06:08:45.214 +07:00 [DBG] The index {'TopicId'} was not created on entity type 'TopicVersion' as the properties are already covered by the index {'TopicId', 'VersionNumber'}.
+2025-09-27 06:08:45.215 +07:00 [DBG] The index {'UserId'} was not created on entity type 'UserRole' as the properties are already covered by the index {'UserId', 'RoleId'}.
+2025-09-27 06:08:45.215 +07:00 [DBG] The index {'UserId'} was not created on entity type 'UserToken' as the properties are already covered by the index {'UserId', 'LoginProvider', 'Name'}.
+2025-09-27 06:08:45.244 +07:00 [WRN] The 'ProficiencyLevels' property 'ProficiencyLevel' on entity type 'LecturerSkill' is configured with a database-generated default, but has no configured sentinel value. The database-generated default will always be used for inserts when the property has the value '0', since this is the CLR default for the 'ProficiencyLevels' type. Consider using a nullable type, using a nullable backing field, or setting the sentinel value for the property to ensure the database default is used when, and only when, appropriate. See https://aka.ms/efcore-docs-default-values for more information.
+2025-09-27 06:08:45.246 +07:00 [WRN] The 'ReviewRecommendations' property 'Recommendation' on entity type 'Review' is configured with a database-generated default, but has no configured sentinel value. The database-generated default will always be used for inserts when the property has the value '0', since this is the CLR default for the 'ReviewRecommendations' type. Consider using a nullable type, using a nullable backing field, or setting the sentinel value for the property to ensure the database default is used when, and only when, appropriate. See https://aka.ms/efcore-docs-default-values for more information.
+2025-09-27 06:08:45.246 +07:00 [WRN] The 'ReviewStatus' property 'Status' on entity type 'Review' is configured with a database-generated default, but has no configured sentinel value. The database-generated default will always be used for inserts when the property has the value '0', since this is the CLR default for the 'ReviewStatus' type. Consider using a nullable type, using a nullable backing field, or setting the sentinel value for the property to ensure the database default is used when, and only when, appropriate. See https://aka.ms/efcore-docs-default-values for more information.
+2025-09-27 06:08:45.247 +07:00 [WRN] The 'CommentTypes' property 'CommentType' on entity type 'ReviewComment' is configured with a database-generated default, but has no configured sentinel value. The database-generated default will always be used for inserts when the property has the value '0', since this is the CLR default for the 'CommentTypes' type. Consider using a nullable type, using a nullable backing field, or setting the sentinel value for the property to ensure the database default is used when, and only when, appropriate. See https://aka.ms/efcore-docs-default-values for more information.
+2025-09-27 06:08:45.247 +07:00 [WRN] The 'PriorityLevels' property 'Priority' on entity type 'ReviewComment' is configured with a database-generated default, but has no configured sentinel value. The database-generated default will always be used for inserts when the property has the value '0', since this is the CLR default for the 'PriorityLevels' type. Consider using a nullable type, using a nullable backing field, or setting the sentinel value for the property to ensure the database default is used when, and only when, appropriate. See https://aka.ms/efcore-docs-default-values for more information.
+2025-09-27 06:08:45.248 +07:00 [WRN] The 'AssignmentTypes' property 'AssignmentType' on entity type 'ReviewerAssignment' is configured with a database-generated default, but has no configured sentinel value. The database-generated default will always be used for inserts when the property has the value '0', since this is the CLR default for the 'AssignmentTypes' type. Consider using a nullable type, using a nullable backing field, or setting the sentinel value for the property to ensure the database default is used when, and only when, appropriate. See https://aka.ms/efcore-docs-default-values for more information.
+2025-09-27 06:08:45.248 +07:00 [WRN] The 'AssignmentStatus' property 'Status' on entity type 'ReviewerAssignment' is configured with a database-generated default, but has no configured sentinel value. The database-generated default will always be used for inserts when the property has the value '0', since this is the CLR default for the 'AssignmentStatus' type. Consider using a nullable type, using a nullable backing field, or setting the sentinel value for the property to ensure the database default is used when, and only when, appropriate. See https://aka.ms/efcore-docs-default-values for more information.
+2025-09-27 06:08:45.249 +07:00 [WRN] The 'AiCheckStatus' property 'AiCheckStatus' on entity type 'Submission' is configured with a database-generated default, but has no configured sentinel value. The database-generated default will always be used for inserts when the property has the value '0', since this is the CLR default for the 'AiCheckStatus' type. Consider using a nullable type, using a nullable backing field, or setting the sentinel value for the property to ensure the database default is used when, and only when, appropriate. See https://aka.ms/efcore-docs-default-values for more information.
+2025-09-27 06:08:45.249 +07:00 [WRN] The 'SubmissionStatus' property 'Status' on entity type 'Submission' is configured with a database-generated default, but has no configured sentinel value. The database-generated default will always be used for inserts when the property has the value '0', since this is the CLR default for the 'SubmissionStatus' type. Consider using a nullable type, using a nullable backing field, or setting the sentinel value for the property to ensure the database default is used when, and only when, appropriate. See https://aka.ms/efcore-docs-default-values for more information.
+2025-09-27 06:08:45.249 +07:00 [WRN] The 'NotificationTypes' property 'Type' on entity type 'SystemNotification' is configured with a database-generated default, but has no configured sentinel value. The database-generated default will always be used for inserts when the property has the value '0', since this is the CLR default for the 'NotificationTypes' type. Consider using a nullable type, using a nullable backing field, or setting the sentinel value for the property to ensure the database default is used when, and only when, appropriate. See https://aka.ms/efcore-docs-default-values for more information.
+2025-09-27 06:08:45.250 +07:00 [WRN] The 'TopicStatus' property 'Status' on entity type 'TopicVersion' is configured with a database-generated default, but has no configured sentinel value. The database-generated default will always be used for inserts when the property has the value '0', since this is the CLR default for the 'TopicStatus' type. Consider using a nullable type, using a nullable backing field, or setting the sentinel value for the property to ensure the database default is used when, and only when, appropriate. See https://aka.ms/efcore-docs-default-values for more information.
+2025-09-27 06:08:46.004 +07:00 [DBG] 'MyDbContext' disposed.
+2025-09-27 06:12:16.891 +07:00 [DBG] An 'IServiceProvider' was created for internal use by Entity Framework.
+2025-09-27 06:12:17.106 +07:00 [DBG] No relationship from 'ReviewerAssignment' to 'User' has been configured by convention because there are multiple properties on one entity type - {'AssignedByUser', 'Reviewer'} that could be matched with the properties on the other entity type - {'ReviewerAssignments'}. This message can be disregarded if explicit configuration has been specified in 'OnModelCreating'.
+2025-09-27 06:12:17.136 +07:00 [DBG] No relationship from 'SubmissionWorkflowLog' to 'WorkflowState' has been configured by convention because there are multiple properties on one entity type - {'FromState', 'ToState'} that could be matched with the properties on the other entity type - {'FromStateLogs', 'ToStateLogs'}. This message can be disregarded if explicit configuration has been specified in 'OnModelCreating'.
+2025-09-27 06:12:17.146 +07:00 [DBG] No relationship from 'User' to 'ReviewerAssignment' has been configured by convention because there are multiple properties on one entity type - {'ReviewerAssignments'} that could be matched with the properties on the other entity type - {'AssignedByUser', 'Reviewer'}. This message can be disregarded if explicit configuration has been specified in 'OnModelCreating'.
+2025-09-27 06:12:17.148 +07:00 [DBG] No relationship from 'WorkflowState' to 'SubmissionWorkflowLog' has been configured by convention because there are multiple properties on one entity type - {'FromStateLogs', 'ToStateLogs'} that could be matched with the properties on the other entity type - {'FromState', 'ToState'}. This message can be disregarded if explicit configuration has been specified in 'OnModelCreating'.
+2025-09-27 06:12:17.149 +07:00 [DBG] No relationship from 'WorkflowState' to 'WorkflowTransition' has been configured by convention because there are multiple properties on one entity type - {'FromTransitions', 'ToTransitions'} that could be matched with the properties on the other entity type - {'FromState', 'ToState'}. This message can be disregarded if explicit configuration has been specified in 'OnModelCreating'.
+2025-09-27 06:12:17.149 +07:00 [DBG] No relationship from 'WorkflowTransition' to 'WorkflowState' has been configured by convention because there are multiple properties on one entity type - {'FromState', 'ToState'} that could be matched with the properties on the other entity type - {'FromTransitions', 'ToTransitions'}. This message can be disregarded if explicit configuration has been specified in 'OnModelCreating'.
+2025-09-27 06:12:17.317 +07:00 [DBG] No relationship from 'ReviewerAssignment' to 'User' has been configured by convention because there are multiple properties on one entity type - {'AssignedByUser', 'Reviewer'} that could be matched with the properties on the other entity type - {'ReviewerAssignments'}. This message can be disregarded if explicit configuration has been specified in 'OnModelCreating'.
+2025-09-27 06:12:17.319 +07:00 [DBG] No relationship from 'User' to 'ReviewerAssignment' has been configured by convention because there are multiple properties on one entity type - {'ReviewerAssignments'} that could be matched with the properties on the other entity type - {'AssignedByUser', 'Reviewer'}. This message can be disregarded if explicit configuration has been specified in 'OnModelCreating'.
+2025-09-27 06:12:17.337 +07:00 [DBG] No relationship from 'WorkflowTransition' to 'WorkflowState' has been configured by convention because there are multiple properties on one entity type - {'FromState', 'ToState'} that could be matched with the properties on the other entity type - {'FromTransitions', 'ToTransitions'}. This message can be disregarded if explicit configuration has been specified in 'OnModelCreating'.
+2025-09-27 06:12:17.337 +07:00 [DBG] No relationship from 'WorkflowState' to 'SubmissionWorkflowLog' has been configured by convention because there are multiple properties on one entity type - {'FromStateLogs', 'ToStateLogs'} that could be matched with the properties on the other entity type - {'FromState', 'ToState'}. This message can be disregarded if explicit configuration has been specified in 'OnModelCreating'.
+2025-09-27 06:12:17.338 +07:00 [DBG] No relationship from 'WorkflowState' to 'WorkflowTransition' has been configured by convention because there are multiple properties on one entity type - {'FromTransitions', 'ToTransitions'} that could be matched with the properties on the other entity type - {'FromState', 'ToState'}. This message can be disregarded if explicit configuration has been specified in 'OnModelCreating'.
+2025-09-27 06:12:17.339 +07:00 [DBG] No relationship from 'WorkflowState' to 'SubmissionWorkflowLog' has been configured by convention because there are multiple properties on one entity type - {'FromStateLogs', 'ToStateLogs'} that could be matched with the properties on the other entity type - {'FromState', 'ToState'}. This message can be disregarded if explicit configuration has been specified in 'OnModelCreating'.
+2025-09-27 06:12:17.344 +07:00 [DBG] No relationship from 'SubmissionWorkflowLog' to 'WorkflowState' has been configured by convention because there are multiple properties on one entity type - {'FromState', 'ToState'} that could be matched with the properties on the other entity type - {'FromStateLogs', 'ToStateLogs'}. This message can be disregarded if explicit configuration has been specified in 'OnModelCreating'.
+2025-09-27 06:12:17.344 +07:00 [DBG] No relationship from 'WorkflowState' to 'SubmissionWorkflowLog' has been configured by convention because there are multiple properties on one entity type - {'FromStateLogs', 'ToStateLogs'} that could be matched with the properties on the other entity type - {'FromState', 'ToState'}. This message can be disregarded if explicit configuration has been specified in 'OnModelCreating'.
+2025-09-27 06:12:17.385 +07:00 [DBG] The index {'LecturerId'} was not created on entity type 'LecturerSkill' as the properties are already covered by the index {'LecturerId', 'SkillTag'}.
+2025-09-27 06:12:17.385 +07:00 [DBG] The index {'SemesterId'} was not created on entity type 'Phase' as the properties are already covered by the index {'SemesterId', 'PhaseTypeId'}.
+2025-09-27 06:12:17.386 +07:00 [DBG] The index {'AssignmentId'} was not created on entity type 'Review' as the properties are already covered by the index {'AssignmentId', 'Status'}.
+2025-09-27 06:12:17.386 +07:00 [DBG] The index {'ReviewId'} was not created on entity type 'ReviewComment' as the properties are already covered by the index {'ReviewId', 'SectionName'}.
+2025-09-27 06:12:17.386 +07:00 [DBG] The index {'ReviewId'} was not created on entity type 'ReviewCriteriaScore' as the properties are already covered by the index {'ReviewId', 'CriteriaId'}.
+2025-09-27 06:12:17.387 +07:00 [DBG] The index {'ReviewerId'} was not created on entity type 'ReviewerAssignment' as the properties are already covered by the index {'ReviewerId', 'Status'}.
+2025-09-27 06:12:17.387 +07:00 [DBG] The index {'SubmissionId'} was not created on entity type 'ReviewerAssignment' as the properties are already covered by the index {'SubmissionId', 'ReviewerId'}.
+2025-09-27 06:12:17.387 +07:00 [DBG] The index {'ReviewerId'} was not created on entity type 'ReviewerPerformance' as the properties are already covered by the index {'ReviewerId', 'SemesterId'}.
+2025-09-27 06:12:17.388 +07:00 [DBG] The index {'PhaseId'} was not created on entity type 'Submission' as the properties are already covered by the index {'PhaseId', 'Status'}.
+2025-09-27 06:12:17.388 +07:00 [DBG] The index {'PhaseId'} was not created on entity type 'Submission' as the properties are already covered by the index {'PhaseId', 'Status', 'SubmittedAt'}.
+2025-09-27 06:12:17.388 +07:00 [DBG] The index {'TopicId'} was not created on entity type 'Submission' as the properties are already covered by the index {'TopicId', 'PhaseId', 'SubmissionRound'}.
+2025-09-27 06:12:17.388 +07:00 [DBG] The index {'SubmissionId'} was not created on entity type 'SubmissionWorkflowLog' as the properties are already covered by the index {'SubmissionId', 'CreatedAt'}.
+2025-09-27 06:12:17.389 +07:00 [DBG] The index {'UserId'} was not created on entity type 'SystemNotification' as the properties are already covered by the index {'UserId', 'IsRead', 'CreatedAt'}.
+2025-09-27 06:12:17.389 +07:00 [DBG] The index {'SemesterId'} was not created on entity type 'Topic' as the properties are already covered by the index {'SemesterId', 'IsApproved'}.
+2025-09-27 06:12:17.389 +07:00 [DBG] The index {'SupervisorId'} was not created on entity type 'Topic' as the properties are already covered by the index {'SupervisorId', 'SemesterId'}.
+2025-09-27 06:12:17.389 +07:00 [DBG] The index {'TopicId'} was not created on entity type 'TopicVersion' as the properties are already covered by the index {'TopicId', 'Status'}.
+2025-09-27 06:12:17.389 +07:00 [DBG] The index {'TopicId'} was not created on entity type 'TopicVersion' as the properties are already covered by the index {'TopicId', 'VersionNumber'}.
+2025-09-27 06:12:17.389 +07:00 [DBG] The index {'UserId'} was not created on entity type 'UserRole' as the properties are already covered by the index {'UserId', 'RoleId'}.
+2025-09-27 06:12:17.390 +07:00 [DBG] The index {'UserId'} was not created on entity type 'UserToken' as the properties are already covered by the index {'UserId', 'LoginProvider', 'Name'}.
+2025-09-27 06:12:17.516 +07:00 [WRN] The 'ProficiencyLevels' property 'ProficiencyLevel' on entity type 'LecturerSkill' is configured with a database-generated default, but has no configured sentinel value. The database-generated default will always be used for inserts when the property has the value '0', since this is the CLR default for the 'ProficiencyLevels' type. Consider using a nullable type, using a nullable backing field, or setting the sentinel value for the property to ensure the database default is used when, and only when, appropriate. See https://aka.ms/efcore-docs-default-values for more information.
+2025-09-27 06:12:17.517 +07:00 [WRN] The 'ReviewRecommendations' property 'Recommendation' on entity type 'Review' is configured with a database-generated default, but has no configured sentinel value. The database-generated default will always be used for inserts when the property has the value '0', since this is the CLR default for the 'ReviewRecommendations' type. Consider using a nullable type, using a nullable backing field, or setting the sentinel value for the property to ensure the database default is used when, and only when, appropriate. See https://aka.ms/efcore-docs-default-values for more information.
+2025-09-27 06:12:17.517 +07:00 [WRN] The 'ReviewStatus' property 'Status' on entity type 'Review' is configured with a database-generated default, but has no configured sentinel value. The database-generated default will always be used for inserts when the property has the value '0', since this is the CLR default for the 'ReviewStatus' type. Consider using a nullable type, using a nullable backing field, or setting the sentinel value for the property to ensure the database default is used when, and only when, appropriate. See https://aka.ms/efcore-docs-default-values for more information.
+2025-09-27 06:12:17.518 +07:00 [WRN] The 'CommentTypes' property 'CommentType' on entity type 'ReviewComment' is configured with a database-generated default, but has no configured sentinel value. The database-generated default will always be used for inserts when the property has the value '0', since this is the CLR default for the 'CommentTypes' type. Consider using a nullable type, using a nullable backing field, or setting the sentinel value for the property to ensure the database default is used when, and only when, appropriate. See https://aka.ms/efcore-docs-default-values for more information.
+2025-09-27 06:12:17.518 +07:00 [WRN] The 'PriorityLevels' property 'Priority' on entity type 'ReviewComment' is configured with a database-generated default, but has no configured sentinel value. The database-generated default will always be used for inserts when the property has the value '0', since this is the CLR default for the 'PriorityLevels' type. Consider using a nullable type, using a nullable backing field, or setting the sentinel value for the property to ensure the database default is used when, and only when, appropriate. See https://aka.ms/efcore-docs-default-values for more information.
+2025-09-27 06:12:17.518 +07:00 [WRN] The 'AssignmentTypes' property 'AssignmentType' on entity type 'ReviewerAssignment' is configured with a database-generated default, but has no configured sentinel value. The database-generated default will always be used for inserts when the property has the value '0', since this is the CLR default for the 'AssignmentTypes' type. Consider using a nullable type, using a nullable backing field, or setting the sentinel value for the property to ensure the database default is used when, and only when, appropriate. See https://aka.ms/efcore-docs-default-values for more information.
+2025-09-27 06:12:17.519 +07:00 [WRN] The 'AssignmentStatus' property 'Status' on entity type 'ReviewerAssignment' is configured with a database-generated default, but has no configured sentinel value. The database-generated default will always be used for inserts when the property has the value '0', since this is the CLR default for the 'AssignmentStatus' type. Consider using a nullable type, using a nullable backing field, or setting the sentinel value for the property to ensure the database default is used when, and only when, appropriate. See https://aka.ms/efcore-docs-default-values for more information.
+2025-09-27 06:12:17.520 +07:00 [WRN] The 'AiCheckStatus' property 'AiCheckStatus' on entity type 'Submission' is configured with a database-generated default, but has no configured sentinel value. The database-generated default will always be used for inserts when the property has the value '0', since this is the CLR default for the 'AiCheckStatus' type. Consider using a nullable type, using a nullable backing field, or setting the sentinel value for the property to ensure the database default is used when, and only when, appropriate. See https://aka.ms/efcore-docs-default-values for more information.
+2025-09-27 06:12:17.521 +07:00 [WRN] The 'SubmissionStatus' property 'Status' on entity type 'Submission' is configured with a database-generated default, but has no configured sentinel value. The database-generated default will always be used for inserts when the property has the value '0', since this is the CLR default for the 'SubmissionStatus' type. Consider using a nullable type, using a nullable backing field, or setting the sentinel value for the property to ensure the database default is used when, and only when, appropriate. See https://aka.ms/efcore-docs-default-values for more information.
+2025-09-27 06:12:17.521 +07:00 [WRN] The 'NotificationTypes' property 'Type' on entity type 'SystemNotification' is configured with a database-generated default, but has no configured sentinel value. The database-generated default will always be used for inserts when the property has the value '0', since this is the CLR default for the 'NotificationTypes' type. Consider using a nullable type, using a nullable backing field, or setting the sentinel value for the property to ensure the database default is used when, and only when, appropriate. See https://aka.ms/efcore-docs-default-values for more information.
+2025-09-27 06:12:17.522 +07:00 [WRN] The 'TopicStatus' property 'Status' on entity type 'TopicVersion' is configured with a database-generated default, but has no configured sentinel value. The database-generated default will always be used for inserts when the property has the value '0', since this is the CLR default for the 'TopicStatus' type. Consider using a nullable type, using a nullable backing field, or setting the sentinel value for the property to ensure the database default is used when, and only when, appropriate. See https://aka.ms/efcore-docs-default-values for more information.
+2025-09-27 06:12:17.663 +07:00 [DBG] Entity Framework Core 8.0.16 initialized 'MyDbContext' using provider 'Microsoft.EntityFrameworkCore.SqlServer:8.0.13' with options: MigrationsAssembly=App.DAL 
+2025-09-27 06:12:17.673 +07:00 [DBG] Creating DbConnection.
+2025-09-27 06:12:17.712 +07:00 [DBG] Created DbConnection. (33ms).
+2025-09-27 06:12:17.722 +07:00 [DBG] Migrating using database 'capbot_db' on server 'localhost'.
+2025-09-27 06:12:17.731 +07:00 [DBG] Opening connection to database 'capbot_db' on server 'localhost'.
+2025-09-27 06:12:17.855 +07:00 [DBG] Opened connection to database 'capbot_db' on server 'localhost'.
+2025-09-27 06:12:17.859 +07:00 [DBG] Creating DbCommand for 'ExecuteNonQuery'.
+2025-09-27 06:12:17.863 +07:00 [DBG] Created DbCommand for 'ExecuteNonQuery' (4ms).
+2025-09-27 06:12:17.865 +07:00 [DBG] Initialized DbCommand for 'ExecuteNonQuery' (7ms).
+2025-09-27 06:12:17.869 +07:00 [DBG] Executing DbCommand [Parameters=[], CommandType='"Text"', CommandTimeout='30']
+SELECT 1
+2025-09-27 06:12:17.886 +07:00 [INF] Executed DbCommand (16ms) [Parameters=[], CommandType='"Text"', CommandTimeout='30']
+SELECT 1
+2025-09-27 06:12:17.888 +07:00 [DBG] Closing connection to database 'capbot_db' on server 'localhost'.
+2025-09-27 06:12:17.892 +07:00 [DBG] Closed connection to database 'capbot_db' on server 'localhost' (3ms).
+2025-09-27 06:12:17.894 +07:00 [DBG] Creating DbCommand for 'ExecuteScalar'.
+2025-09-27 06:12:17.895 +07:00 [DBG] Created DbCommand for 'ExecuteScalar' (0ms).
+2025-09-27 06:12:17.895 +07:00 [DBG] Initialized DbCommand for 'ExecuteScalar' (0ms).
+2025-09-27 06:12:17.895 +07:00 [DBG] Opening connection to database 'capbot_db' on server 'localhost'.
+2025-09-27 06:12:17.896 +07:00 [DBG] Opened connection to database 'capbot_db' on server 'localhost'.
+2025-09-27 06:12:17.897 +07:00 [DBG] Executing DbCommand [Parameters=[], CommandType='"Text"', CommandTimeout='30']
+SELECT OBJECT_ID(N'[__EFMigrationsHistory]');
+2025-09-27 06:12:17.905 +07:00 [INF] Executed DbCommand (9ms) [Parameters=[], CommandType='"Text"', CommandTimeout='30']
+SELECT OBJECT_ID(N'[__EFMigrationsHistory]');
+2025-09-27 06:12:17.906 +07:00 [DBG] Closing connection to database 'capbot_db' on server 'localhost'.
+2025-09-27 06:12:17.906 +07:00 [DBG] Closed connection to database 'capbot_db' on server 'localhost' (0ms).
+2025-09-27 06:12:17.907 +07:00 [DBG] Opening connection to database 'capbot_db' on server 'localhost'.
+2025-09-27 06:12:17.907 +07:00 [DBG] Opened connection to database 'capbot_db' on server 'localhost'.
+2025-09-27 06:12:17.907 +07:00 [DBG] Creating DbCommand for 'ExecuteNonQuery'.
+2025-09-27 06:12:17.908 +07:00 [DBG] Created DbCommand for 'ExecuteNonQuery' (0ms).
+2025-09-27 06:12:17.908 +07:00 [DBG] Initialized DbCommand for 'ExecuteNonQuery' (0ms).
+2025-09-27 06:12:17.909 +07:00 [DBG] Executing DbCommand [Parameters=[], CommandType='"Text"', CommandTimeout='30']
+SELECT 1
+2025-09-27 06:12:17.911 +07:00 [INF] Executed DbCommand (3ms) [Parameters=[], CommandType='"Text"', CommandTimeout='30']
+SELECT 1
+2025-09-27 06:12:17.912 +07:00 [DBG] Closing connection to database 'capbot_db' on server 'localhost'.
+2025-09-27 06:12:17.912 +07:00 [DBG] Closed connection to database 'capbot_db' on server 'localhost' (0ms).
+2025-09-27 06:12:17.913 +07:00 [DBG] Creating DbCommand for 'ExecuteScalar'.
+2025-09-27 06:12:17.913 +07:00 [DBG] Created DbCommand for 'ExecuteScalar' (0ms).
+2025-09-27 06:12:17.914 +07:00 [DBG] Initialized DbCommand for 'ExecuteScalar' (0ms).
+2025-09-27 06:12:17.914 +07:00 [DBG] Opening connection to database 'capbot_db' on server 'localhost'.
+2025-09-27 06:12:17.914 +07:00 [DBG] Opened connection to database 'capbot_db' on server 'localhost'.
+2025-09-27 06:12:17.914 +07:00 [DBG] Executing DbCommand [Parameters=[], CommandType='"Text"', CommandTimeout='30']
+SELECT OBJECT_ID(N'[__EFMigrationsHistory]');
+2025-09-27 06:12:17.916 +07:00 [INF] Executed DbCommand (2ms) [Parameters=[], CommandType='"Text"', CommandTimeout='30']
+SELECT OBJECT_ID(N'[__EFMigrationsHistory]');
+2025-09-27 06:12:17.916 +07:00 [DBG] Closing connection to database 'capbot_db' on server 'localhost'.
+2025-09-27 06:12:17.917 +07:00 [DBG] Closed connection to database 'capbot_db' on server 'localhost' (0ms).
+2025-09-27 06:12:17.929 +07:00 [DBG] Opening connection to database 'capbot_db' on server 'localhost'.
+2025-09-27 06:12:17.930 +07:00 [DBG] Opened connection to database 'capbot_db' on server 'localhost'.
+2025-09-27 06:12:17.931 +07:00 [DBG] Creating DbCommand for 'ExecuteReader'.
+2025-09-27 06:12:17.931 +07:00 [DBG] Created DbCommand for 'ExecuteReader' (0ms).
+2025-09-27 06:12:17.931 +07:00 [DBG] Initialized DbCommand for 'ExecuteReader' (0ms).
+2025-09-27 06:12:17.932 +07:00 [DBG] Executing DbCommand [Parameters=[], CommandType='"Text"', CommandTimeout='30']
+SELECT [MigrationId], [ProductVersion]
+FROM [__EFMigrationsHistory]
+ORDER BY [MigrationId];
+2025-09-27 06:12:17.936 +07:00 [INF] Executed DbCommand (4ms) [Parameters=[], CommandType='"Text"', CommandTimeout='30']
+SELECT [MigrationId], [ProductVersion]
+FROM [__EFMigrationsHistory]
+ORDER BY [MigrationId];
+2025-09-27 06:12:17.939 +07:00 [DBG] Closing data reader to 'capbot_db' on server 'localhost'.
+2025-09-27 06:12:17.940 +07:00 [DBG] A data reader for 'capbot_db' on server 'localhost' is being disposed after spending 2ms reading results.
+2025-09-27 06:12:17.940 +07:00 [DBG] Closing connection to database 'capbot_db' on server 'localhost'.
+2025-09-27 06:12:17.940 +07:00 [DBG] Closed connection to database 'capbot_db' on server 'localhost' (0ms).
+2025-09-27 06:12:17.948 +07:00 [INF] Applying migration '20250926230845_FixScoreInReviewCriteriaScore'.
+2025-09-27 06:12:18.011 +07:00 [DBG] Opening connection to database 'capbot_db' on server 'localhost'.
+2025-09-27 06:12:18.012 +07:00 [DBG] Opened connection to database 'capbot_db' on server 'localhost'.
+2025-09-27 06:12:18.015 +07:00 [DBG] Beginning transaction with isolation level 'Unspecified'.
+2025-09-27 06:12:18.020 +07:00 [DBG] Began transaction with isolation level 'ReadCommitted'.
+2025-09-27 06:12:18.021 +07:00 [DBG] Creating DbCommand for 'ExecuteNonQuery'.
+2025-09-27 06:12:18.021 +07:00 [DBG] Created DbCommand for 'ExecuteNonQuery' (0ms).
+2025-09-27 06:12:18.022 +07:00 [DBG] Initialized DbCommand for 'ExecuteNonQuery' (1ms).
+2025-09-27 06:12:18.022 +07:00 [DBG] Executing DbCommand [Parameters=[], CommandType='"Text"', CommandTimeout='30']
+DECLARE @var0 sysname;
+SELECT @var0 = [d].[name]
+FROM [sys].[default_constraints] [d]
+INNER JOIN [sys].[columns] [c] ON [d].[parent_column_id] = [c].[column_id] AND [d].[parent_object_id] = [c].[object_id]
+WHERE ([d].[parent_object_id] = OBJECT_ID(N'[review_criteria_scores]') AND [c].[name] = N'Score');
+IF @var0 IS NOT NULL EXEC(N'ALTER TABLE [review_criteria_scores] DROP CONSTRAINT [' + @var0 + '];');
+ALTER TABLE [review_criteria_scores] ALTER COLUMN [Score] decimal(6,2) NOT NULL;
+2025-09-27 06:12:18.090 +07:00 [INF] Executed DbCommand (67ms) [Parameters=[], CommandType='"Text"', CommandTimeout='30']
+DECLARE @var0 sysname;
+SELECT @var0 = [d].[name]
+FROM [sys].[default_constraints] [d]
+INNER JOIN [sys].[columns] [c] ON [d].[parent_column_id] = [c].[column_id] AND [d].[parent_object_id] = [c].[object_id]
+WHERE ([d].[parent_object_id] = OBJECT_ID(N'[review_criteria_scores]') AND [c].[name] = N'Score');
+IF @var0 IS NOT NULL EXEC(N'ALTER TABLE [review_criteria_scores] DROP CONSTRAINT [' + @var0 + '];');
+ALTER TABLE [review_criteria_scores] ALTER COLUMN [Score] decimal(6,2) NOT NULL;
+2025-09-27 06:12:18.091 +07:00 [DBG] Creating DbCommand for 'ExecuteNonQuery'.
+2025-09-27 06:12:18.091 +07:00 [DBG] Created DbCommand for 'ExecuteNonQuery' (0ms).
+2025-09-27 06:12:18.092 +07:00 [DBG] Initialized DbCommand for 'ExecuteNonQuery' (0ms).
+2025-09-27 06:12:18.092 +07:00 [DBG] Executing DbCommand [Parameters=[], CommandType='"Text"', CommandTimeout='30']
+INSERT INTO [__EFMigrationsHistory] ([MigrationId], [ProductVersion])
+VALUES (N'20250926230845_FixScoreInReviewCriteriaScore', N'8.0.16');
+2025-09-27 06:12:18.094 +07:00 [INF] Executed DbCommand (2ms) [Parameters=[], CommandType='"Text"', CommandTimeout='30']
+INSERT INTO [__EFMigrationsHistory] ([MigrationId], [ProductVersion])
+VALUES (N'20250926230845_FixScoreInReviewCriteriaScore', N'8.0.16');
+2025-09-27 06:12:18.095 +07:00 [DBG] Committing transaction.
+2025-09-27 06:12:18.100 +07:00 [DBG] Committed transaction.
+2025-09-27 06:12:18.101 +07:00 [DBG] Disposing transaction.
+2025-09-27 06:12:18.101 +07:00 [DBG] Closing connection to database 'capbot_db' on server 'localhost'.
+2025-09-27 06:12:18.102 +07:00 [DBG] Closed connection to database 'capbot_db' on server 'localhost' (0ms).
+2025-09-27 06:12:18.104 +07:00 [DBG] 'MyDbContext' disposed.
+2025-09-27 06:12:18.106 +07:00 [DBG] Disposing connection to database 'capbot_db' on server 'localhost'.
+2025-09-27 06:12:18.107 +07:00 [DBG] Disposed connection to database '' on server '' (0ms).
+2025-09-27 06:12:31.675 +07:00 [DBG] An 'IServiceProvider' was created for internal use by Entity Framework.
+2025-09-27 06:12:31.884 +07:00 [DBG] No relationship from 'ReviewerAssignment' to 'User' has been configured by convention because there are multiple properties on one entity type - {'AssignedByUser', 'Reviewer'} that could be matched with the properties on the other entity type - {'ReviewerAssignments'}. This message can be disregarded if explicit configuration has been specified in 'OnModelCreating'.
+2025-09-27 06:12:31.899 +07:00 [DBG] No relationship from 'SubmissionWorkflowLog' to 'WorkflowState' has been configured by convention because there are multiple properties on one entity type - {'FromState', 'ToState'} that could be matched with the properties on the other entity type - {'FromStateLogs', 'ToStateLogs'}. This message can be disregarded if explicit configuration has been specified in 'OnModelCreating'.
+2025-09-27 06:12:31.910 +07:00 [DBG] No relationship from 'User' to 'ReviewerAssignment' has been configured by convention because there are multiple properties on one entity type - {'ReviewerAssignments'} that could be matched with the properties on the other entity type - {'AssignedByUser', 'Reviewer'}. This message can be disregarded if explicit configuration has been specified in 'OnModelCreating'.
+2025-09-27 06:12:31.912 +07:00 [DBG] No relationship from 'WorkflowState' to 'SubmissionWorkflowLog' has been configured by convention because there are multiple properties on one entity type - {'FromStateLogs', 'ToStateLogs'} that could be matched with the properties on the other entity type - {'FromState', 'ToState'}. This message can be disregarded if explicit configuration has been specified in 'OnModelCreating'.
+2025-09-27 06:12:31.912 +07:00 [DBG] No relationship from 'WorkflowState' to 'WorkflowTransition' has been configured by convention because there are multiple properties on one entity type - {'FromTransitions', 'ToTransitions'} that could be matched with the properties on the other entity type - {'FromState', 'ToState'}. This message can be disregarded if explicit configuration has been specified in 'OnModelCreating'.
+2025-09-27 06:12:31.914 +07:00 [DBG] No relationship from 'WorkflowTransition' to 'WorkflowState' has been configured by convention because there are multiple properties on one entity type - {'FromState', 'ToState'} that could be matched with the properties on the other entity type - {'FromTransitions', 'ToTransitions'}. This message can be disregarded if explicit configuration has been specified in 'OnModelCreating'.
+2025-09-27 06:12:32.084 +07:00 [DBG] No relationship from 'ReviewerAssignment' to 'User' has been configured by convention because there are multiple properties on one entity type - {'AssignedByUser', 'Reviewer'} that could be matched with the properties on the other entity type - {'ReviewerAssignments'}. This message can be disregarded if explicit configuration has been specified in 'OnModelCreating'.
+2025-09-27 06:12:32.086 +07:00 [DBG] No relationship from 'User' to 'ReviewerAssignment' has been configured by convention because there are multiple properties on one entity type - {'ReviewerAssignments'} that could be matched with the properties on the other entity type - {'AssignedByUser', 'Reviewer'}. This message can be disregarded if explicit configuration has been specified in 'OnModelCreating'.
+2025-09-27 06:12:32.113 +07:00 [DBG] No relationship from 'WorkflowTransition' to 'WorkflowState' has been configured by convention because there are multiple properties on one entity type - {'FromState', 'ToState'} that could be matched with the properties on the other entity type - {'FromTransitions', 'ToTransitions'}. This message can be disregarded if explicit configuration has been specified in 'OnModelCreating'.
+2025-09-27 06:12:32.115 +07:00 [DBG] No relationship from 'WorkflowState' to 'SubmissionWorkflowLog' has been configured by convention because there are multiple properties on one entity type - {'FromStateLogs', 'ToStateLogs'} that could be matched with the properties on the other entity type - {'FromState', 'ToState'}. This message can be disregarded if explicit configuration has been specified in 'OnModelCreating'.
+2025-09-27 06:12:32.116 +07:00 [DBG] No relationship from 'WorkflowState' to 'WorkflowTransition' has been configured by convention because there are multiple properties on one entity type - {'FromTransitions', 'ToTransitions'} that could be matched with the properties on the other entity type - {'FromState', 'ToState'}. This message can be disregarded if explicit configuration has been specified in 'OnModelCreating'.
+2025-09-27 06:12:32.118 +07:00 [DBG] No relationship from 'WorkflowState' to 'SubmissionWorkflowLog' has been configured by convention because there are multiple properties on one entity type - {'FromStateLogs', 'ToStateLogs'} that could be matched with the properties on the other entity type - {'FromState', 'ToState'}. This message can be disregarded if explicit configuration has been specified in 'OnModelCreating'.
+2025-09-27 06:12:32.126 +07:00 [DBG] No relationship from 'SubmissionWorkflowLog' to 'WorkflowState' has been configured by convention because there are multiple properties on one entity type - {'FromState', 'ToState'} that could be matched with the properties on the other entity type - {'FromStateLogs', 'ToStateLogs'}. This message can be disregarded if explicit configuration has been specified in 'OnModelCreating'.
+2025-09-27 06:12:32.128 +07:00 [DBG] No relationship from 'WorkflowState' to 'SubmissionWorkflowLog' has been configured by convention because there are multiple properties on one entity type - {'FromStateLogs', 'ToStateLogs'} that could be matched with the properties on the other entity type - {'FromState', 'ToState'}. This message can be disregarded if explicit configuration has been specified in 'OnModelCreating'.
+2025-09-27 06:12:32.174 +07:00 [DBG] The index {'LecturerId'} was not created on entity type 'LecturerSkill' as the properties are already covered by the index {'LecturerId', 'SkillTag'}.
+2025-09-27 06:12:32.175 +07:00 [DBG] The index {'SemesterId'} was not created on entity type 'Phase' as the properties are already covered by the index {'SemesterId', 'PhaseTypeId'}.
+2025-09-27 06:12:32.175 +07:00 [DBG] The index {'AssignmentId'} was not created on entity type 'Review' as the properties are already covered by the index {'AssignmentId', 'Status'}.
+2025-09-27 06:12:32.175 +07:00 [DBG] The index {'ReviewId'} was not created on entity type 'ReviewComment' as the properties are already covered by the index {'ReviewId', 'SectionName'}.
+2025-09-27 06:12:32.175 +07:00 [DBG] The index {'ReviewId'} was not created on entity type 'ReviewCriteriaScore' as the properties are already covered by the index {'ReviewId', 'CriteriaId'}.
+2025-09-27 06:12:32.175 +07:00 [DBG] The index {'ReviewerId'} was not created on entity type 'ReviewerAssignment' as the properties are already covered by the index {'ReviewerId', 'Status'}.
+2025-09-27 06:12:32.175 +07:00 [DBG] The index {'SubmissionId'} was not created on entity type 'ReviewerAssignment' as the properties are already covered by the index {'SubmissionId', 'ReviewerId'}.
+2025-09-27 06:12:32.176 +07:00 [DBG] The index {'ReviewerId'} was not created on entity type 'ReviewerPerformance' as the properties are already covered by the index {'ReviewerId', 'SemesterId'}.
+2025-09-27 06:12:32.176 +07:00 [DBG] The index {'PhaseId'} was not created on entity type 'Submission' as the properties are already covered by the index {'PhaseId', 'Status'}.
+2025-09-27 06:12:32.176 +07:00 [DBG] The index {'PhaseId'} was not created on entity type 'Submission' as the properties are already covered by the index {'PhaseId', 'Status', 'SubmittedAt'}.
+2025-09-27 06:12:32.177 +07:00 [DBG] The index {'TopicId'} was not created on entity type 'Submission' as the properties are already covered by the index {'TopicId', 'PhaseId', 'SubmissionRound'}.
+2025-09-27 06:12:32.177 +07:00 [DBG] The index {'SubmissionId'} was not created on entity type 'SubmissionWorkflowLog' as the properties are already covered by the index {'SubmissionId', 'CreatedAt'}.
+2025-09-27 06:12:32.177 +07:00 [DBG] The index {'UserId'} was not created on entity type 'SystemNotification' as the properties are already covered by the index {'UserId', 'IsRead', 'CreatedAt'}.
+2025-09-27 06:12:32.177 +07:00 [DBG] The index {'SemesterId'} was not created on entity type 'Topic' as the properties are already covered by the index {'SemesterId', 'IsApproved'}.
+2025-09-27 06:12:32.177 +07:00 [DBG] The index {'SupervisorId'} was not created on entity type 'Topic' as the properties are already covered by the index {'SupervisorId', 'SemesterId'}.
+2025-09-27 06:12:32.177 +07:00 [DBG] The index {'TopicId'} was not created on entity type 'TopicVersion' as the properties are already covered by the index {'TopicId', 'Status'}.
+2025-09-27 06:12:32.177 +07:00 [DBG] The index {'TopicId'} was not created on entity type 'TopicVersion' as the properties are already covered by the index {'TopicId', 'VersionNumber'}.
+2025-09-27 06:12:32.178 +07:00 [DBG] The index {'UserId'} was not created on entity type 'UserRole' as the properties are already covered by the index {'UserId', 'RoleId'}.
+2025-09-27 06:12:32.178 +07:00 [DBG] The index {'UserId'} was not created on entity type 'UserToken' as the properties are already covered by the index {'UserId', 'LoginProvider', 'Name'}.
+2025-09-27 06:12:32.303 +07:00 [WRN] The 'ProficiencyLevels' property 'ProficiencyLevel' on entity type 'LecturerSkill' is configured with a database-generated default, but has no configured sentinel value. The database-generated default will always be used for inserts when the property has the value '0', since this is the CLR default for the 'ProficiencyLevels' type. Consider using a nullable type, using a nullable backing field, or setting the sentinel value for the property to ensure the database default is used when, and only when, appropriate. See https://aka.ms/efcore-docs-default-values for more information.
+2025-09-27 06:12:32.303 +07:00 [WRN] The 'ReviewRecommendations' property 'Recommendation' on entity type 'Review' is configured with a database-generated default, but has no configured sentinel value. The database-generated default will always be used for inserts when the property has the value '0', since this is the CLR default for the 'ReviewRecommendations' type. Consider using a nullable type, using a nullable backing field, or setting the sentinel value for the property to ensure the database default is used when, and only when, appropriate. See https://aka.ms/efcore-docs-default-values for more information.
+2025-09-27 06:12:32.304 +07:00 [WRN] The 'ReviewStatus' property 'Status' on entity type 'Review' is configured with a database-generated default, but has no configured sentinel value. The database-generated default will always be used for inserts when the property has the value '0', since this is the CLR default for the 'ReviewStatus' type. Consider using a nullable type, using a nullable backing field, or setting the sentinel value for the property to ensure the database default is used when, and only when, appropriate. See https://aka.ms/efcore-docs-default-values for more information.
+2025-09-27 06:12:32.305 +07:00 [WRN] The 'CommentTypes' property 'CommentType' on entity type 'ReviewComment' is configured with a database-generated default, but has no configured sentinel value. The database-generated default will always be used for inserts when the property has the value '0', since this is the CLR default for the 'CommentTypes' type. Consider using a nullable type, using a nullable backing field, or setting the sentinel value for the property to ensure the database default is used when, and only when, appropriate. See https://aka.ms/efcore-docs-default-values for more information.
+2025-09-27 06:12:32.305 +07:00 [WRN] The 'PriorityLevels' property 'Priority' on entity type 'ReviewComment' is configured with a database-generated default, but has no configured sentinel value. The database-generated default will always be used for inserts when the property has the value '0', since this is the CLR default for the 'PriorityLevels' type. Consider using a nullable type, using a nullable backing field, or setting the sentinel value for the property to ensure the database default is used when, and only when, appropriate. See https://aka.ms/efcore-docs-default-values for more information.
+2025-09-27 06:12:32.305 +07:00 [WRN] The 'AssignmentTypes' property 'AssignmentType' on entity type 'ReviewerAssignment' is configured with a database-generated default, but has no configured sentinel value. The database-generated default will always be used for inserts when the property has the value '0', since this is the CLR default for the 'AssignmentTypes' type. Consider using a nullable type, using a nullable backing field, or setting the sentinel value for the property to ensure the database default is used when, and only when, appropriate. See https://aka.ms/efcore-docs-default-values for more information.
+2025-09-27 06:12:32.306 +07:00 [WRN] The 'AssignmentStatus' property 'Status' on entity type 'ReviewerAssignment' is configured with a database-generated default, but has no configured sentinel value. The database-generated default will always be used for inserts when the property has the value '0', since this is the CLR default for the 'AssignmentStatus' type. Consider using a nullable type, using a nullable backing field, or setting the sentinel value for the property to ensure the database default is used when, and only when, appropriate. See https://aka.ms/efcore-docs-default-values for more information.
+2025-09-27 06:12:32.306 +07:00 [WRN] The 'AiCheckStatus' property 'AiCheckStatus' on entity type 'Submission' is configured with a database-generated default, but has no configured sentinel value. The database-generated default will always be used for inserts when the property has the value '0', since this is the CLR default for the 'AiCheckStatus' type. Consider using a nullable type, using a nullable backing field, or setting the sentinel value for the property to ensure the database default is used when, and only when, appropriate. See https://aka.ms/efcore-docs-default-values for more information.
+2025-09-27 06:12:32.306 +07:00 [WRN] The 'SubmissionStatus' property 'Status' on entity type 'Submission' is configured with a database-generated default, but has no configured sentinel value. The database-generated default will always be used for inserts when the property has the value '0', since this is the CLR default for the 'SubmissionStatus' type. Consider using a nullable type, using a nullable backing field, or setting the sentinel value for the property to ensure the database default is used when, and only when, appropriate. See https://aka.ms/efcore-docs-default-values for more information.
+2025-09-27 06:12:32.306 +07:00 [WRN] The 'NotificationTypes' property 'Type' on entity type 'SystemNotification' is configured with a database-generated default, but has no configured sentinel value. The database-generated default will always be used for inserts when the property has the value '0', since this is the CLR default for the 'NotificationTypes' type. Consider using a nullable type, using a nullable backing field, or setting the sentinel value for the property to ensure the database default is used when, and only when, appropriate. See https://aka.ms/efcore-docs-default-values for more information.
+2025-09-27 06:12:32.307 +07:00 [WRN] The 'TopicStatus' property 'Status' on entity type 'TopicVersion' is configured with a database-generated default, but has no configured sentinel value. The database-generated default will always be used for inserts when the property has the value '0', since this is the CLR default for the 'TopicStatus' type. Consider using a nullable type, using a nullable backing field, or setting the sentinel value for the property to ensure the database default is used when, and only when, appropriate. See https://aka.ms/efcore-docs-default-values for more information.
+2025-09-27 06:12:32.429 +07:00 [DBG] Entity Framework Core 8.0.16 initialized 'MyDbContext' using provider 'Microsoft.EntityFrameworkCore.SqlServer:8.0.13' with options: MigrationsAssembly=App.DAL 
+2025-09-27 06:12:32.441 +07:00 [DBG] Creating DbConnection.
+2025-09-27 06:12:32.470 +07:00 [DBG] Created DbConnection. (25ms).
+2025-09-27 06:12:32.476 +07:00 [DBG] Migrating using database 'capbot_db' on server 'localhost'.
+2025-09-27 06:12:32.480 +07:00 [DBG] Opening connection to database 'capbot_db' on server 'localhost'.
+2025-09-27 06:12:32.595 +07:00 [DBG] Opened connection to database 'capbot_db' on server 'localhost'.
+2025-09-27 06:12:32.599 +07:00 [DBG] Creating DbCommand for 'ExecuteNonQuery'.
+2025-09-27 06:12:32.603 +07:00 [DBG] Created DbCommand for 'ExecuteNonQuery' (3ms).
+2025-09-27 06:12:32.605 +07:00 [DBG] Initialized DbCommand for 'ExecuteNonQuery' (7ms).
+2025-09-27 06:12:32.610 +07:00 [DBG] Executing DbCommand [Parameters=[], CommandType='"Text"', CommandTimeout='30']
+SELECT 1
+2025-09-27 06:12:32.626 +07:00 [INF] Executed DbCommand (17ms) [Parameters=[], CommandType='"Text"', CommandTimeout='30']
+SELECT 1
+2025-09-27 06:12:32.628 +07:00 [DBG] Closing connection to database 'capbot_db' on server 'localhost'.
+2025-09-27 06:12:32.632 +07:00 [DBG] Closed connection to database 'capbot_db' on server 'localhost' (2ms).
+2025-09-27 06:12:32.634 +07:00 [DBG] Creating DbCommand for 'ExecuteScalar'.
+2025-09-27 06:12:32.635 +07:00 [DBG] Created DbCommand for 'ExecuteScalar' (0ms).
+2025-09-27 06:12:32.635 +07:00 [DBG] Initialized DbCommand for 'ExecuteScalar' (0ms).
+2025-09-27 06:12:32.635 +07:00 [DBG] Opening connection to database 'capbot_db' on server 'localhost'.
+2025-09-27 06:12:32.636 +07:00 [DBG] Opened connection to database 'capbot_db' on server 'localhost'.
+2025-09-27 06:12:32.636 +07:00 [DBG] Executing DbCommand [Parameters=[], CommandType='"Text"', CommandTimeout='30']
+SELECT OBJECT_ID(N'[__EFMigrationsHistory]');
+2025-09-27 06:12:32.645 +07:00 [INF] Executed DbCommand (9ms) [Parameters=[], CommandType='"Text"', CommandTimeout='30']
+SELECT OBJECT_ID(N'[__EFMigrationsHistory]');
+2025-09-27 06:12:32.646 +07:00 [DBG] Closing connection to database 'capbot_db' on server 'localhost'.
+2025-09-27 06:12:32.646 +07:00 [DBG] Closed connection to database 'capbot_db' on server 'localhost' (0ms).
+2025-09-27 06:12:32.647 +07:00 [DBG] Opening connection to database 'capbot_db' on server 'localhost'.
+2025-09-27 06:12:32.647 +07:00 [DBG] Opened connection to database 'capbot_db' on server 'localhost'.
+2025-09-27 06:12:32.648 +07:00 [DBG] Creating DbCommand for 'ExecuteNonQuery'.
+2025-09-27 06:12:32.648 +07:00 [DBG] Created DbCommand for 'ExecuteNonQuery' (0ms).
+2025-09-27 06:12:32.648 +07:00 [DBG] Initialized DbCommand for 'ExecuteNonQuery' (0ms).
+2025-09-27 06:12:32.648 +07:00 [DBG] Executing DbCommand [Parameters=[], CommandType='"Text"', CommandTimeout='30']
+SELECT 1
+2025-09-27 06:12:32.650 +07:00 [INF] Executed DbCommand (2ms) [Parameters=[], CommandType='"Text"', CommandTimeout='30']
+SELECT 1
+2025-09-27 06:12:32.651 +07:00 [DBG] Closing connection to database 'capbot_db' on server 'localhost'.
+2025-09-27 06:12:32.651 +07:00 [DBG] Closed connection to database 'capbot_db' on server 'localhost' (0ms).
+2025-09-27 06:12:32.651 +07:00 [DBG] Creating DbCommand for 'ExecuteScalar'.
+2025-09-27 06:12:32.652 +07:00 [DBG] Created DbCommand for 'ExecuteScalar' (0ms).
+2025-09-27 06:12:32.652 +07:00 [DBG] Initialized DbCommand for 'ExecuteScalar' (0ms).
+2025-09-27 06:12:32.652 +07:00 [DBG] Opening connection to database 'capbot_db' on server 'localhost'.
+2025-09-27 06:12:32.652 +07:00 [DBG] Opened connection to database 'capbot_db' on server 'localhost'.
+2025-09-27 06:12:32.653 +07:00 [DBG] Executing DbCommand [Parameters=[], CommandType='"Text"', CommandTimeout='30']
+SELECT OBJECT_ID(N'[__EFMigrationsHistory]');
+2025-09-27 06:12:32.654 +07:00 [INF] Executed DbCommand (2ms) [Parameters=[], CommandType='"Text"', CommandTimeout='30']
+SELECT OBJECT_ID(N'[__EFMigrationsHistory]');
+2025-09-27 06:12:32.655 +07:00 [DBG] Closing connection to database 'capbot_db' on server 'localhost'.
+2025-09-27 06:12:32.656 +07:00 [DBG] Closed connection to database 'capbot_db' on server 'localhost' (0ms).
+2025-09-27 06:12:32.665 +07:00 [DBG] Opening connection to database 'capbot_db' on server 'localhost'.
+2025-09-27 06:12:32.666 +07:00 [DBG] Opened connection to database 'capbot_db' on server 'localhost'.
+2025-09-27 06:12:32.666 +07:00 [DBG] Creating DbCommand for 'ExecuteReader'.
+2025-09-27 06:12:32.666 +07:00 [DBG] Created DbCommand for 'ExecuteReader' (0ms).
+2025-09-27 06:12:32.666 +07:00 [DBG] Initialized DbCommand for 'ExecuteReader' (0ms).
+2025-09-27 06:12:32.667 +07:00 [DBG] Executing DbCommand [Parameters=[], CommandType='"Text"', CommandTimeout='30']
+SELECT [MigrationId], [ProductVersion]
+FROM [__EFMigrationsHistory]
+ORDER BY [MigrationId];
+2025-09-27 06:12:32.676 +07:00 [INF] Executed DbCommand (9ms) [Parameters=[], CommandType='"Text"', CommandTimeout='30']
+SELECT [MigrationId], [ProductVersion]
+FROM [__EFMigrationsHistory]
+ORDER BY [MigrationId];
+2025-09-27 06:12:32.678 +07:00 [DBG] Closing data reader to 'capbot_db' on server 'localhost'.
+2025-09-27 06:12:32.679 +07:00 [DBG] A data reader for 'capbot_db' on server 'localhost' is being disposed after spending 1ms reading results.
+2025-09-27 06:12:32.680 +07:00 [DBG] Closing connection to database 'capbot_db' on server 'localhost'.
+2025-09-27 06:12:32.680 +07:00 [DBG] Closed connection to database 'capbot_db' on server 'localhost' (0ms).
+2025-09-27 06:12:32.686 +07:00 [INF] No migrations were applied. The database is already up to date.
+2025-09-27 06:12:32.687 +07:00 [DBG] 'MyDbContext' disposed.
+2025-09-27 06:12:32.688 +07:00 [DBG] Disposing connection to database 'capbot_db' on server 'localhost'.
+2025-09-27 06:12:32.689 +07:00 [DBG] Disposed connection to database '' on server '' (0ms).
+2025-09-27 06:13:51.118 +07:00 [DBG] An 'IServiceProvider' was created for internal use by Entity Framework.
+2025-09-27 06:13:51.199 +07:00 [INF] User profile is available. Using 'C:\Users\Admin\AppData\Local\ASP.NET\DataProtection-Keys' as key repository and Windows DPAPI to encrypt keys at rest.
+2025-09-27 06:13:51.388 +07:00 [DBG] No relationship from 'ReviewerAssignment' to 'User' has been configured by convention because there are multiple properties on one entity type - {'AssignedByUser', 'Reviewer'} that could be matched with the properties on the other entity type - {'ReviewerAssignments'}. This message can be disregarded if explicit configuration has been specified in 'OnModelCreating'.
+2025-09-27 06:13:51.407 +07:00 [DBG] No relationship from 'SubmissionWorkflowLog' to 'WorkflowState' has been configured by convention because there are multiple properties on one entity type - {'FromState', 'ToState'} that could be matched with the properties on the other entity type - {'FromStateLogs', 'ToStateLogs'}. This message can be disregarded if explicit configuration has been specified in 'OnModelCreating'.
+2025-09-27 06:13:51.424 +07:00 [DBG] No relationship from 'User' to 'ReviewerAssignment' has been configured by convention because there are multiple properties on one entity type - {'ReviewerAssignments'} that could be matched with the properties on the other entity type - {'AssignedByUser', 'Reviewer'}. This message can be disregarded if explicit configuration has been specified in 'OnModelCreating'.
+2025-09-27 06:13:51.426 +07:00 [DBG] No relationship from 'WorkflowState' to 'SubmissionWorkflowLog' has been configured by convention because there are multiple properties on one entity type - {'FromStateLogs', 'ToStateLogs'} that could be matched with the properties on the other entity type - {'FromState', 'ToState'}. This message can be disregarded if explicit configuration has been specified in 'OnModelCreating'.
+2025-09-27 06:13:51.426 +07:00 [DBG] No relationship from 'WorkflowState' to 'WorkflowTransition' has been configured by convention because there are multiple properties on one entity type - {'FromTransitions', 'ToTransitions'} that could be matched with the properties on the other entity type - {'FromState', 'ToState'}. This message can be disregarded if explicit configuration has been specified in 'OnModelCreating'.
+2025-09-27 06:13:51.427 +07:00 [DBG] No relationship from 'WorkflowTransition' to 'WorkflowState' has been configured by convention because there are multiple properties on one entity type - {'FromState', 'ToState'} that could be matched with the properties on the other entity type - {'FromTransitions', 'ToTransitions'}. This message can be disregarded if explicit configuration has been specified in 'OnModelCreating'.
+2025-09-27 06:13:51.608 +07:00 [DBG] No relationship from 'ReviewerAssignment' to 'User' has been configured by convention because there are multiple properties on one entity type - {'AssignedByUser', 'Reviewer'} that could be matched with the properties on the other entity type - {'ReviewerAssignments'}. This message can be disregarded if explicit configuration has been specified in 'OnModelCreating'.
+2025-09-27 06:13:51.609 +07:00 [DBG] No relationship from 'User' to 'ReviewerAssignment' has been configured by convention because there are multiple properties on one entity type - {'ReviewerAssignments'} that could be matched with the properties on the other entity type - {'AssignedByUser', 'Reviewer'}. This message can be disregarded if explicit configuration has been specified in 'OnModelCreating'.
+2025-09-27 06:13:51.629 +07:00 [DBG] No relationship from 'WorkflowTransition' to 'WorkflowState' has been configured by convention because there are multiple properties on one entity type - {'FromState', 'ToState'} that could be matched with the properties on the other entity type - {'FromTransitions', 'ToTransitions'}. This message can be disregarded if explicit configuration has been specified in 'OnModelCreating'.
+2025-09-27 06:13:51.629 +07:00 [DBG] No relationship from 'WorkflowState' to 'SubmissionWorkflowLog' has been configured by convention because there are multiple properties on one entity type - {'FromStateLogs', 'ToStateLogs'} that could be matched with the properties on the other entity type - {'FromState', 'ToState'}. This message can be disregarded if explicit configuration has been specified in 'OnModelCreating'.
+2025-09-27 06:13:51.629 +07:00 [DBG] No relationship from 'WorkflowState' to 'WorkflowTransition' has been configured by convention because there are multiple properties on one entity type - {'FromTransitions', 'ToTransitions'} that could be matched with the properties on the other entity type - {'FromState', 'ToState'}. This message can be disregarded if explicit configuration has been specified in 'OnModelCreating'.
+2025-09-27 06:13:51.630 +07:00 [DBG] No relationship from 'WorkflowState' to 'SubmissionWorkflowLog' has been configured by convention because there are multiple properties on one entity type - {'FromStateLogs', 'ToStateLogs'} that could be matched with the properties on the other entity type - {'FromState', 'ToState'}. This message can be disregarded if explicit configuration has been specified in 'OnModelCreating'.
+2025-09-27 06:13:51.634 +07:00 [DBG] No relationship from 'SubmissionWorkflowLog' to 'WorkflowState' has been configured by convention because there are multiple properties on one entity type - {'FromState', 'ToState'} that could be matched with the properties on the other entity type - {'FromStateLogs', 'ToStateLogs'}. This message can be disregarded if explicit configuration has been specified in 'OnModelCreating'.
+2025-09-27 06:13:51.635 +07:00 [DBG] No relationship from 'WorkflowState' to 'SubmissionWorkflowLog' has been configured by convention because there are multiple properties on one entity type - {'FromStateLogs', 'ToStateLogs'} that could be matched with the properties on the other entity type - {'FromState', 'ToState'}. This message can be disregarded if explicit configuration has been specified in 'OnModelCreating'.
+2025-09-27 06:13:51.668 +07:00 [DBG] The index {'LecturerId'} was not created on entity type 'LecturerSkill' as the properties are already covered by the index {'LecturerId', 'SkillTag'}.
+2025-09-27 06:13:51.669 +07:00 [DBG] The index {'SemesterId'} was not created on entity type 'Phase' as the properties are already covered by the index {'SemesterId', 'PhaseTypeId'}.
+2025-09-27 06:13:51.669 +07:00 [DBG] The index {'AssignmentId'} was not created on entity type 'Review' as the properties are already covered by the index {'AssignmentId', 'Status'}.
+2025-09-27 06:13:51.669 +07:00 [DBG] The index {'ReviewId'} was not created on entity type 'ReviewComment' as the properties are already covered by the index {'ReviewId', 'SectionName'}.
+2025-09-27 06:13:51.669 +07:00 [DBG] The index {'ReviewId'} was not created on entity type 'ReviewCriteriaScore' as the properties are already covered by the index {'ReviewId', 'CriteriaId'}.
+2025-09-27 06:13:51.669 +07:00 [DBG] The index {'ReviewerId'} was not created on entity type 'ReviewerAssignment' as the properties are already covered by the index {'ReviewerId', 'Status'}.
+2025-09-27 06:13:51.669 +07:00 [DBG] The index {'SubmissionId'} was not created on entity type 'ReviewerAssignment' as the properties are already covered by the index {'SubmissionId', 'ReviewerId'}.
+2025-09-27 06:13:51.669 +07:00 [DBG] The index {'ReviewerId'} was not created on entity type 'ReviewerPerformance' as the properties are already covered by the index {'ReviewerId', 'SemesterId'}.
+2025-09-27 06:13:51.669 +07:00 [DBG] The index {'PhaseId'} was not created on entity type 'Submission' as the properties are already covered by the index {'PhaseId', 'Status'}.
+2025-09-27 06:13:51.669 +07:00 [DBG] The index {'PhaseId'} was not created on entity type 'Submission' as the properties are already covered by the index {'PhaseId', 'Status', 'SubmittedAt'}.
+2025-09-27 06:13:51.669 +07:00 [DBG] The index {'TopicId'} was not created on entity type 'Submission' as the properties are already covered by the index {'TopicId', 'PhaseId', 'SubmissionRound'}.
+2025-09-27 06:13:51.669 +07:00 [DBG] The index {'SubmissionId'} was not created on entity type 'SubmissionWorkflowLog' as the properties are already covered by the index {'SubmissionId', 'CreatedAt'}.
+2025-09-27 06:13:51.669 +07:00 [DBG] The index {'UserId'} was not created on entity type 'SystemNotification' as the properties are already covered by the index {'UserId', 'IsRead', 'CreatedAt'}.
+2025-09-27 06:13:51.669 +07:00 [DBG] The index {'SemesterId'} was not created on entity type 'Topic' as the properties are already covered by the index {'SemesterId', 'IsApproved'}.
+2025-09-27 06:13:51.670 +07:00 [DBG] The index {'SupervisorId'} was not created on entity type 'Topic' as the properties are already covered by the index {'SupervisorId', 'SemesterId'}.
+2025-09-27 06:13:51.670 +07:00 [DBG] The index {'TopicId'} was not created on entity type 'TopicVersion' as the properties are already covered by the index {'TopicId', 'Status'}.
+2025-09-27 06:13:51.670 +07:00 [DBG] The index {'TopicId'} was not created on entity type 'TopicVersion' as the properties are already covered by the index {'TopicId', 'VersionNumber'}.
+2025-09-27 06:13:51.670 +07:00 [DBG] The index {'UserId'} was not created on entity type 'UserRole' as the properties are already covered by the index {'UserId', 'RoleId'}.
+2025-09-27 06:13:51.670 +07:00 [DBG] The index {'UserId'} was not created on entity type 'UserToken' as the properties are already covered by the index {'UserId', 'LoginProvider', 'Name'}.
+2025-09-27 06:13:51.786 +07:00 [WRN] The 'ProficiencyLevels' property 'ProficiencyLevel' on entity type 'LecturerSkill' is configured with a database-generated default, but has no configured sentinel value. The database-generated default will always be used for inserts when the property has the value '0', since this is the CLR default for the 'ProficiencyLevels' type. Consider using a nullable type, using a nullable backing field, or setting the sentinel value for the property to ensure the database default is used when, and only when, appropriate. See https://aka.ms/efcore-docs-default-values for more information.
+2025-09-27 06:13:51.787 +07:00 [WRN] The 'ReviewRecommendations' property 'Recommendation' on entity type 'Review' is configured with a database-generated default, but has no configured sentinel value. The database-generated default will always be used for inserts when the property has the value '0', since this is the CLR default for the 'ReviewRecommendations' type. Consider using a nullable type, using a nullable backing field, or setting the sentinel value for the property to ensure the database default is used when, and only when, appropriate. See https://aka.ms/efcore-docs-default-values for more information.
+2025-09-27 06:13:51.787 +07:00 [WRN] The 'ReviewStatus' property 'Status' on entity type 'Review' is configured with a database-generated default, but has no configured sentinel value. The database-generated default will always be used for inserts when the property has the value '0', since this is the CLR default for the 'ReviewStatus' type. Consider using a nullable type, using a nullable backing field, or setting the sentinel value for the property to ensure the database default is used when, and only when, appropriate. See https://aka.ms/efcore-docs-default-values for more information.
+2025-09-27 06:13:51.787 +07:00 [WRN] The 'CommentTypes' property 'CommentType' on entity type 'ReviewComment' is configured with a database-generated default, but has no configured sentinel value. The database-generated default will always be used for inserts when the property has the value '0', since this is the CLR default for the 'CommentTypes' type. Consider using a nullable type, using a nullable backing field, or setting the sentinel value for the property to ensure the database default is used when, and only when, appropriate. See https://aka.ms/efcore-docs-default-values for more information.
+2025-09-27 06:13:51.787 +07:00 [WRN] The 'PriorityLevels' property 'Priority' on entity type 'ReviewComment' is configured with a database-generated default, but has no configured sentinel value. The database-generated default will always be used for inserts when the property has the value '0', since this is the CLR default for the 'PriorityLevels' type. Consider using a nullable type, using a nullable backing field, or setting the sentinel value for the property to ensure the database default is used when, and only when, appropriate. See https://aka.ms/efcore-docs-default-values for more information.
+2025-09-27 06:13:51.787 +07:00 [WRN] The 'AssignmentTypes' property 'AssignmentType' on entity type 'ReviewerAssignment' is configured with a database-generated default, but has no configured sentinel value. The database-generated default will always be used for inserts when the property has the value '0', since this is the CLR default for the 'AssignmentTypes' type. Consider using a nullable type, using a nullable backing field, or setting the sentinel value for the property to ensure the database default is used when, and only when, appropriate. See https://aka.ms/efcore-docs-default-values for more information.
+2025-09-27 06:13:51.787 +07:00 [WRN] The 'AssignmentStatus' property 'Status' on entity type 'ReviewerAssignment' is configured with a database-generated default, but has no configured sentinel value. The database-generated default will always be used for inserts when the property has the value '0', since this is the CLR default for the 'AssignmentStatus' type. Consider using a nullable type, using a nullable backing field, or setting the sentinel value for the property to ensure the database default is used when, and only when, appropriate. See https://aka.ms/efcore-docs-default-values for more information.
+2025-09-27 06:13:51.787 +07:00 [WRN] The 'AiCheckStatus' property 'AiCheckStatus' on entity type 'Submission' is configured with a database-generated default, but has no configured sentinel value. The database-generated default will always be used for inserts when the property has the value '0', since this is the CLR default for the 'AiCheckStatus' type. Consider using a nullable type, using a nullable backing field, or setting the sentinel value for the property to ensure the database default is used when, and only when, appropriate. See https://aka.ms/efcore-docs-default-values for more information.
+2025-09-27 06:13:51.787 +07:00 [WRN] The 'SubmissionStatus' property 'Status' on entity type 'Submission' is configured with a database-generated default, but has no configured sentinel value. The database-generated default will always be used for inserts when the property has the value '0', since this is the CLR default for the 'SubmissionStatus' type. Consider using a nullable type, using a nullable backing field, or setting the sentinel value for the property to ensure the database default is used when, and only when, appropriate. See https://aka.ms/efcore-docs-default-values for more information.
+2025-09-27 06:13:51.787 +07:00 [WRN] The 'NotificationTypes' property 'Type' on entity type 'SystemNotification' is configured with a database-generated default, but has no configured sentinel value. The database-generated default will always be used for inserts when the property has the value '0', since this is the CLR default for the 'NotificationTypes' type. Consider using a nullable type, using a nullable backing field, or setting the sentinel value for the property to ensure the database default is used when, and only when, appropriate. See https://aka.ms/efcore-docs-default-values for more information.
+2025-09-27 06:13:51.788 +07:00 [WRN] The 'TopicStatus' property 'Status' on entity type 'TopicVersion' is configured with a database-generated default, but has no configured sentinel value. The database-generated default will always be used for inserts when the property has the value '0', since this is the CLR default for the 'TopicStatus' type. Consider using a nullable type, using a nullable backing field, or setting the sentinel value for the property to ensure the database default is used when, and only when, appropriate. See https://aka.ms/efcore-docs-default-values for more information.
+2025-09-27 06:13:51.917 +07:00 [DBG] Entity Framework Core 8.0.16 initialized 'MyDbContext' using provider 'Microsoft.EntityFrameworkCore.SqlServer:8.0.13' with options: MigrationsAssembly=App.DAL 
+2025-09-27 06:13:51.962 +07:00 [DBG] Compiling query expression: 
+'DbSet<Role>()
+    .FirstOrDefault(r => r.NormalizedName == __normalizedName_0)'
+2025-09-27 06:13:52.076 +07:00 [DBG] Generated query execution expression: 
+'queryContext => ShapedQueryCompilingExpressionVisitor.SingleOrDefaultAsync<Role>(
+    asyncEnumerable: new SingleQueryingEnumerable<Role>(
+        (RelationalQueryContext)queryContext, 
+        RelationalCommandCache.QueryExpression(
+            Projection Mapping:
+                EmptyProjectionMember -> Dictionary<IProperty, int> { [Property: Role.Id (int) Required PK AfterSave:Throw ValueGenerated.OnAdd, 0], [Property: Role.ConcurrencyStamp (string), 1], [Property: Role.IsAdmin (bool) Required, 2], [Property: Role.Name (string), 3], [Property: Role.NormalizedName (string), 4] }
+            SELECT TOP(1) r.Id, r.ConcurrencyStamp, r.IsAdmin, r.Name, r.NormalizedName
+            FROM roles AS r
+            WHERE r.NormalizedName == @__normalizedName_0), 
+        null, 
+        Func<QueryContext, DbDataReader, ResultContext, SingleQueryResultCoordinator, Role>, 
+        App.DAL.Context.MyDbContext, 
+        False, 
+        False, 
+        True
+    ), 
+    cancellationToken: queryContext.CancellationToken)'
+2025-09-27 06:13:52.101 +07:00 [DBG] Creating DbConnection.
+2025-09-27 06:13:52.113 +07:00 [DBG] Created DbConnection. (9ms).
+2025-09-27 06:13:52.116 +07:00 [DBG] Opening connection to database 'capbot_db' on server 'localhost'.
+2025-09-27 06:13:52.221 +07:00 [DBG] Opened connection to database 'capbot_db' on server 'localhost'.
+2025-09-27 06:13:52.224 +07:00 [DBG] Creating DbCommand for 'ExecuteReader'.
+2025-09-27 06:13:52.228 +07:00 [DBG] Created DbCommand for 'ExecuteReader' (2ms).
+2025-09-27 06:13:52.233 +07:00 [DBG] Initialized DbCommand for 'ExecuteReader' (8ms).
+2025-09-27 06:13:52.237 +07:00 [DBG] Executing DbCommand [Parameters=[@__normalizedName_0='?' (Size = 4000)], CommandType='"Text"', CommandTimeout='30']
+SELECT TOP(1) [r].[Id], [r].[ConcurrencyStamp], [r].[IsAdmin], [r].[Name], [r].[NormalizedName]
+FROM [roles] AS [r]
+WHERE [r].[NormalizedName] = @__normalizedName_0
+2025-09-27 06:13:52.274 +07:00 [INF] Executed DbCommand (36ms) [Parameters=[@__normalizedName_0='?' (Size = 4000)], CommandType='"Text"', CommandTimeout='30']
+SELECT TOP(1) [r].[Id], [r].[ConcurrencyStamp], [r].[IsAdmin], [r].[Name], [r].[NormalizedName]
+FROM [roles] AS [r]
+WHERE [r].[NormalizedName] = @__normalizedName_0
+2025-09-27 06:13:52.305 +07:00 [DBG] Context 'MyDbContext' started tracking 'Role' entity. Consider using 'DbContextOptionsBuilder.EnableSensitiveDataLogging' to see key values.
+2025-09-27 06:13:52.319 +07:00 [DBG] Closing data reader to 'capbot_db' on server 'localhost'.
+2025-09-27 06:13:52.323 +07:00 [DBG] A data reader for 'capbot_db' on server 'localhost' is being disposed after spending 46ms reading results.
+2025-09-27 06:13:52.325 +07:00 [DBG] Closing connection to database 'capbot_db' on server 'localhost'.
+2025-09-27 06:13:52.328 +07:00 [DBG] Closed connection to database 'capbot_db' on server 'localhost' (3ms).
+2025-09-27 06:13:52.330 +07:00 [DBG] Opening connection to database 'capbot_db' on server 'localhost'.
+2025-09-27 06:13:52.331 +07:00 [DBG] Opened connection to database 'capbot_db' on server 'localhost'.
+2025-09-27 06:13:52.331 +07:00 [DBG] Creating DbCommand for 'ExecuteReader'.
+2025-09-27 06:13:52.331 +07:00 [DBG] Created DbCommand for 'ExecuteReader' (0ms).
+2025-09-27 06:13:52.331 +07:00 [DBG] Initialized DbCommand for 'ExecuteReader' (0ms).
+2025-09-27 06:13:52.332 +07:00 [DBG] Executing DbCommand [Parameters=[@__normalizedName_0='?' (Size = 4000)], CommandType='"Text"', CommandTimeout='30']
+SELECT TOP(1) [r].[Id], [r].[ConcurrencyStamp], [r].[IsAdmin], [r].[Name], [r].[NormalizedName]
+FROM [roles] AS [r]
+WHERE [r].[NormalizedName] = @__normalizedName_0
+2025-09-27 06:13:52.334 +07:00 [INF] Executed DbCommand (3ms) [Parameters=[@__normalizedName_0='?' (Size = 4000)], CommandType='"Text"', CommandTimeout='30']
+SELECT TOP(1) [r].[Id], [r].[ConcurrencyStamp], [r].[IsAdmin], [r].[Name], [r].[NormalizedName]
+FROM [roles] AS [r]
+WHERE [r].[NormalizedName] = @__normalizedName_0
+2025-09-27 06:13:52.335 +07:00 [DBG] Context 'MyDbContext' started tracking 'Role' entity. Consider using 'DbContextOptionsBuilder.EnableSensitiveDataLogging' to see key values.
+2025-09-27 06:13:52.335 +07:00 [DBG] Closing data reader to 'capbot_db' on server 'localhost'.
+2025-09-27 06:13:52.336 +07:00 [DBG] A data reader for 'capbot_db' on server 'localhost' is being disposed after spending 0ms reading results.
+2025-09-27 06:13:52.336 +07:00 [DBG] Closing connection to database 'capbot_db' on server 'localhost'.
+2025-09-27 06:13:52.336 +07:00 [DBG] Closed connection to database 'capbot_db' on server 'localhost' (0ms).
+2025-09-27 06:13:52.337 +07:00 [DBG] Opening connection to database 'capbot_db' on server 'localhost'.
+2025-09-27 06:13:52.337 +07:00 [DBG] Opened connection to database 'capbot_db' on server 'localhost'.
+2025-09-27 06:13:52.337 +07:00 [DBG] Creating DbCommand for 'ExecuteReader'.
+2025-09-27 06:13:52.337 +07:00 [DBG] Created DbCommand for 'ExecuteReader' (0ms).
+2025-09-27 06:13:52.337 +07:00 [DBG] Initialized DbCommand for 'ExecuteReader' (0ms).
+2025-09-27 06:13:52.337 +07:00 [DBG] Executing DbCommand [Parameters=[@__normalizedName_0='?' (Size = 4000)], CommandType='"Text"', CommandTimeout='30']
+SELECT TOP(1) [r].[Id], [r].[ConcurrencyStamp], [r].[IsAdmin], [r].[Name], [r].[NormalizedName]
+FROM [roles] AS [r]
+WHERE [r].[NormalizedName] = @__normalizedName_0
+2025-09-27 06:13:52.339 +07:00 [INF] Executed DbCommand (1ms) [Parameters=[@__normalizedName_0='?' (Size = 4000)], CommandType='"Text"', CommandTimeout='30']
+SELECT TOP(1) [r].[Id], [r].[ConcurrencyStamp], [r].[IsAdmin], [r].[Name], [r].[NormalizedName]
+FROM [roles] AS [r]
+WHERE [r].[NormalizedName] = @__normalizedName_0
+2025-09-27 06:13:52.339 +07:00 [DBG] Context 'MyDbContext' started tracking 'Role' entity. Consider using 'DbContextOptionsBuilder.EnableSensitiveDataLogging' to see key values.
+2025-09-27 06:13:52.339 +07:00 [DBG] Closing data reader to 'capbot_db' on server 'localhost'.
+2025-09-27 06:13:52.339 +07:00 [DBG] A data reader for 'capbot_db' on server 'localhost' is being disposed after spending 0ms reading results.
+2025-09-27 06:13:52.340 +07:00 [DBG] Closing connection to database 'capbot_db' on server 'localhost'.
+2025-09-27 06:13:52.340 +07:00 [DBG] Closed connection to database 'capbot_db' on server 'localhost' (0ms).
+2025-09-27 06:13:52.340 +07:00 [DBG] Opening connection to database 'capbot_db' on server 'localhost'.
+2025-09-27 06:13:52.340 +07:00 [DBG] Opened connection to database 'capbot_db' on server 'localhost'.
+2025-09-27 06:13:52.341 +07:00 [DBG] Creating DbCommand for 'ExecuteReader'.
+2025-09-27 06:13:52.341 +07:00 [DBG] Created DbCommand for 'ExecuteReader' (0ms).
+2025-09-27 06:13:52.341 +07:00 [DBG] Initialized DbCommand for 'ExecuteReader' (0ms).
+2025-09-27 06:13:52.341 +07:00 [DBG] Executing DbCommand [Parameters=[@__normalizedName_0='?' (Size = 4000)], CommandType='"Text"', CommandTimeout='30']
+SELECT TOP(1) [r].[Id], [r].[ConcurrencyStamp], [r].[IsAdmin], [r].[Name], [r].[NormalizedName]
+FROM [roles] AS [r]
+WHERE [r].[NormalizedName] = @__normalizedName_0
+2025-09-27 06:13:52.342 +07:00 [INF] Executed DbCommand (1ms) [Parameters=[@__normalizedName_0='?' (Size = 4000)], CommandType='"Text"', CommandTimeout='30']
+SELECT TOP(1) [r].[Id], [r].[ConcurrencyStamp], [r].[IsAdmin], [r].[Name], [r].[NormalizedName]
+FROM [roles] AS [r]
+WHERE [r].[NormalizedName] = @__normalizedName_0
+2025-09-27 06:13:52.343 +07:00 [DBG] Context 'MyDbContext' started tracking 'Role' entity. Consider using 'DbContextOptionsBuilder.EnableSensitiveDataLogging' to see key values.
+2025-09-27 06:13:52.343 +07:00 [DBG] Closing data reader to 'capbot_db' on server 'localhost'.
+2025-09-27 06:13:52.343 +07:00 [DBG] A data reader for 'capbot_db' on server 'localhost' is being disposed after spending 0ms reading results.
+2025-09-27 06:13:52.343 +07:00 [DBG] Closing connection to database 'capbot_db' on server 'localhost'.
+2025-09-27 06:13:52.343 +07:00 [DBG] Closed connection to database 'capbot_db' on server 'localhost' (0ms).
+2025-09-27 06:13:52.350 +07:00 [DBG] Compiling query expression: 
+'DbSet<User>()
+    .SingleOrDefault(u => u.NormalizedEmail == __normalizedEmail_0)'
+2025-09-27 06:13:52.355 +07:00 [DBG] Generated query execution expression: 
+'queryContext => ShapedQueryCompilingExpressionVisitor.SingleOrDefaultAsync<User>(
+    asyncEnumerable: new SingleQueryingEnumerable<User>(
+        (RelationalQueryContext)queryContext, 
+        RelationalCommandCache.QueryExpression(
+            Projection Mapping:
+                EmptyProjectionMember -> Dictionary<IProperty, int> { [Property: User.Id (int) Required PK AfterSave:Throw ValueGenerated.OnAdd, 0], [Property: User.AccessFailedCount (int) Required, 1], [Property: User.ConcurrencyStamp (string), 2], [Property: User.CreatedAt (DateTime) Required, 3], [Property: User.DeletedAt (DateTime?), 4], [Property: User.Email (string), 5], [Property: User.EmailConfirmed (bool) Required, 6], [Property: User.LastModifiedAt (DateTime) Required, 7], [Property: User.LastModifiedBy (string), 8], [Property: User.LockoutEnabled (bool) Required, 9], [Property: User.LockoutEnd (DateTimeOffset?), 10], [Property: User.NormalizedEmail (string), 11], [Property: User.NormalizedUserName (string), 12], [Property: User.PasswordHash (string), 13], [Property: User.PhoneNumber (string), 14], [Property: User.PhoneNumberConfirmed (bool) Required, 15], [Property: User.SecurityStamp (string), 16], [Property: User.TwoFactorEnabled (bool) Required, 17], [Property: User.UserName (string), 18] }
+            SELECT TOP(2) u.Id, u.AccessFailedCount, u.ConcurrencyStamp, u.CreatedAt, u.DeletedAt, u.Email, u.EmailConfirmed, u.LastModifiedAt, u.LastModifiedBy, u.LockoutEnabled, u.LockoutEnd, u.NormalizedEmail, u.NormalizedUserName, u.PasswordHash, u.PhoneNumber, u.PhoneNumberConfirmed, u.SecurityStamp, u.TwoFactorEnabled, u.UserName
+            FROM users AS u
+            WHERE u.NormalizedEmail == @__normalizedEmail_0), 
+        null, 
+        Func<QueryContext, DbDataReader, ResultContext, SingleQueryResultCoordinator, User>, 
+        App.DAL.Context.MyDbContext, 
+        False, 
+        False, 
+        True
+    ), 
+    cancellationToken: queryContext.CancellationToken)'
+2025-09-27 06:13:52.356 +07:00 [DBG] Opening connection to database 'capbot_db' on server 'localhost'.
+2025-09-27 06:13:52.356 +07:00 [DBG] Opened connection to database 'capbot_db' on server 'localhost'.
+2025-09-27 06:13:52.356 +07:00 [DBG] Creating DbCommand for 'ExecuteReader'.
+2025-09-27 06:13:52.356 +07:00 [DBG] Created DbCommand for 'ExecuteReader' (0ms).
+2025-09-27 06:13:52.356 +07:00 [DBG] Initialized DbCommand for 'ExecuteReader' (0ms).
+2025-09-27 06:13:52.356 +07:00 [DBG] Executing DbCommand [Parameters=[@__normalizedEmail_0='?' (Size = 4000)], CommandType='"Text"', CommandTimeout='30']
+SELECT TOP(2) [u].[Id], [u].[AccessFailedCount], [u].[ConcurrencyStamp], [u].[CreatedAt], [u].[DeletedAt], [u].[Email], [u].[EmailConfirmed], [u].[LastModifiedAt], [u].[LastModifiedBy], [u].[LockoutEnabled], [u].[LockoutEnd], [u].[NormalizedEmail], [u].[NormalizedUserName], [u].[PasswordHash], [u].[PhoneNumber], [u].[PhoneNumberConfirmed], [u].[SecurityStamp], [u].[TwoFactorEnabled], [u].[UserName]
+FROM [users] AS [u]
+WHERE [u].[NormalizedEmail] = @__normalizedEmail_0
+2025-09-27 06:13:52.359 +07:00 [INF] Executed DbCommand (3ms) [Parameters=[@__normalizedEmail_0='?' (Size = 4000)], CommandType='"Text"', CommandTimeout='30']
+SELECT TOP(2) [u].[Id], [u].[AccessFailedCount], [u].[ConcurrencyStamp], [u].[CreatedAt], [u].[DeletedAt], [u].[Email], [u].[EmailConfirmed], [u].[LastModifiedAt], [u].[LastModifiedBy], [u].[LockoutEnabled], [u].[LockoutEnd], [u].[NormalizedEmail], [u].[NormalizedUserName], [u].[PasswordHash], [u].[PhoneNumber], [u].[PhoneNumberConfirmed], [u].[SecurityStamp], [u].[TwoFactorEnabled], [u].[UserName]
+FROM [users] AS [u]
+WHERE [u].[NormalizedEmail] = @__normalizedEmail_0
+2025-09-27 06:13:52.378 +07:00 [DBG] Context 'MyDbContext' started tracking 'User' entity. Consider using 'DbContextOptionsBuilder.EnableSensitiveDataLogging' to see key values.
+2025-09-27 06:13:52.401 +07:00 [DBG] Closing data reader to 'capbot_db' on server 'localhost'.
+2025-09-27 06:13:52.401 +07:00 [DBG] A data reader for 'capbot_db' on server 'localhost' is being disposed after spending 41ms reading results.
+2025-09-27 06:13:52.401 +07:00 [DBG] Closing connection to database 'capbot_db' on server 'localhost'.
+2025-09-27 06:13:52.401 +07:00 [DBG] Closed connection to database 'capbot_db' on server 'localhost' (0ms).
+2025-09-27 06:13:52.404 +07:00 [INF] Admin user 'fptslayer@gmail.com' already exists
+2025-09-27 06:13:52.406 +07:00 [DBG] Opening connection to database 'capbot_db' on server 'localhost'.
+2025-09-27 06:13:52.406 +07:00 [DBG] Opened connection to database 'capbot_db' on server 'localhost'.
+2025-09-27 06:13:52.406 +07:00 [DBG] Creating DbCommand for 'ExecuteReader'.
+2025-09-27 06:13:52.406 +07:00 [DBG] Created DbCommand for 'ExecuteReader' (0ms).
+2025-09-27 06:13:52.406 +07:00 [DBG] Initialized DbCommand for 'ExecuteReader' (0ms).
+2025-09-27 06:13:52.406 +07:00 [DBG] Executing DbCommand [Parameters=[@__normalizedEmail_0='?' (Size = 4000)], CommandType='"Text"', CommandTimeout='30']
+SELECT TOP(2) [u].[Id], [u].[AccessFailedCount], [u].[ConcurrencyStamp], [u].[CreatedAt], [u].[DeletedAt], [u].[Email], [u].[EmailConfirmed], [u].[LastModifiedAt], [u].[LastModifiedBy], [u].[LockoutEnabled], [u].[LockoutEnd], [u].[NormalizedEmail], [u].[NormalizedUserName], [u].[PasswordHash], [u].[PhoneNumber], [u].[PhoneNumberConfirmed], [u].[SecurityStamp], [u].[TwoFactorEnabled], [u].[UserName]
+FROM [users] AS [u]
+WHERE [u].[NormalizedEmail] = @__normalizedEmail_0
+2025-09-27 06:13:52.407 +07:00 [INF] Executed DbCommand (1ms) [Parameters=[@__normalizedEmail_0='?' (Size = 4000)], CommandType='"Text"', CommandTimeout='30']
+SELECT TOP(2) [u].[Id], [u].[AccessFailedCount], [u].[ConcurrencyStamp], [u].[CreatedAt], [u].[DeletedAt], [u].[Email], [u].[EmailConfirmed], [u].[LastModifiedAt], [u].[LastModifiedBy], [u].[LockoutEnabled], [u].[LockoutEnd], [u].[NormalizedEmail], [u].[NormalizedUserName], [u].[PasswordHash], [u].[PhoneNumber], [u].[PhoneNumberConfirmed], [u].[SecurityStamp], [u].[TwoFactorEnabled], [u].[UserName]
+FROM [users] AS [u]
+WHERE [u].[NormalizedEmail] = @__normalizedEmail_0
+2025-09-27 06:13:52.407 +07:00 [DBG] Context 'MyDbContext' started tracking 'User' entity. Consider using 'DbContextOptionsBuilder.EnableSensitiveDataLogging' to see key values.
+2025-09-27 06:13:52.407 +07:00 [DBG] Closing data reader to 'capbot_db' on server 'localhost'.
+2025-09-27 06:13:52.407 +07:00 [DBG] A data reader for 'capbot_db' on server 'localhost' is being disposed after spending 0ms reading results.
+2025-09-27 06:13:52.407 +07:00 [DBG] Closing connection to database 'capbot_db' on server 'localhost'.
+2025-09-27 06:13:52.407 +07:00 [DBG] Closed connection to database 'capbot_db' on server 'localhost' (0ms).
+2025-09-27 06:13:52.407 +07:00 [INF] Sample moderator 'moderator@example.com' already exists
+2025-09-27 06:13:52.408 +07:00 [DBG] Opening connection to database 'capbot_db' on server 'localhost'.
+2025-09-27 06:13:52.408 +07:00 [DBG] Opened connection to database 'capbot_db' on server 'localhost'.
+2025-09-27 06:13:52.408 +07:00 [DBG] Creating DbCommand for 'ExecuteReader'.
+2025-09-27 06:13:52.408 +07:00 [DBG] Created DbCommand for 'ExecuteReader' (0ms).
+2025-09-27 06:13:52.408 +07:00 [DBG] Initialized DbCommand for 'ExecuteReader' (0ms).
+2025-09-27 06:13:52.408 +07:00 [DBG] Executing DbCommand [Parameters=[@__normalizedEmail_0='?' (Size = 4000)], CommandType='"Text"', CommandTimeout='30']
+SELECT TOP(2) [u].[Id], [u].[AccessFailedCount], [u].[ConcurrencyStamp], [u].[CreatedAt], [u].[DeletedAt], [u].[Email], [u].[EmailConfirmed], [u].[LastModifiedAt], [u].[LastModifiedBy], [u].[LockoutEnabled], [u].[LockoutEnd], [u].[NormalizedEmail], [u].[NormalizedUserName], [u].[PasswordHash], [u].[PhoneNumber], [u].[PhoneNumberConfirmed], [u].[SecurityStamp], [u].[TwoFactorEnabled], [u].[UserName]
+FROM [users] AS [u]
+WHERE [u].[NormalizedEmail] = @__normalizedEmail_0
+2025-09-27 06:13:52.409 +07:00 [INF] Executed DbCommand (1ms) [Parameters=[@__normalizedEmail_0='?' (Size = 4000)], CommandType='"Text"', CommandTimeout='30']
+SELECT TOP(2) [u].[Id], [u].[AccessFailedCount], [u].[ConcurrencyStamp], [u].[CreatedAt], [u].[DeletedAt], [u].[Email], [u].[EmailConfirmed], [u].[LastModifiedAt], [u].[LastModifiedBy], [u].[LockoutEnabled], [u].[LockoutEnd], [u].[NormalizedEmail], [u].[NormalizedUserName], [u].[PasswordHash], [u].[PhoneNumber], [u].[PhoneNumberConfirmed], [u].[SecurityStamp], [u].[TwoFactorEnabled], [u].[UserName]
+FROM [users] AS [u]
+WHERE [u].[NormalizedEmail] = @__normalizedEmail_0
+2025-09-27 06:13:52.409 +07:00 [DBG] Context 'MyDbContext' started tracking 'User' entity. Consider using 'DbContextOptionsBuilder.EnableSensitiveDataLogging' to see key values.
+2025-09-27 06:13:52.409 +07:00 [DBG] Closing data reader to 'capbot_db' on server 'localhost'.
+2025-09-27 06:13:52.410 +07:00 [DBG] A data reader for 'capbot_db' on server 'localhost' is being disposed after spending 0ms reading results.
+2025-09-27 06:13:52.410 +07:00 [DBG] Closing connection to database 'capbot_db' on server 'localhost'.
+2025-09-27 06:13:52.410 +07:00 [DBG] Closed connection to database 'capbot_db' on server 'localhost' (0ms).
+2025-09-27 06:13:52.410 +07:00 [DBG] Opening connection to database 'capbot_db' on server 'localhost'.
+2025-09-27 06:13:52.410 +07:00 [DBG] Opened connection to database 'capbot_db' on server 'localhost'.
+2025-09-27 06:13:52.410 +07:00 [DBG] Creating DbCommand for 'ExecuteReader'.
+2025-09-27 06:13:52.410 +07:00 [DBG] Created DbCommand for 'ExecuteReader' (0ms).
+2025-09-27 06:13:52.411 +07:00 [DBG] Initialized DbCommand for 'ExecuteReader' (0ms).
+2025-09-27 06:13:52.411 +07:00 [DBG] Executing DbCommand [Parameters=[@__normalizedEmail_0='?' (Size = 4000)], CommandType='"Text"', CommandTimeout='30']
+SELECT TOP(2) [u].[Id], [u].[AccessFailedCount], [u].[ConcurrencyStamp], [u].[CreatedAt], [u].[DeletedAt], [u].[Email], [u].[EmailConfirmed], [u].[LastModifiedAt], [u].[LastModifiedBy], [u].[LockoutEnabled], [u].[LockoutEnd], [u].[NormalizedEmail], [u].[NormalizedUserName], [u].[PasswordHash], [u].[PhoneNumber], [u].[PhoneNumberConfirmed], [u].[SecurityStamp], [u].[TwoFactorEnabled], [u].[UserName]
+FROM [users] AS [u]
+WHERE [u].[NormalizedEmail] = @__normalizedEmail_0
+2025-09-27 06:13:52.412 +07:00 [INF] Executed DbCommand (1ms) [Parameters=[@__normalizedEmail_0='?' (Size = 4000)], CommandType='"Text"', CommandTimeout='30']
+SELECT TOP(2) [u].[Id], [u].[AccessFailedCount], [u].[ConcurrencyStamp], [u].[CreatedAt], [u].[DeletedAt], [u].[Email], [u].[EmailConfirmed], [u].[LastModifiedAt], [u].[LastModifiedBy], [u].[LockoutEnabled], [u].[LockoutEnd], [u].[NormalizedEmail], [u].[NormalizedUserName], [u].[PasswordHash], [u].[PhoneNumber], [u].[PhoneNumberConfirmed], [u].[SecurityStamp], [u].[TwoFactorEnabled], [u].[UserName]
+FROM [users] AS [u]
+WHERE [u].[NormalizedEmail] = @__normalizedEmail_0
+2025-09-27 06:13:52.412 +07:00 [DBG] Context 'MyDbContext' started tracking 'User' entity. Consider using 'DbContextOptionsBuilder.EnableSensitiveDataLogging' to see key values.
+2025-09-27 06:13:52.413 +07:00 [DBG] Closing data reader to 'capbot_db' on server 'localhost'.
+2025-09-27 06:13:52.413 +07:00 [DBG] A data reader for 'capbot_db' on server 'localhost' is being disposed after spending 0ms reading results.
+2025-09-27 06:13:52.413 +07:00 [DBG] Closing connection to database 'capbot_db' on server 'localhost'.
+2025-09-27 06:13:52.413 +07:00 [DBG] Closed connection to database 'capbot_db' on server 'localhost' (0ms).
+2025-09-27 06:13:52.413 +07:00 [INF] Data seeding completed successfully
+2025-09-27 06:13:52.414 +07:00 [DBG] 'MyDbContext' disposed.
+2025-09-27 06:13:52.415 +07:00 [DBG] Disposing connection to database 'capbot_db' on server 'localhost'.
+2025-09-27 06:13:52.416 +07:00 [DBG] Disposed connection to database '' on server '' (0ms).
+2025-09-27 06:13:52.426 +07:00 [DBG] Registered SignalR Protocol: json, implemented by Microsoft.AspNetCore.SignalR.Protocol.JsonHubProtocol.
+2025-09-27 06:13:52.546 +07:00 [DBG] Registered model binder providers, in the following order: ["Microsoft.AspNetCore.Mvc.ModelBinding.Binders.BinderTypeModelBinderProvider","Microsoft.AspNetCore.Mvc.ModelBinding.Binders.ServicesModelBinderProvider","Microsoft.AspNetCore.Mvc.ModelBinding.Binders.BodyModelBinderProvider","Microsoft.AspNetCore.Mvc.ModelBinding.Binders.HeaderModelBinderProvider","Microsoft.AspNetCore.Mvc.ModelBinding.Binders.FloatingPointTypeModelBinderProvider","Microsoft.AspNetCore.Mvc.ModelBinding.Binders.EnumTypeModelBinderProvider","Microsoft.AspNetCore.Mvc.ModelBinding.Binders.DateTimeModelBinderProvider","Microsoft.AspNetCore.Mvc.ModelBinding.Binders.SimpleTypeModelBinderProvider","Microsoft.AspNetCore.Mvc.ModelBinding.Binders.TryParseModelBinderProvider","Microsoft.AspNetCore.Mvc.ModelBinding.Binders.CancellationTokenModelBinderProvider"]
+2025-09-27 06:13:52.627 +07:00 [DBG] Hosting starting
+2025-09-27 06:13:52.635 +07:00 [DBG] Reading data from file 'C:\Users\Admin\AppData\Local\ASP.NET\DataProtection-Keys\key-1d6bcff1-a155-4167-8a22-de35a5f05047.xml'.
+2025-09-27 06:13:52.636 +07:00 [DBG] Reading data from file 'C:\Users\Admin\AppData\Local\ASP.NET\DataProtection-Keys\key-2459dd29-32d5-4c49-ac9d-33896047bb78.xml'.
+2025-09-27 06:13:52.637 +07:00 [DBG] Reading data from file 'C:\Users\Admin\AppData\Local\ASP.NET\DataProtection-Keys\key-374624f1-e856-4617-8ae6-fe6a81ce6346.xml'.
+2025-09-27 06:13:52.640 +07:00 [DBG] Found key {1d6bcff1-a155-4167-8a22-de35a5f05047}.
+2025-09-27 06:13:52.643 +07:00 [DBG] Found key {2459dd29-32d5-4c49-ac9d-33896047bb78}.
+2025-09-27 06:13:52.643 +07:00 [DBG] Found key {374624f1-e856-4617-8ae6-fe6a81ce6346}.
+2025-09-27 06:13:52.647 +07:00 [DBG] Considering key {2459dd29-32d5-4c49-ac9d-33896047bb78} with expiration date 2025-11-03 12:40:53Z as default key.
+2025-09-27 06:13:52.649 +07:00 [DBG] Forwarded activator type request from Microsoft.AspNetCore.DataProtection.XmlEncryption.DpapiXmlDecryptor, Microsoft.AspNetCore.DataProtection, Version=8.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60 to Microsoft.AspNetCore.DataProtection.XmlEncryption.DpapiXmlDecryptor, Microsoft.AspNetCore.DataProtection, Culture=neutral, PublicKeyToken=adb9793829ddae60
+2025-09-27 06:13:52.650 +07:00 [DBG] Decrypting secret element using Windows DPAPI.
+2025-09-27 06:13:52.651 +07:00 [DBG] Forwarded activator type request from Microsoft.AspNetCore.DataProtection.AuthenticatedEncryption.ConfigurationModel.AuthenticatedEncryptorDescriptorDeserializer, Microsoft.AspNetCore.DataProtection, Version=8.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60 to Microsoft.AspNetCore.DataProtection.AuthenticatedEncryption.ConfigurationModel.AuthenticatedEncryptorDescriptorDeserializer, Microsoft.AspNetCore.DataProtection, Culture=neutral, PublicKeyToken=adb9793829ddae60
+2025-09-27 06:13:52.652 +07:00 [DBG] Opening CNG algorithm 'AES' from provider 'null' with chaining mode CBC.
+2025-09-27 06:13:52.653 +07:00 [DBG] Opening CNG algorithm 'SHA256' from provider 'null' with HMAC.
+2025-09-27 06:13:52.654 +07:00 [DBG] Using key {2459dd29-32d5-4c49-ac9d-33896047bb78} as the default key.
+2025-09-27 06:13:52.655 +07:00 [DBG] Key ring with default key {2459dd29-32d5-4c49-ac9d-33896047bb78} was loaded during application startup.
+2025-09-27 06:13:52.659 +07:00 [DBG] Middleware loaded
+2025-09-27 06:13:52.661 +07:00 [DBG] Middleware loaded. Script /_framework/aspnetcore-browser-refresh.js (16481 B).
+2025-09-27 06:13:52.662 +07:00 [DBG] Middleware loaded. Script /_framework/blazor-hotreload.js (799 B).
+2025-09-27 06:13:52.685 +07:00 [DBG] Middleware loaded: DOTNET_MODIFIABLE_ASSEMBLIES=debug, __ASPNETCORE_BROWSER_TOOLS=true
+2025-09-27 06:13:52.694 +07:00 [INF] Now listening on: http://localhost:5207
+2025-09-27 06:13:52.695 +07:00 [DBG] Loaded hosting startup assembly CapBot.api
+2025-09-27 06:13:52.695 +07:00 [DBG] Loaded hosting startup assembly Microsoft.AspNetCore.Watch.BrowserRefresh
+2025-09-27 06:13:52.695 +07:00 [INF] Application started. Press Ctrl+C to shut down.
+2025-09-27 06:13:52.695 +07:00 [INF] Hosting environment: Development
+2025-09-27 06:13:52.695 +07:00 [INF] Content root path: C:\Users\Admin\Downloads\CBAI_API\capbot.api
+2025-09-27 06:13:52.696 +07:00 [DBG] Hosting started
+2025-09-27 06:13:52.786 +07:00 [DBG] Connection id "0HNFTA9DUP8V6" accepted.
+2025-09-27 06:13:52.787 +07:00 [DBG] Connection id "0HNFTA9DUP8V6" started.
+2025-09-27 06:13:52.818 +07:00 [INF] Request starting HTTP/1.1 GET http://localhost:5207/index.html - null null
+2025-09-27 06:13:52.828 +07:00 [DBG] Connection id "0HNFTA9DUP8V7" accepted.
+2025-09-27 06:13:52.829 +07:00 [DBG] Connection id "0HNFTA9DUP8V7" started.
+2025-09-27 06:13:52.831 +07:00 [DBG] Wildcard detected, all requests with hosts will be allowed.
+2025-09-27 06:13:52.973 +07:00 [DBG] Response markup is scheduled to include browser refresh script injection.
+2025-09-27 06:13:52.984 +07:00 [DBG] Response markup was updated to include browser refresh script injection.
+2025-09-27 06:13:52.984 +07:00 [DBG] Connection id "0HNFTA9DUP8V6" completed keep alive response.
+2025-09-27 06:13:52.986 +07:00 [INF] Request finished HTTP/1.1 GET http://localhost:5207/index.html - 200 null text/html;charset=utf-8 169.3652ms
+2025-09-27 06:13:52.992 +07:00 [INF] Request starting HTTP/1.1 GET http://localhost:5207/_framework/aspnetcore-browser-refresh.js - null null
+2025-09-27 06:13:52.998 +07:00 [DBG] Script injected: /_framework/aspnetcore-browser-refresh.js
+2025-09-27 06:13:53.002 +07:00 [DBG] Connection id "0HNFTA9DUP8V6" completed keep alive response.
+2025-09-27 06:13:53.003 +07:00 [INF] Request finished HTTP/1.1 GET http://localhost:5207/_framework/aspnetcore-browser-refresh.js - 200 16481 application/javascript; charset=utf-8 11.2849ms
+2025-09-27 06:13:53.049 +07:00 [INF] Request starting HTTP/1.1 GET http://localhost:5207/swagger/v1/swagger.json - null null
+2025-09-27 06:13:53.279 +07:00 [DBG] Connection id "0HNFTA9DUP8V6" completed keep alive response.
+2025-09-27 06:13:53.280 +07:00 [INF] Request finished HTTP/1.1 GET http://localhost:5207/swagger/v1/swagger.json - 200 null application/json;charset=utf-8 230.4162ms
+2025-09-27 06:14:10.411 +07:00 [INF] Request starting HTTP/1.1 POST http://localhost:5207/api/reviews - application/json;odata.metadata=minimal;odata.streaming=true 193
+2025-09-27 06:14:10.414 +07:00 [DBG] POST requests are not supported
+2025-09-27 06:14:10.415 +07:00 [WRN] Failed to determine the https port for redirect.
+2025-09-27 06:14:10.415 +07:00 [DBG] POST requests are not supported
+2025-09-27 06:14:10.417 +07:00 [DBG] The request has an origin header: 'http://localhost:5207'.
+2025-09-27 06:14:10.418 +07:00 [INF] CORS policy execution successful.
+2025-09-27 06:14:10.502 +07:00 [DBG] 1 candidate(s) found for the request path '/api/reviews'
+2025-09-27 06:14:10.503 +07:00 [DBG] Endpoint 'CapBot.api.Controllers.ReviewController.Create (CapBot.api)' with route pattern 'api/reviews' is valid for the request path '/api/reviews'
+2025-09-27 06:14:10.504 +07:00 [DBG] Request matched endpoint 'CapBot.api.Controllers.ReviewController.Create (CapBot.api)'
+2025-09-27 06:14:10.661 +07:00 [DBG] Successfully validated the token.
+2025-09-27 06:14:10.663 +07:00 [DBG] AuthenticationScheme: Bearer was successfully authenticated.
+2025-09-27 06:14:10.671 +07:00 [DBG] Authorization was successful.
+2025-09-27 06:14:10.690 +07:00 [INF] Executing endpoint 'CapBot.api.Controllers.ReviewController.Create (CapBot.api)'
+2025-09-27 06:14:10.719 +07:00 [INF] Route matched with {action = "Create", controller = "Review"}. Executing controller action with signature System.Threading.Tasks.Task`1[Microsoft.AspNetCore.Mvc.IActionResult] Create(App.Entities.DTOs.Review.CreateReviewDTO) on controller CapBot.api.Controllers.ReviewController (CapBot.api).
+2025-09-27 06:14:10.721 +07:00 [DBG] Execution plan of authorization filters (in the following order): ["None"]
+2025-09-27 06:14:10.724 +07:00 [DBG] Execution plan of resource filters (in the following order): ["None"]
+2025-09-27 06:14:10.735 +07:00 [DBG] Execution plan of action filters (in the following order): ["Microsoft.AspNetCore.Mvc.ModelBinding.UnsupportedContentTypeFilter (Order: -3000)"]
+2025-09-27 06:14:10.736 +07:00 [DBG] Execution plan of exception filters (in the following order): ["None"]
+2025-09-27 06:14:10.737 +07:00 [DBG] Execution plan of result filters (in the following order): ["Microsoft.AspNetCore.Mvc.Infrastructure.ClientErrorResultFilter (Order: -2000)"]
+2025-09-27 06:14:10.741 +07:00 [DBG] Executing controller factory for controller CapBot.api.Controllers.ReviewController (CapBot.api)
+2025-09-27 06:14:11.016 +07:00 [DBG] Executed controller factory for controller CapBot.api.Controllers.ReviewController (CapBot.api)
+2025-09-27 06:14:11.029 +07:00 [DBG] Attempting to bind parameter 'createDTO' of type 'App.Entities.DTOs.Review.CreateReviewDTO' ...
+2025-09-27 06:14:11.032 +07:00 [DBG] Attempting to bind parameter 'createDTO' of type 'App.Entities.DTOs.Review.CreateReviewDTO' using the name '' in request data ...
+2025-09-27 06:14:11.034 +07:00 [DBG] Rejected input formatter 'Microsoft.AspNetCore.OData.Formatter.ODataInputFormatter' for content type 'application/json;odata.metadata=minimal;odata.streaming=true'.
+2025-09-27 06:14:11.035 +07:00 [DBG] Rejected input formatter 'Microsoft.AspNetCore.OData.Formatter.ODataInputFormatter' for content type 'application/json;odata.metadata=minimal;odata.streaming=true'.
+2025-09-27 06:14:11.036 +07:00 [DBG] Rejected input formatter 'Microsoft.AspNetCore.OData.Formatter.ODataInputFormatter' for content type 'application/json;odata.metadata=minimal;odata.streaming=true'.
+2025-09-27 06:14:11.037 +07:00 [DBG] Selected input formatter 'Microsoft.AspNetCore.Mvc.Formatters.SystemTextJsonInputFormatter' for content type 'application/json;odata.metadata=minimal;odata.streaming=true'.
+2025-09-27 06:14:11.064 +07:00 [DBG] Connection id "0HNFTA9DUP8V6", Request id "0HNFTA9DUP8V6:00000004": started reading request body.
+2025-09-27 06:14:11.064 +07:00 [DBG] Connection id "0HNFTA9DUP8V6", Request id "0HNFTA9DUP8V6:00000004": done reading request body.
+2025-09-27 06:14:11.084 +07:00 [DBG] JSON input formatter succeeded, deserializing to type 'App.Entities.DTOs.Review.CreateReviewDTO'
+2025-09-27 06:14:11.085 +07:00 [DBG] Done attempting to bind parameter 'createDTO' of type 'App.Entities.DTOs.Review.CreateReviewDTO'.
+2025-09-27 06:14:11.086 +07:00 [DBG] Done attempting to bind parameter 'createDTO' of type 'App.Entities.DTOs.Review.CreateReviewDTO'.
+2025-09-27 06:14:11.086 +07:00 [DBG] Attempting to validate the bound parameter 'createDTO' of type 'App.Entities.DTOs.Review.CreateReviewDTO' ...
+2025-09-27 06:14:11.117 +07:00 [DBG] Done attempting to validate the bound parameter 'createDTO' of type 'App.Entities.DTOs.Review.CreateReviewDTO'.
+2025-09-27 06:14:11.244 +07:00 [DBG] Entity Framework Core 8.0.16 initialized 'MyDbContext' using provider 'Microsoft.EntityFrameworkCore.SqlServer:8.0.13' with options: MigrationsAssembly=App.DAL 
+2025-09-27 06:14:11.251 +07:00 [DBG] Creating DbConnection.
+2025-09-27 06:14:11.252 +07:00 [DBG] Created DbConnection. (0ms).
+2025-09-27 06:14:11.253 +07:00 [DBG] Opening connection to database 'capbot_db' on server 'localhost'.
+2025-09-27 06:14:11.253 +07:00 [DBG] Opened connection to database 'capbot_db' on server 'localhost'.
+2025-09-27 06:14:11.268 +07:00 [DBG] Beginning transaction with isolation level 'Unspecified'.
+2025-09-27 06:14:11.287 +07:00 [DBG] Began transaction with isolation level 'ReadCommitted'.
+2025-09-27 06:14:11.312 +07:00 [DBG] Compiling query expression: 
+'DbSet<ReviewerAssignment>()
+    .AsNoTracking()
+    .Where(x => x.Id == __createDTO_AssignmentId_0 && x.ReviewerId == __currentUserId_1)
+    .FirstOrDefault()'
+2025-09-27 06:14:11.327 +07:00 [DBG] Generated query execution expression: 
+'queryContext => ShapedQueryCompilingExpressionVisitor.SingleOrDefaultAsync<ReviewerAssignment>(
+    asyncEnumerable: new SingleQueryingEnumerable<ReviewerAssignment>(
+        (RelationalQueryContext)queryContext, 
+        RelationalCommandCache.QueryExpression(
+            Projection Mapping:
+                EmptyProjectionMember -> Dictionary<IProperty, int> { [Property: ReviewerAssignment.Id (int) Required PK AfterSave:Throw ValueGenerated.OnAdd, 0], [Property: ReviewerAssignment.AssignedAt (DateTime) Required ValueGenerated.OnAdd, 1], [Property: ReviewerAssignment.AssignedBy (int) Required FK Index, 2], [Property: ReviewerAssignment.AssignmentType (AssignmentTypes) Required ValueGenerated.OnAdd, 3], [Property: ReviewerAssignment.CompletedAt (DateTime?), 4], [Property: ReviewerAssignment.Deadline (DateTime?) Index, 5], [Property: ReviewerAssignment.ReviewerId (int) Required FK Index, 6], [Property: ReviewerAssignment.SkillMatchScore (decimal?), 7], [Property: ReviewerAssignment.StartedAt (DateTime?), 8], [Property: ReviewerAssignment.Status (AssignmentStatus) Required Index ValueGenerated.OnAdd, 9], [Property: ReviewerAssignment.SubmissionId (int) Required FK Index, 10] }
+            SELECT TOP(1) r.Id, r.AssignedAt, r.AssignedBy, r.AssignmentType, r.CompletedAt, r.Deadline, r.ReviewerId, r.SkillMatchScore, r.StartedAt, r.Status, r.SubmissionId
+            FROM reviewer_assignments AS r
+            WHERE (r.Id == @__createDTO_AssignmentId_0) && (r.ReviewerId == @__currentUserId_1)), 
+        null, 
+        Func<QueryContext, DbDataReader, ResultContext, SingleQueryResultCoordinator, ReviewerAssignment>, 
+        App.DAL.Context.MyDbContext, 
+        False, 
+        False, 
+        True
+    ), 
+    cancellationToken: queryContext.CancellationToken)'
+2025-09-27 06:14:11.335 +07:00 [DBG] Creating DbCommand for 'ExecuteReader'.
+2025-09-27 06:14:11.335 +07:00 [DBG] Created DbCommand for 'ExecuteReader' (0ms).
+2025-09-27 06:14:11.336 +07:00 [DBG] Initialized DbCommand for 'ExecuteReader' (1ms).
+2025-09-27 06:14:11.337 +07:00 [DBG] Executing DbCommand [Parameters=[@__createDTO_AssignmentId_0='?' (DbType = Int32), @__currentUserId_1='?' (DbType = Int32)], CommandType='"Text"', CommandTimeout='30']
+SELECT TOP(1) [r].[Id], [r].[AssignedAt], [r].[AssignedBy], [r].[AssignmentType], [r].[CompletedAt], [r].[Deadline], [r].[ReviewerId], [r].[SkillMatchScore], [r].[StartedAt], [r].[Status], [r].[SubmissionId]
+FROM [reviewer_assignments] AS [r]
+WHERE [r].[Id] = @__createDTO_AssignmentId_0 AND [r].[ReviewerId] = @__currentUserId_1
+2025-09-27 06:14:11.350 +07:00 [INF] Executed DbCommand (13ms) [Parameters=[@__createDTO_AssignmentId_0='?' (DbType = Int32), @__currentUserId_1='?' (DbType = Int32)], CommandType='"Text"', CommandTimeout='30']
+SELECT TOP(1) [r].[Id], [r].[AssignedAt], [r].[AssignedBy], [r].[AssignmentType], [r].[CompletedAt], [r].[Deadline], [r].[ReviewerId], [r].[SkillMatchScore], [r].[StartedAt], [r].[Status], [r].[SubmissionId]
+FROM [reviewer_assignments] AS [r]
+WHERE [r].[Id] = @__createDTO_AssignmentId_0 AND [r].[ReviewerId] = @__currentUserId_1
+2025-09-27 06:14:11.359 +07:00 [DBG] Closing data reader to 'capbot_db' on server 'localhost'.
+2025-09-27 06:14:11.360 +07:00 [DBG] A data reader for 'capbot_db' on server 'localhost' is being disposed after spending 8ms reading results.
+2025-09-27 06:14:11.365 +07:00 [DBG] Compiling query expression: 
+'DbSet<Review>()
+    .AsNoTracking()
+    .Where(x => x.AssignmentId == __createDTO_AssignmentId_0 && x.IsActive)
+    .FirstOrDefault()'
+2025-09-27 06:14:11.378 +07:00 [DBG] Generated query execution expression: 
+'queryContext => ShapedQueryCompilingExpressionVisitor.SingleOrDefaultAsync<Review>(
+    asyncEnumerable: new SingleQueryingEnumerable<Review>(
+        (RelationalQueryContext)queryContext, 
+        RelationalCommandCache.QueryExpression(
+            Projection Mapping:
+                EmptyProjectionMember -> Dictionary<IProperty, int> { [Property: Review.Id (int) Required PK AfterSave:Throw ValueGenerated.OnAdd, 0], [Property: Review.AssignmentId (int) Required FK Index, 1], [Property: Review.CreatedAt (DateTime) Required ValueGenerated.OnAdd, 2], [Property: Review.CreatedBy (string), 3], [Property: Review.DeletedAt (DateTime?), 4], [Property: Review.IsActive (bool) Required, 5], [Property: Review.LastModifiedAt (DateTime?), 6], [Property: Review.LastModifiedBy (string), 7], [Property: Review.OverallComment (string), 8], [Property: Review.OverallScore (decimal?), 9], [Property: Review.Recommendation (ReviewRecommendations) Required Index ValueGenerated.OnAdd, 10], [Property: Review.Status (ReviewStatus) Required Index ValueGenerated.OnAdd, 11], [Property: Review.SubmittedAt (DateTime?) Index, 12], [Property: Review.TimeSpentMinutes (int?), 13] }
+            SELECT TOP(1) r.Id, r.AssignmentId, r.CreatedAt, r.CreatedBy, r.DeletedAt, r.IsActive, r.LastModifiedAt, r.LastModifiedBy, r.OverallComment, r.OverallScore, r.Recommendation, r.Status, r.SubmittedAt, r.TimeSpentMinutes
+            FROM reviews AS r
+            WHERE (r.AssignmentId == @__createDTO_AssignmentId_0) && r.IsActive), 
+        null, 
+        Func<QueryContext, DbDataReader, ResultContext, SingleQueryResultCoordinator, Review>, 
+        App.DAL.Context.MyDbContext, 
+        False, 
+        False, 
+        True
+    ), 
+    cancellationToken: queryContext.CancellationToken)'
+2025-09-27 06:14:11.380 +07:00 [DBG] Creating DbCommand for 'ExecuteReader'.
+2025-09-27 06:14:11.382 +07:00 [DBG] Created DbCommand for 'ExecuteReader' (2ms).
+2025-09-27 06:14:11.383 +07:00 [DBG] Initialized DbCommand for 'ExecuteReader' (3ms).
+2025-09-27 06:14:11.383 +07:00 [DBG] Executing DbCommand [Parameters=[@__createDTO_AssignmentId_0='?' (DbType = Int32)], CommandType='"Text"', CommandTimeout='30']
+SELECT TOP(1) [r].[Id], [r].[AssignmentId], [r].[CreatedAt], [r].[CreatedBy], [r].[DeletedAt], [r].[IsActive], [r].[LastModifiedAt], [r].[LastModifiedBy], [r].[OverallComment], [r].[OverallScore], [r].[Recommendation], [r].[Status], [r].[SubmittedAt], [r].[TimeSpentMinutes]
+FROM [reviews] AS [r]
+WHERE [r].[AssignmentId] = @__createDTO_AssignmentId_0 AND [r].[IsActive] = CAST(1 AS bit)
+2025-09-27 06:14:11.393 +07:00 [INF] Executed DbCommand (9ms) [Parameters=[@__createDTO_AssignmentId_0='?' (DbType = Int32)], CommandType='"Text"', CommandTimeout='30']
+SELECT TOP(1) [r].[Id], [r].[AssignmentId], [r].[CreatedAt], [r].[CreatedBy], [r].[DeletedAt], [r].[IsActive], [r].[LastModifiedAt], [r].[LastModifiedBy], [r].[OverallComment], [r].[OverallScore], [r].[Recommendation], [r].[Status], [r].[SubmittedAt], [r].[TimeSpentMinutes]
+FROM [reviews] AS [r]
+WHERE [r].[AssignmentId] = @__createDTO_AssignmentId_0 AND [r].[IsActive] = CAST(1 AS bit)
+2025-09-27 06:14:11.395 +07:00 [DBG] Closing data reader to 'capbot_db' on server 'localhost'.
+2025-09-27 06:14:11.398 +07:00 [DBG] A data reader for 'capbot_db' on server 'localhost' is being disposed after spending 4ms reading results.
+2025-09-27 06:14:11.407 +07:00 [DBG] Compiling query expression: 
+'DbSet<Semester>()
+    .AsNoTracking()
+    .Where(x => x.IsActive && x.DeletedAt == null && x.StartDate <= __currentDate_0 && x.EndDate >= __currentDate_0)
+    .FirstOrDefault()'
+2025-09-27 06:14:11.420 +07:00 [DBG] Generated query execution expression: 
+'queryContext => ShapedQueryCompilingExpressionVisitor.SingleOrDefaultAsync<Semester>(
+    asyncEnumerable: new SingleQueryingEnumerable<Semester>(
+        (RelationalQueryContext)queryContext, 
+        RelationalCommandCache.QueryExpression(
+            Projection Mapping:
+                EmptyProjectionMember -> Dictionary<IProperty, int> { [Property: Semester.Id (int) Required PK AfterSave:Throw ValueGenerated.OnAdd, 0], [Property: Semester.CreatedAt (DateTime) Required, 1], [Property: Semester.CreatedBy (string), 2], [Property: Semester.DeletedAt (DateTime?), 3], [Property: Semester.Description (string), 4], [Property: Semester.EndDate (DateTime) Required, 5], [Property: Semester.IsActive (bool) Required, 6], [Property: Semester.LastModifiedAt (DateTime?), 7], [Property: Semester.LastModifiedBy (string), 8], [Property: Semester.Name (string) Required Index MaxLength(50), 9], [Property: Semester.StartDate (DateTime) Required, 10] }
+            SELECT TOP(1) s.Id, s.CreatedAt, s.CreatedBy, s.DeletedAt, s.Description, s.EndDate, s.IsActive, s.LastModifiedAt, s.LastModifiedBy, s.Name, s.StartDate
+            FROM semesters AS s
+            WHERE ((s.IsActive && (s.DeletedAt == NULL)) && (s.StartDate <= @__currentDate_0)) && (s.EndDate >= @__currentDate_0)), 
+        null, 
+        Func<QueryContext, DbDataReader, ResultContext, SingleQueryResultCoordinator, Semester>, 
+        App.DAL.Context.MyDbContext, 
+        False, 
+        False, 
+        True
+    ), 
+    cancellationToken: queryContext.CancellationToken)'
+2025-09-27 06:14:11.454 +07:00 [DBG] Creating DbCommand for 'ExecuteReader'.
+2025-09-27 06:14:11.455 +07:00 [DBG] Created DbCommand for 'ExecuteReader' (0ms).
+2025-09-27 06:14:11.456 +07:00 [DBG] Initialized DbCommand for 'ExecuteReader' (1ms).
+2025-09-27 06:14:11.460 +07:00 [DBG] Executing DbCommand [Parameters=[@__currentDate_0='?' (DbType = DateTime2)], CommandType='"Text"', CommandTimeout='30']
+SELECT TOP(1) [s].[Id], [s].[CreatedAt], [s].[CreatedBy], [s].[DeletedAt], [s].[Description], [s].[EndDate], [s].[IsActive], [s].[LastModifiedAt], [s].[LastModifiedBy], [s].[Name], [s].[StartDate]
+FROM [semesters] AS [s]
+WHERE [s].[IsActive] = CAST(1 AS bit) AND [s].[DeletedAt] IS NULL AND [s].[StartDate] <= @__currentDate_0 AND [s].[EndDate] >= @__currentDate_0
+2025-09-27 06:14:11.468 +07:00 [INF] Executed DbCommand (8ms) [Parameters=[@__currentDate_0='?' (DbType = DateTime2)], CommandType='"Text"', CommandTimeout='30']
+SELECT TOP(1) [s].[Id], [s].[CreatedAt], [s].[CreatedBy], [s].[DeletedAt], [s].[Description], [s].[EndDate], [s].[IsActive], [s].[LastModifiedAt], [s].[LastModifiedBy], [s].[Name], [s].[StartDate]
+FROM [semesters] AS [s]
+WHERE [s].[IsActive] = CAST(1 AS bit) AND [s].[DeletedAt] IS NULL AND [s].[StartDate] <= @__currentDate_0 AND [s].[EndDate] >= @__currentDate_0
+2025-09-27 06:14:11.470 +07:00 [DBG] Closing data reader to 'capbot_db' on server 'localhost'.
+2025-09-27 06:14:11.473 +07:00 [DBG] A data reader for 'capbot_db' on server 'localhost' is being disposed after spending 3ms reading results.
+2025-09-27 06:14:11.489 +07:00 [DBG] Compiling query expression: 
+'DbSet<EvaluationCriteria>()
+    .AsNoTracking()
+    .Where(x => __criteriaIds_0.Contains(x.Id) && x.IsActive && x.SemesterId == __currentSemesterId_1 || x.SemesterId == null)'
+2025-09-27 06:14:11.600 +07:00 [DBG] Generated query execution expression: 
+'queryContext => new SingleQueryingEnumerable<EvaluationCriteria>(
+    (RelationalQueryContext)queryContext, 
+    RelationalCommandCache.QueryExpression(
+        Projection Mapping:
+            EmptyProjectionMember -> Dictionary<IProperty, int> { [Property: EvaluationCriteria.Id (int) Required PK AfterSave:Throw ValueGenerated.OnAdd, 0], [Property: EvaluationCriteria.CreatedAt (DateTime) Required ValueGenerated.OnAdd, 1], [Property: EvaluationCriteria.CreatedBy (string), 2], [Property: EvaluationCriteria.DeletedAt (DateTime?), 3], [Property: EvaluationCriteria.Description (string), 4], [Property: EvaluationCriteria.IsActive (bool) Required Index Sentinel:True ValueGenerated.OnAdd, 5], [Property: EvaluationCriteria.LastModifiedAt (DateTime?), 6], [Property: EvaluationCriteria.LastModifiedBy (string), 7], [Property: EvaluationCriteria.MaxScore (int) Required ValueGenerated.OnAdd, 8], [Property: EvaluationCriteria.Name (string) Required MaxLength(100), 9], [Property: EvaluationCriteria.SemesterId (int?) Required FK Index, 10], [Property: EvaluationCriteria.Weight (decimal) Required ValueGenerated.OnAdd, 11] }
+        SELECT e.Id, e.CreatedAt, e.CreatedBy, e.DeletedAt, e.Description, e.IsActive, e.LastModifiedAt, e.LastModifiedBy, e.MaxScore, e.Name, e.SemesterId, e.Weight
+        FROM evaluation_criteria AS e
+        WHERE (e.Id IN (
+            SELECT c.value
+            FROM OPENJSON(@__criteriaIds_0) WITH (value int '') AS c) && e.IsActive) && ((e.SemesterId == @__currentSemesterId_1) || (e.SemesterId == NULL))), 
+    null, 
+    Func<QueryContext, DbDataReader, ResultContext, SingleQueryResultCoordinator, EvaluationCriteria>, 
+    App.DAL.Context.MyDbContext, 
+    False, 
+    False, 
+    True
+)'
+2025-09-27 06:14:11.611 +07:00 [DBG] Creating DbCommand for 'ExecuteReader'.
+2025-09-27 06:14:11.611 +07:00 [DBG] Created DbCommand for 'ExecuteReader' (0ms).
+2025-09-27 06:14:11.628 +07:00 [DBG] Initialized DbCommand for 'ExecuteReader' (16ms).
+2025-09-27 06:14:11.632 +07:00 [DBG] Executing DbCommand [Parameters=[@__criteriaIds_0='?' (Size = 4000), @__currentSemesterId_1='?' (DbType = Int32)], CommandType='"Text"', CommandTimeout='30']
+SELECT [e].[Id], [e].[CreatedAt], [e].[CreatedBy], [e].[DeletedAt], [e].[Description], [e].[IsActive], [e].[LastModifiedAt], [e].[LastModifiedBy], [e].[MaxScore], [e].[Name], [e].[SemesterId], [e].[Weight]
+FROM [evaluation_criteria] AS [e]
+WHERE [e].[Id] IN (
+    SELECT [c].[value]
+    FROM OPENJSON(@__criteriaIds_0) WITH ([value] int '$') AS [c]
+) AND [e].[IsActive] = CAST(1 AS bit) AND [e].[SemesterId] = @__currentSemesterId_1
+2025-09-27 06:14:11.652 +07:00 [INF] Executed DbCommand (20ms) [Parameters=[@__criteriaIds_0='?' (Size = 4000), @__currentSemesterId_1='?' (DbType = Int32)], CommandType='"Text"', CommandTimeout='30']
+SELECT [e].[Id], [e].[CreatedAt], [e].[CreatedBy], [e].[DeletedAt], [e].[Description], [e].[IsActive], [e].[LastModifiedAt], [e].[LastModifiedBy], [e].[MaxScore], [e].[Name], [e].[SemesterId], [e].[Weight]
+FROM [evaluation_criteria] AS [e]
+WHERE [e].[Id] IN (
+    SELECT [c].[value]
+    FROM OPENJSON(@__criteriaIds_0) WITH ([value] int '$') AS [c]
+) AND [e].[IsActive] = CAST(1 AS bit) AND [e].[SemesterId] = @__currentSemesterId_1
+2025-09-27 06:14:11.656 +07:00 [DBG] Closing data reader to 'capbot_db' on server 'localhost'.
+2025-09-27 06:14:11.656 +07:00 [DBG] A data reader for 'capbot_db' on server 'localhost' is being disposed after spending 3ms reading results.
+2025-09-27 06:14:11.702 +07:00 [DBG] 'MyDbContext' generated a temporary value for the property 'Review.Id'. Consider using 'DbContextOptionsBuilder.EnableSensitiveDataLogging' to see key values.
+2025-09-27 06:14:11.791 +07:00 [DBG] Context 'MyDbContext' started tracking 'Review' entity. Consider using 'DbContextOptionsBuilder.EnableSensitiveDataLogging' to see key values.
+2025-09-27 06:14:11.796 +07:00 [DBG] SaveChanges starting for 'MyDbContext'.
+2025-09-27 06:14:11.808 +07:00 [DBG] DetectChanges starting for 'MyDbContext'.
+2025-09-27 06:14:11.875 +07:00 [DBG] DetectChanges completed for 'MyDbContext'.
+2025-09-27 06:14:12.030 +07:00 [DBG] Creating transaction savepoint.
+2025-09-27 06:14:12.053 +07:00 [DBG] Created transaction savepoint.
+2025-09-27 06:14:12.073 +07:00 [DBG] Creating DbCommand for 'ExecuteReader'.
+2025-09-27 06:14:12.073 +07:00 [DBG] Created DbCommand for 'ExecuteReader' (0ms).
+2025-09-27 06:14:12.082 +07:00 [DBG] Initialized DbCommand for 'ExecuteReader' (9ms).
+2025-09-27 06:14:12.083 +07:00 [DBG] Executing DbCommand [Parameters=[@p0='?' (DbType = Int32), @p1='?' (DbType = DateTime2), @p2='?' (Size = 4000), @p3='?' (DbType = DateTime2), @p4='?' (DbType = Boolean), @p5='?' (DbType = DateTime2), @p6='?' (Size = 4000), @p7='?' (Size = 4000), @p8='?' (Precision = 4) (Scale = 2) (DbType = Decimal), @p9='?' (DbType = Int32), @p10='?' (DbType = Int32), @p11='?' (DbType = DateTime2), @p12='?' (DbType = Int32)], CommandType='"Text"', CommandTimeout='30']
+SET IMPLICIT_TRANSACTIONS OFF;
+SET NOCOUNT ON;
+INSERT INTO [reviews] ([AssignmentId], [CreatedAt], [CreatedBy], [DeletedAt], [IsActive], [LastModifiedAt], [LastModifiedBy], [OverallComment], [OverallScore], [Recommendation], [Status], [SubmittedAt], [TimeSpentMinutes])
+OUTPUT INSERTED.[Id]
+VALUES (@p0, @p1, @p2, @p3, @p4, @p5, @p6, @p7, @p8, @p9, @p10, @p11, @p12);
+2025-09-27 06:14:12.100 +07:00 [INF] Executed DbCommand (17ms) [Parameters=[@p0='?' (DbType = Int32), @p1='?' (DbType = DateTime2), @p2='?' (Size = 4000), @p3='?' (DbType = DateTime2), @p4='?' (DbType = Boolean), @p5='?' (DbType = DateTime2), @p6='?' (Size = 4000), @p7='?' (Size = 4000), @p8='?' (Precision = 4) (Scale = 2) (DbType = Decimal), @p9='?' (DbType = Int32), @p10='?' (DbType = Int32), @p11='?' (DbType = DateTime2), @p12='?' (DbType = Int32)], CommandType='"Text"', CommandTimeout='30']
+SET IMPLICIT_TRANSACTIONS OFF;
+SET NOCOUNT ON;
+INSERT INTO [reviews] ([AssignmentId], [CreatedAt], [CreatedBy], [DeletedAt], [IsActive], [LastModifiedAt], [LastModifiedBy], [OverallComment], [OverallScore], [Recommendation], [Status], [SubmittedAt], [TimeSpentMinutes])
+OUTPUT INSERTED.[Id]
+VALUES (@p0, @p1, @p2, @p3, @p4, @p5, @p6, @p7, @p8, @p9, @p10, @p11, @p12);
+2025-09-27 06:14:12.122 +07:00 [DBG] The foreign key property 'Review.Id' was detected as changed. Consider using 'DbContextOptionsBuilder.EnableSensitiveDataLogging' to see property values.
+2025-09-27 06:14:12.132 +07:00 [DBG] Closing data reader to 'capbot_db' on server 'localhost'.
+2025-09-27 06:14:12.132 +07:00 [DBG] A data reader for 'capbot_db' on server 'localhost' is being disposed after spending 31ms reading results.
+2025-09-27 06:14:12.161 +07:00 [DBG] An entity of type 'Review' tracked by 'MyDbContext' changed state from '"Added"' to '"Unchanged"'. Consider using 'DbContextOptionsBuilder.EnableSensitiveDataLogging' to see key values.
+2025-09-27 06:14:12.166 +07:00 [DBG] SaveChanges completed for 'MyDbContext' with 1 entities written to the database.
+2025-09-27 06:14:12.198 +07:00 [DBG] 'MyDbContext' generated a temporary value for the property 'ReviewCriteriaScore.Id'. Consider using 'DbContextOptionsBuilder.EnableSensitiveDataLogging' to see key values.
+2025-09-27 06:14:12.257 +07:00 [DBG] The navigation 'ReviewCriteriaScore.Review' was detected as changed. Consider using 'DbContextOptionsBuilder.EnableSensitiveDataLogging' to see key values.
+2025-09-27 06:14:12.283 +07:00 [DBG] Context 'MyDbContext' started tracking 'ReviewCriteriaScore' entity. Consider using 'DbContextOptionsBuilder.EnableSensitiveDataLogging' to see key values.
+2025-09-27 06:14:12.284 +07:00 [DBG] SaveChanges starting for 'MyDbContext'.
+2025-09-27 06:14:12.284 +07:00 [DBG] DetectChanges starting for 'MyDbContext'.
+2025-09-27 06:14:12.304 +07:00 [DBG] DetectChanges completed for 'MyDbContext'.
+2025-09-27 06:14:12.307 +07:00 [DBG] Creating transaction savepoint.
+2025-09-27 06:14:12.308 +07:00 [DBG] Created transaction savepoint.
+2025-09-27 06:14:12.309 +07:00 [DBG] Creating DbCommand for 'ExecuteReader'.
+2025-09-27 06:14:12.309 +07:00 [DBG] Created DbCommand for 'ExecuteReader' (0ms).
+2025-09-27 06:14:12.309 +07:00 [DBG] Initialized DbCommand for 'ExecuteReader' (0ms).
+2025-09-27 06:14:12.310 +07:00 [DBG] Executing DbCommand [Parameters=[@p0='?' (Size = 4000), @p1='?' (DbType = DateTime2), @p2='?' (Size = 4000), @p3='?' (DbType = Int32), @p4='?' (DbType = DateTime2), @p5='?' (DbType = Boolean), @p6='?' (DbType = DateTime2), @p7='?' (Size = 4000), @p8='?' (DbType = Int32), @p9='?' (Precision = 6) (Scale = 2) (DbType = Decimal)], CommandType='"Text"', CommandTimeout='30']
+SET IMPLICIT_TRANSACTIONS OFF;
+SET NOCOUNT ON;
+INSERT INTO [review_criteria_scores] ([Comment], [CreatedAt], [CreatedBy], [CriteriaId], [DeletedAt], [IsActive], [LastModifiedAt], [LastModifiedBy], [ReviewId], [Score])
+OUTPUT INSERTED.[Id]
+VALUES (@p0, @p1, @p2, @p3, @p4, @p5, @p6, @p7, @p8, @p9);
+2025-09-27 06:14:12.319 +07:00 [INF] Executed DbCommand (10ms) [Parameters=[@p0='?' (Size = 4000), @p1='?' (DbType = DateTime2), @p2='?' (Size = 4000), @p3='?' (DbType = Int32), @p4='?' (DbType = DateTime2), @p5='?' (DbType = Boolean), @p6='?' (DbType = DateTime2), @p7='?' (Size = 4000), @p8='?' (DbType = Int32), @p9='?' (Precision = 6) (Scale = 2) (DbType = Decimal)], CommandType='"Text"', CommandTimeout='30']
+SET IMPLICIT_TRANSACTIONS OFF;
+SET NOCOUNT ON;
+INSERT INTO [review_criteria_scores] ([Comment], [CreatedAt], [CreatedBy], [CriteriaId], [DeletedAt], [IsActive], [LastModifiedAt], [LastModifiedBy], [ReviewId], [Score])
+OUTPUT INSERTED.[Id]
+VALUES (@p0, @p1, @p2, @p3, @p4, @p5, @p6, @p7, @p8, @p9);
+2025-09-27 06:14:12.322 +07:00 [DBG] The foreign key property 'ReviewCriteriaScore.Id' was detected as changed. Consider using 'DbContextOptionsBuilder.EnableSensitiveDataLogging' to see property values.
+2025-09-27 06:14:12.323 +07:00 [DBG] Closing data reader to 'capbot_db' on server 'localhost'.
+2025-09-27 06:14:12.324 +07:00 [DBG] A data reader for 'capbot_db' on server 'localhost' is being disposed after spending 3ms reading results.
+2025-09-27 06:14:12.327 +07:00 [DBG] An entity of type 'ReviewCriteriaScore' tracked by 'MyDbContext' changed state from '"Added"' to '"Unchanged"'. Consider using 'DbContextOptionsBuilder.EnableSensitiveDataLogging' to see key values.
+2025-09-27 06:14:12.327 +07:00 [DBG] SaveChanges completed for 'MyDbContext' with 1 entities written to the database.
+2025-09-27 06:14:12.334 +07:00 [DBG] Committing transaction.
+2025-09-27 06:14:12.340 +07:00 [DBG] Committed transaction.
+2025-09-27 06:14:12.342 +07:00 [DBG] Closing connection to database 'capbot_db' on server 'localhost'.
+2025-09-27 06:14:12.344 +07:00 [DBG] Closed connection to database 'capbot_db' on server 'localhost' (1ms).
+2025-09-27 06:14:12.348 +07:00 [DBG] Disposing transaction.
+2025-09-27 06:14:12.356 +07:00 [DBG] Compiling query expression: 
+'DbSet<Review>()
+    .AsNoTracking()
+    .Include(x => x.ReviewCriteriaScores)
+    .Include("ReviewCriteriaScores.Criteria")
+    .Where(x => x.Id == __id_0 && x.IsActive)
+    .FirstOrDefault()'
+2025-09-27 06:14:12.384 +07:00 [DBG] Including navigation: 'Review.ReviewCriteriaScores'.
+2025-09-27 06:14:12.393 +07:00 [DBG] Including navigation: 'ReviewCriteriaScore.Criteria'.
+2025-09-27 06:14:12.522 +07:00 [DBG] Generated query execution expression: 
+'queryContext => ShapedQueryCompilingExpressionVisitor.SingleOrDefaultAsync<Review>(
+    asyncEnumerable: new SingleQueryingEnumerable<Review>(
+        (RelationalQueryContext)queryContext, 
+        RelationalCommandCache.QueryExpression(
+            Client Projections:
+                0 -> Dictionary<IProperty, int> { [Property: Review.Id (int) Required PK AfterSave:Throw ValueGenerated.OnAdd, 0], [Property: Review.AssignmentId (int) Required FK Index, 1], [Property: Review.CreatedAt (DateTime) Required ValueGenerated.OnAdd, 2], [Property: Review.CreatedBy (string), 3], [Property: Review.DeletedAt (DateTime?), 4], [Property: Review.IsActive (bool) Required, 5], [Property: Review.LastModifiedAt (DateTime?), 6], [Property: Review.LastModifiedBy (string), 7], [Property: Review.OverallComment (string), 8], [Property: Review.OverallScore (decimal?), 9], [Property: Review.Recommendation (ReviewRecommendations) Required Index ValueGenerated.OnAdd, 10], [Property: Review.Status (ReviewStatus) Required Index ValueGenerated.OnAdd, 11], [Property: Review.SubmittedAt (DateTime?) Index, 12], [Property: Review.TimeSpentMinutes (int?), 13] }
+                1 -> 0
+                2 -> Dictionary<IProperty, int> { [Property: ReviewCriteriaScore.Id (int) Required PK AfterSave:Throw ValueGenerated.OnAdd, 14], [Property: ReviewCriteriaScore.Comment (string), 15], [Property: ReviewCriteriaScore.CreatedAt (DateTime) Required ValueGenerated.OnAdd, 16], [Property: ReviewCriteriaScore.CreatedBy (string), 17], [Property: ReviewCriteriaScore.CriteriaId (int) Required FK Index, 18], [Property: ReviewCriteriaScore.DeletedAt (DateTime?), 19], [Property: ReviewCriteriaScore.IsActive (bool) Required, 20], [Property: ReviewCriteriaScore.LastModifiedAt (DateTime?), 21], [Property: ReviewCriteriaScore.LastModifiedBy (string), 22], [Property: ReviewCriteriaScore.ReviewId (int) Required FK Index, 23], [Property: ReviewCriteriaScore.Score (decimal) Required, 24] }
+                3 -> Dictionary<IProperty, int> { [Property: EvaluationCriteria.Id (int) Required PK AfterSave:Throw ValueGenerated.OnAdd, 25], [Property: EvaluationCriteria.CreatedAt (DateTime) Required ValueGenerated.OnAdd, 26], [Property: EvaluationCriteria.CreatedBy (string), 27], [Property: EvaluationCriteria.DeletedAt (DateTime?), 28], [Property: EvaluationCriteria.Description (string), 29], [Property: EvaluationCriteria.IsActive (bool) Required Index Sentinel:True ValueGenerated.OnAdd, 30], [Property: EvaluationCriteria.LastModifiedAt (DateTime?), 31], [Property: EvaluationCriteria.LastModifiedBy (string), 32], [Property: EvaluationCriteria.MaxScore (int) Required ValueGenerated.OnAdd, 33], [Property: EvaluationCriteria.Name (string) Required MaxLength(100), 34], [Property: EvaluationCriteria.SemesterId (int?) Required FK Index, 35], [Property: EvaluationCriteria.Weight (decimal) Required ValueGenerated.OnAdd, 36] }
+                4 -> 14
+                5 -> 25
+            SELECT t.Id, t.AssignmentId, t.CreatedAt, t.CreatedBy, t.DeletedAt, t.IsActive, t.LastModifiedAt, t.LastModifiedBy, t.OverallComment, t.OverallScore, t.Recommendation, t.Status, t.SubmittedAt, t.TimeSpentMinutes, t0.Id, t0.Comment, t0.CreatedAt, t0.CreatedBy, t0.CriteriaId, t0.DeletedAt, t0.IsActive, t0.LastModifiedAt, t0.LastModifiedBy, t0.ReviewId, t0.Score, t0.Id0, t0.CreatedAt0, t0.CreatedBy0, t0.DeletedAt0, t0.Description, t0.IsActive0, t0.LastModifiedAt0, t0.LastModifiedBy0, t0.MaxScore, t0.Name, t0.SemesterId, t0.Weight
+            FROM 
+            (
+                SELECT TOP(1) r.Id, r.AssignmentId, r.CreatedAt, r.CreatedBy, r.DeletedAt, r.IsActive, r.LastModifiedAt, r.LastModifiedBy, r.OverallComment, r.OverallScore, r.Recommendation, r.Status, r.SubmittedAt, r.TimeSpentMinutes
+                FROM reviews AS r
+                WHERE (r.Id == @__id_0) && r.IsActive
+            ) AS t
+            LEFT JOIN 
+            (
+                SELECT r0.Id, r0.Comment, r0.CreatedAt, r0.CreatedBy, r0.CriteriaId, r0.DeletedAt, r0.IsActive, r0.LastModifiedAt, r0.LastModifiedBy, r0.ReviewId, r0.Score, e.Id AS Id0, e.CreatedAt AS CreatedAt0, e.CreatedBy AS CreatedBy0, e.DeletedAt AS DeletedAt0, e.Description, e.IsActive AS IsActive0, e.LastModifiedAt AS LastModifiedAt0, e.LastModifiedBy AS LastModifiedBy0, e.MaxScore, e.Name, e.SemesterId, e.Weight
+                FROM review_criteria_scores AS r0
+                INNER JOIN evaluation_criteria AS e ON r0.CriteriaId == e.Id
+            ) AS t0 ON t.Id == t0.ReviewId
+            ORDER BY t.Id ASC, t0.Id ASC), 
+        null, 
+        Func<QueryContext, DbDataReader, ResultContext, SingleQueryResultCoordinator, Review>, 
+        App.DAL.Context.MyDbContext, 
+        False, 
+        False, 
+        True
+    ), 
+    cancellationToken: queryContext.CancellationToken)'
+2025-09-27 06:14:12.530 +07:00 [DBG] Opening connection to database 'capbot_db' on server 'localhost'.
+2025-09-27 06:14:12.530 +07:00 [DBG] Opened connection to database 'capbot_db' on server 'localhost'.
+2025-09-27 06:14:12.531 +07:00 [DBG] Creating DbCommand for 'ExecuteReader'.
+2025-09-27 06:14:12.531 +07:00 [DBG] Created DbCommand for 'ExecuteReader' (0ms).
+2025-09-27 06:14:12.531 +07:00 [DBG] Initialized DbCommand for 'ExecuteReader' (0ms).
+2025-09-27 06:14:12.531 +07:00 [DBG] Executing DbCommand [Parameters=[@__id_0='?' (DbType = Int32)], CommandType='"Text"', CommandTimeout='30']
+SELECT [t].[Id], [t].[AssignmentId], [t].[CreatedAt], [t].[CreatedBy], [t].[DeletedAt], [t].[IsActive], [t].[LastModifiedAt], [t].[LastModifiedBy], [t].[OverallComment], [t].[OverallScore], [t].[Recommendation], [t].[Status], [t].[SubmittedAt], [t].[TimeSpentMinutes], [t0].[Id], [t0].[Comment], [t0].[CreatedAt], [t0].[CreatedBy], [t0].[CriteriaId], [t0].[DeletedAt], [t0].[IsActive], [t0].[LastModifiedAt], [t0].[LastModifiedBy], [t0].[ReviewId], [t0].[Score], [t0].[Id0], [t0].[CreatedAt0], [t0].[CreatedBy0], [t0].[DeletedAt0], [t0].[Description], [t0].[IsActive0], [t0].[LastModifiedAt0], [t0].[LastModifiedBy0], [t0].[MaxScore], [t0].[Name], [t0].[SemesterId], [t0].[Weight]
+FROM (
+    SELECT TOP(1) [r].[Id], [r].[AssignmentId], [r].[CreatedAt], [r].[CreatedBy], [r].[DeletedAt], [r].[IsActive], [r].[LastModifiedAt], [r].[LastModifiedBy], [r].[OverallComment], [r].[OverallScore], [r].[Recommendation], [r].[Status], [r].[SubmittedAt], [r].[TimeSpentMinutes]
+    FROM [reviews] AS [r]
+    WHERE [r].[Id] = @__id_0 AND [r].[IsActive] = CAST(1 AS bit)
+) AS [t]
+LEFT JOIN (
+    SELECT [r0].[Id], [r0].[Comment], [r0].[CreatedAt], [r0].[CreatedBy], [r0].[CriteriaId], [r0].[DeletedAt], [r0].[IsActive], [r0].[LastModifiedAt], [r0].[LastModifiedBy], [r0].[ReviewId], [r0].[Score], [e].[Id] AS [Id0], [e].[CreatedAt] AS [CreatedAt0], [e].[CreatedBy] AS [CreatedBy0], [e].[DeletedAt] AS [DeletedAt0], [e].[Description], [e].[IsActive] AS [IsActive0], [e].[LastModifiedAt] AS [LastModifiedAt0], [e].[LastModifiedBy] AS [LastModifiedBy0], [e].[MaxScore], [e].[Name], [e].[SemesterId], [e].[Weight]
+    FROM [review_criteria_scores] AS [r0]
+    INNER JOIN [evaluation_criteria] AS [e] ON [r0].[CriteriaId] = [e].[Id]
+) AS [t0] ON [t].[Id] = [t0].[ReviewId]
+ORDER BY [t].[Id], [t0].[Id]
+2025-09-27 06:14:12.543 +07:00 [INF] Executed DbCommand (12ms) [Parameters=[@__id_0='?' (DbType = Int32)], CommandType='"Text"', CommandTimeout='30']
+SELECT [t].[Id], [t].[AssignmentId], [t].[CreatedAt], [t].[CreatedBy], [t].[DeletedAt], [t].[IsActive], [t].[LastModifiedAt], [t].[LastModifiedBy], [t].[OverallComment], [t].[OverallScore], [t].[Recommendation], [t].[Status], [t].[SubmittedAt], [t].[TimeSpentMinutes], [t0].[Id], [t0].[Comment], [t0].[CreatedAt], [t0].[CreatedBy], [t0].[CriteriaId], [t0].[DeletedAt], [t0].[IsActive], [t0].[LastModifiedAt], [t0].[LastModifiedBy], [t0].[ReviewId], [t0].[Score], [t0].[Id0], [t0].[CreatedAt0], [t0].[CreatedBy0], [t0].[DeletedAt0], [t0].[Description], [t0].[IsActive0], [t0].[LastModifiedAt0], [t0].[LastModifiedBy0], [t0].[MaxScore], [t0].[Name], [t0].[SemesterId], [t0].[Weight]
+FROM (
+    SELECT TOP(1) [r].[Id], [r].[AssignmentId], [r].[CreatedAt], [r].[CreatedBy], [r].[DeletedAt], [r].[IsActive], [r].[LastModifiedAt], [r].[LastModifiedBy], [r].[OverallComment], [r].[OverallScore], [r].[Recommendation], [r].[Status], [r].[SubmittedAt], [r].[TimeSpentMinutes]
+    FROM [reviews] AS [r]
+    WHERE [r].[Id] = @__id_0 AND [r].[IsActive] = CAST(1 AS bit)
+) AS [t]
+LEFT JOIN (
+    SELECT [r0].[Id], [r0].[Comment], [r0].[CreatedAt], [r0].[CreatedBy], [r0].[CriteriaId], [r0].[DeletedAt], [r0].[IsActive], [r0].[LastModifiedAt], [r0].[LastModifiedBy], [r0].[ReviewId], [r0].[Score], [e].[Id] AS [Id0], [e].[CreatedAt] AS [CreatedAt0], [e].[CreatedBy] AS [CreatedBy0], [e].[DeletedAt] AS [DeletedAt0], [e].[Description], [e].[IsActive] AS [IsActive0], [e].[LastModifiedAt] AS [LastModifiedAt0], [e].[LastModifiedBy] AS [LastModifiedBy0], [e].[MaxScore], [e].[Name], [e].[SemesterId], [e].[Weight]
+    FROM [review_criteria_scores] AS [r0]
+    INNER JOIN [evaluation_criteria] AS [e] ON [r0].[CriteriaId] = [e].[Id]
+) AS [t0] ON [t].[Id] = [t0].[ReviewId]
+ORDER BY [t].[Id], [t0].[Id]
+2025-09-27 06:14:12.570 +07:00 [DBG] Closing data reader to 'capbot_db' on server 'localhost'.
+2025-09-27 06:14:12.570 +07:00 [DBG] A data reader for 'capbot_db' on server 'localhost' is being disposed after spending 26ms reading results.
+2025-09-27 06:14:12.572 +07:00 [DBG] Closing connection to database 'capbot_db' on server 'localhost'.
+2025-09-27 06:14:12.573 +07:00 [DBG] Closed connection to database 'capbot_db' on server 'localhost' (1ms).
+2025-09-27 06:14:12.612 +07:00 [DBG] List of registered output formatters, in the following order: ["Microsoft.AspNetCore.OData.Formatter.ODataOutputFormatter","Microsoft.AspNetCore.OData.Formatter.ODataOutputFormatter","Microsoft.AspNetCore.OData.Formatter.ODataOutputFormatter","Microsoft.AspNetCore.Mvc.Formatters.HttpNoContentOutputFormatter","Microsoft.AspNetCore.Mvc.Formatters.StringOutputFormatter","Microsoft.AspNetCore.Mvc.Formatters.StreamOutputFormatter","Microsoft.AspNetCore.Mvc.Formatters.SystemTextJsonOutputFormatter"]
+2025-09-27 06:14:12.619 +07:00 [DBG] No information found on request to perform content negotiation.
+2025-09-27 06:14:12.620 +07:00 [DBG] Attempting to select an output formatter without using a content type as no explicit content types were specified for the response.
+2025-09-27 06:14:12.620 +07:00 [DBG] Attempting to select the first formatter in the output formatters list which can write the result.
+2025-09-27 06:14:12.624 +07:00 [DBG] Selected output formatter 'Microsoft.AspNetCore.Mvc.Formatters.SystemTextJsonOutputFormatter' and content type 'application/json' to write the response.
+2025-09-27 06:14:12.625 +07:00 [INF] Executing ObjectResult, writing value of type 'FS.Commons.FSResponse'.
+2025-09-27 06:14:12.757 +07:00 [INF] Executed action CapBot.api.Controllers.ReviewController.Create (CapBot.api) in 1999.0008ms
+2025-09-27 06:14:12.758 +07:00 [INF] Executed endpoint 'CapBot.api.Controllers.ReviewController.Create (CapBot.api)'
+2025-09-27 06:14:12.771 +07:00 [DBG] Connection id "0HNFTA9DUP8V6" completed keep alive response.
+2025-09-27 06:14:12.772 +07:00 [DBG] 'MyDbContext' disposed.
+2025-09-27 06:14:12.772 +07:00 [DBG] Disposing connection to database 'capbot_db' on server 'localhost'.
+2025-09-27 06:14:12.772 +07:00 [DBG] Disposed connection to database '' on server '' (0ms).
+2025-09-27 06:14:12.774 +07:00 [INF] Request finished HTTP/1.1 POST http://localhost:5207/api/reviews - 201 null application/json; charset=utf-8 2362.804ms
+2025-09-27 06:15:03.996 +07:00 [INF] Application is shutting down...
+2025-09-27 06:15:03.998 +07:00 [DBG] Hosting stopping
+2025-09-27 06:15:04.017 +07:00 [DBG] Connection id "0HNFTA9DUP8V6" disconnecting.
+2025-09-27 06:15:04.017 +07:00 [DBG] Connection id "0HNFTA9DUP8V7" disconnecting.
+2025-09-27 06:15:04.019 +07:00 [DBG] Connection id "0HNFTA9DUP8V6" stopped.
+2025-09-27 06:15:04.019 +07:00 [DBG] Connection id "0HNFTA9DUP8V7" stopped.
+2025-09-27 06:15:04.023 +07:00 [DBG] Connection id "0HNFTA9DUP8V6" sending FIN because: "The Socket transport's send loop completed gracefully."
+2025-09-27 06:15:04.023 +07:00 [DBG] Connection id "0HNFTA9DUP8V7" sending FIN because: "The Socket transport's send loop completed gracefully."
+2025-09-27 06:15:04.029 +07:00 [ERR] Lỗi khi kiểm tra deadline notifications
+System.Threading.Tasks.TaskCanceledException: A task was canceled.
+   at CapBot.api.Services.DeadlineNotificationService.ExecuteAsync(CancellationToken stoppingToken) in C:\Users\Admin\Downloads\CBAI_API\capbot.api\Services\DeadlineNotificationService.cs:line 41
+2025-09-27 06:15:04.047 +07:00 [DBG] Hosting stopped


### PR DESCRIPTION
This pull request updates the database schema to support a wider range of scores for review criteria and introduces a new field to capture potential duplicates in certain entities. The changes ensure that the application can store more precise score values and additional information related to potential duplicates.

Schema and data model changes:

**Score precision update:**
- Increased the precision of the `Score` property in the `review_criteria_scores` table from `decimal(4,2)` to `decimal(6,2)` in both the Entity Framework model configuration (`MyDbContext.cs`) and the corresponding migration file. This allows storing larger and more precise score values. [[1]](diffhunk://#diff-386a5051536ad90cd220916f74ff439f2d697b14ad89e57351096af218fcd23dL427-R427) [[2]](diffhunk://#diff-7d840d298353a5999c070b05b505a59ee752aa784ab4a2be85c3a0cf817ffa8fR1-R44) [[3]](diffhunk://#diff-857ad4d5c508af4d92a3664e81d096ae57591c77171bcc263f076f16b7a435b0L517-R518)

**New property addition:**
- Added a new nullable `PotentialDuplicate` property of type `string` to the relevant entities in the model snapshot, enabling the application to track potential duplicate records. [[1]](diffhunk://#diff-857ad4d5c508af4d92a3664e81d096ae57591c77171bcc263f076f16b7a435b0R943-R945) [[2]](diffhunk://#diff-857ad4d5c508af4d92a3664e81d096ae57591c77171bcc263f076f16b7a435b0R1067-R1069)