### PR TITLE
Fix: constraint for review, assign logic flow

### DIFF
--- a/App.BLL/Implementations/SubmissionReviewService.cs
+++ b/App.BLL/Implementations/SubmissionReviewService.cs
@@ -198,11 +198,11 @@ public class SubmissionReviewService : ISubmissionReviewService
                 {
                     submission.Status = SubmissionStatus.RevisionRequired;
                 }
-                else if (approveCount >= 2 && approveCount == submittedReviews.Count)
+                else if (approveCount >= 2)
                 {
                     submission.Status = SubmissionStatus.Approved;
                 }
-                else if (rejectCount >= 2 && rejectCount == submittedReviews.Count)
+                else if (rejectCount >= 2)
                 {
                     submission.Status = SubmissionStatus.Rejected;
                 }

--- a/CapBot.api/Logs/log20250929.txt
+++ b/CapBot.api/Logs/log20250929.txt
@@ -4528,3 +4528,4840 @@ ORDER BY [t].[SubmittedAt] DESC
 System.Threading.Tasks.TaskCanceledException: A task was canceled.
    at CapBot.api.Services.DeadlineNotificationService.ExecuteAsync(CancellationToken stoppingToken) in C:\Users\Admin\Downloads\CBAI_API\capbot.api\Services\DeadlineNotificationService.cs:line 41
 2025-09-29 00:39:10.370 +07:00 [DBG] Hosting stopped
+2025-09-29 01:11:44.084 +07:00 [DBG] An 'IServiceProvider' was created for internal use by Entity Framework.
+2025-09-29 01:11:44.144 +07:00 [INF] User profile is available. Using 'C:\Users\Admin\AppData\Local\ASP.NET\DataProtection-Keys' as key repository and Windows DPAPI to encrypt keys at rest.
+2025-09-29 01:11:44.302 +07:00 [DBG] No relationship from 'ReviewerAssignment' to 'User' has been configured by convention because there are multiple properties on one entity type - {'AssignedByUser', 'Reviewer'} that could be matched with the properties on the other entity type - {'ReviewerAssignments'}. This message can be disregarded if explicit configuration has been specified in 'OnModelCreating'.
+2025-09-29 01:11:44.318 +07:00 [DBG] No relationship from 'SubmissionWorkflowLog' to 'WorkflowState' has been configured by convention because there are multiple properties on one entity type - {'FromState', 'ToState'} that could be matched with the properties on the other entity type - {'FromStateLogs', 'ToStateLogs'}. This message can be disregarded if explicit configuration has been specified in 'OnModelCreating'.
+2025-09-29 01:11:44.330 +07:00 [DBG] No relationship from 'User' to 'ReviewerAssignment' has been configured by convention because there are multiple properties on one entity type - {'ReviewerAssignments'} that could be matched with the properties on the other entity type - {'AssignedByUser', 'Reviewer'}. This message can be disregarded if explicit configuration has been specified in 'OnModelCreating'.
+2025-09-29 01:11:44.331 +07:00 [DBG] No relationship from 'WorkflowState' to 'SubmissionWorkflowLog' has been configured by convention because there are multiple properties on one entity type - {'FromStateLogs', 'ToStateLogs'} that could be matched with the properties on the other entity type - {'FromState', 'ToState'}. This message can be disregarded if explicit configuration has been specified in 'OnModelCreating'.
+2025-09-29 01:11:44.331 +07:00 [DBG] No relationship from 'WorkflowState' to 'WorkflowTransition' has been configured by convention because there are multiple properties on one entity type - {'FromTransitions', 'ToTransitions'} that could be matched with the properties on the other entity type - {'FromState', 'ToState'}. This message can be disregarded if explicit configuration has been specified in 'OnModelCreating'.
+2025-09-29 01:11:44.332 +07:00 [DBG] No relationship from 'WorkflowTransition' to 'WorkflowState' has been configured by convention because there are multiple properties on one entity type - {'FromState', 'ToState'} that could be matched with the properties on the other entity type - {'FromTransitions', 'ToTransitions'}. This message can be disregarded if explicit configuration has been specified in 'OnModelCreating'.
+2025-09-29 01:11:44.492 +07:00 [DBG] No relationship from 'ReviewerAssignment' to 'User' has been configured by convention because there are multiple properties on one entity type - {'AssignedByUser', 'Reviewer'} that could be matched with the properties on the other entity type - {'ReviewerAssignments'}. This message can be disregarded if explicit configuration has been specified in 'OnModelCreating'.
+2025-09-29 01:11:44.493 +07:00 [DBG] No relationship from 'User' to 'ReviewerAssignment' has been configured by convention because there are multiple properties on one entity type - {'ReviewerAssignments'} that could be matched with the properties on the other entity type - {'AssignedByUser', 'Reviewer'}. This message can be disregarded if explicit configuration has been specified in 'OnModelCreating'.
+2025-09-29 01:11:44.508 +07:00 [DBG] No relationship from 'WorkflowTransition' to 'WorkflowState' has been configured by convention because there are multiple properties on one entity type - {'FromState', 'ToState'} that could be matched with the properties on the other entity type - {'FromTransitions', 'ToTransitions'}. This message can be disregarded if explicit configuration has been specified in 'OnModelCreating'.
+2025-09-29 01:11:44.508 +07:00 [DBG] No relationship from 'WorkflowState' to 'SubmissionWorkflowLog' has been configured by convention because there are multiple properties on one entity type - {'FromStateLogs', 'ToStateLogs'} that could be matched with the properties on the other entity type - {'FromState', 'ToState'}. This message can be disregarded if explicit configuration has been specified in 'OnModelCreating'.
+2025-09-29 01:11:44.509 +07:00 [DBG] No relationship from 'WorkflowState' to 'WorkflowTransition' has been configured by convention because there are multiple properties on one entity type - {'FromTransitions', 'ToTransitions'} that could be matched with the properties on the other entity type - {'FromState', 'ToState'}. This message can be disregarded if explicit configuration has been specified in 'OnModelCreating'.
+2025-09-29 01:11:44.510 +07:00 [DBG] No relationship from 'WorkflowState' to 'SubmissionWorkflowLog' has been configured by convention because there are multiple properties on one entity type - {'FromStateLogs', 'ToStateLogs'} that could be matched with the properties on the other entity type - {'FromState', 'ToState'}. This message can be disregarded if explicit configuration has been specified in 'OnModelCreating'.
+2025-09-29 01:11:44.513 +07:00 [DBG] No relationship from 'SubmissionWorkflowLog' to 'WorkflowState' has been configured by convention because there are multiple properties on one entity type - {'FromState', 'ToState'} that could be matched with the properties on the other entity type - {'FromStateLogs', 'ToStateLogs'}. This message can be disregarded if explicit configuration has been specified in 'OnModelCreating'.
+2025-09-29 01:11:44.514 +07:00 [DBG] No relationship from 'WorkflowState' to 'SubmissionWorkflowLog' has been configured by convention because there are multiple properties on one entity type - {'FromStateLogs', 'ToStateLogs'} that could be matched with the properties on the other entity type - {'FromState', 'ToState'}. This message can be disregarded if explicit configuration has been specified in 'OnModelCreating'.
+2025-09-29 01:11:44.549 +07:00 [DBG] The index {'LecturerId'} was not created on entity type 'LecturerSkill' as the properties are already covered by the index {'LecturerId', 'SkillTag'}.
+2025-09-29 01:11:44.549 +07:00 [DBG] The index {'SemesterId'} was not created on entity type 'Phase' as the properties are already covered by the index {'SemesterId', 'PhaseTypeId'}.
+2025-09-29 01:11:44.550 +07:00 [DBG] The index {'AssignmentId'} was not created on entity type 'Review' as the properties are already covered by the index {'AssignmentId', 'Status'}.
+2025-09-29 01:11:44.550 +07:00 [DBG] The index {'ReviewId'} was not created on entity type 'ReviewComment' as the properties are already covered by the index {'ReviewId', 'SectionName'}.
+2025-09-29 01:11:44.550 +07:00 [DBG] The index {'ReviewId'} was not created on entity type 'ReviewCriteriaScore' as the properties are already covered by the index {'ReviewId', 'CriteriaId'}.
+2025-09-29 01:11:44.550 +07:00 [DBG] The index {'ReviewerId'} was not created on entity type 'ReviewerAssignment' as the properties are already covered by the index {'ReviewerId', 'Status'}.
+2025-09-29 01:11:44.550 +07:00 [DBG] The index {'SubmissionId'} was not created on entity type 'ReviewerAssignment' as the properties are already covered by the index {'SubmissionId', 'ReviewerId'}.
+2025-09-29 01:11:44.550 +07:00 [DBG] The index {'ReviewerId'} was not created on entity type 'ReviewerPerformance' as the properties are already covered by the index {'ReviewerId', 'SemesterId'}.
+2025-09-29 01:11:44.550 +07:00 [DBG] The index {'PhaseId'} was not created on entity type 'Submission' as the properties are already covered by the index {'PhaseId', 'Status'}.
+2025-09-29 01:11:44.550 +07:00 [DBG] The index {'PhaseId'} was not created on entity type 'Submission' as the properties are already covered by the index {'PhaseId', 'Status', 'SubmittedAt'}.
+2025-09-29 01:11:44.550 +07:00 [DBG] The index {'TopicId'} was not created on entity type 'Submission' as the properties are already covered by the index {'TopicId', 'PhaseId', 'SubmissionRound'}.
+2025-09-29 01:11:44.550 +07:00 [DBG] The index {'SubmissionId'} was not created on entity type 'SubmissionWorkflowLog' as the properties are already covered by the index {'SubmissionId', 'CreatedAt'}.
+2025-09-29 01:11:44.550 +07:00 [DBG] The index {'UserId'} was not created on entity type 'SystemNotification' as the properties are already covered by the index {'UserId', 'IsRead', 'CreatedAt'}.
+2025-09-29 01:11:44.551 +07:00 [DBG] The index {'SemesterId'} was not created on entity type 'Topic' as the properties are already covered by the index {'SemesterId', 'IsApproved'}.
+2025-09-29 01:11:44.551 +07:00 [DBG] The index {'SupervisorId'} was not created on entity type 'Topic' as the properties are already covered by the index {'SupervisorId', 'SemesterId'}.
+2025-09-29 01:11:44.551 +07:00 [DBG] The index {'TopicId'} was not created on entity type 'TopicVersion' as the properties are already covered by the index {'TopicId', 'Status'}.
+2025-09-29 01:11:44.551 +07:00 [DBG] The index {'TopicId'} was not created on entity type 'TopicVersion' as the properties are already covered by the index {'TopicId', 'VersionNumber'}.
+2025-09-29 01:11:44.551 +07:00 [DBG] The index {'UserId'} was not created on entity type 'UserRole' as the properties are already covered by the index {'UserId', 'RoleId'}.
+2025-09-29 01:11:44.551 +07:00 [DBG] The index {'UserId'} was not created on entity type 'UserToken' as the properties are already covered by the index {'UserId', 'LoginProvider', 'Name'}.
+2025-09-29 01:11:44.664 +07:00 [WRN] The 'ProficiencyLevels' property 'ProficiencyLevel' on entity type 'LecturerSkill' is configured with a database-generated default, but has no configured sentinel value. The database-generated default will always be used for inserts when the property has the value '0', since this is the CLR default for the 'ProficiencyLevels' type. Consider using a nullable type, using a nullable backing field, or setting the sentinel value for the property to ensure the database default is used when, and only when, appropriate. See https://aka.ms/efcore-docs-default-values for more information.
+2025-09-29 01:11:44.664 +07:00 [WRN] The 'ReviewRecommendations' property 'Recommendation' on entity type 'Review' is configured with a database-generated default, but has no configured sentinel value. The database-generated default will always be used for inserts when the property has the value '0', since this is the CLR default for the 'ReviewRecommendations' type. Consider using a nullable type, using a nullable backing field, or setting the sentinel value for the property to ensure the database default is used when, and only when, appropriate. See https://aka.ms/efcore-docs-default-values for more information.
+2025-09-29 01:11:44.664 +07:00 [WRN] The 'ReviewStatus' property 'Status' on entity type 'Review' is configured with a database-generated default, but has no configured sentinel value. The database-generated default will always be used for inserts when the property has the value '0', since this is the CLR default for the 'ReviewStatus' type. Consider using a nullable type, using a nullable backing field, or setting the sentinel value for the property to ensure the database default is used when, and only when, appropriate. See https://aka.ms/efcore-docs-default-values for more information.
+2025-09-29 01:11:44.664 +07:00 [WRN] The 'CommentTypes' property 'CommentType' on entity type 'ReviewComment' is configured with a database-generated default, but has no configured sentinel value. The database-generated default will always be used for inserts when the property has the value '0', since this is the CLR default for the 'CommentTypes' type. Consider using a nullable type, using a nullable backing field, or setting the sentinel value for the property to ensure the database default is used when, and only when, appropriate. See https://aka.ms/efcore-docs-default-values for more information.
+2025-09-29 01:11:44.664 +07:00 [WRN] The 'PriorityLevels' property 'Priority' on entity type 'ReviewComment' is configured with a database-generated default, but has no configured sentinel value. The database-generated default will always be used for inserts when the property has the value '0', since this is the CLR default for the 'PriorityLevels' type. Consider using a nullable type, using a nullable backing field, or setting the sentinel value for the property to ensure the database default is used when, and only when, appropriate. See https://aka.ms/efcore-docs-default-values for more information.
+2025-09-29 01:11:44.664 +07:00 [WRN] The 'AssignmentTypes' property 'AssignmentType' on entity type 'ReviewerAssignment' is configured with a database-generated default, but has no configured sentinel value. The database-generated default will always be used for inserts when the property has the value '0', since this is the CLR default for the 'AssignmentTypes' type. Consider using a nullable type, using a nullable backing field, or setting the sentinel value for the property to ensure the database default is used when, and only when, appropriate. See https://aka.ms/efcore-docs-default-values for more information.
+2025-09-29 01:11:44.665 +07:00 [WRN] The 'AssignmentStatus' property 'Status' on entity type 'ReviewerAssignment' is configured with a database-generated default, but has no configured sentinel value. The database-generated default will always be used for inserts when the property has the value '0', since this is the CLR default for the 'AssignmentStatus' type. Consider using a nullable type, using a nullable backing field, or setting the sentinel value for the property to ensure the database default is used when, and only when, appropriate. See https://aka.ms/efcore-docs-default-values for more information.
+2025-09-29 01:11:44.665 +07:00 [WRN] The 'AiCheckStatus' property 'AiCheckStatus' on entity type 'Submission' is configured with a database-generated default, but has no configured sentinel value. The database-generated default will always be used for inserts when the property has the value '0', since this is the CLR default for the 'AiCheckStatus' type. Consider using a nullable type, using a nullable backing field, or setting the sentinel value for the property to ensure the database default is used when, and only when, appropriate. See https://aka.ms/efcore-docs-default-values for more information.
+2025-09-29 01:11:44.665 +07:00 [WRN] The 'SubmissionStatus' property 'Status' on entity type 'Submission' is configured with a database-generated default, but has no configured sentinel value. The database-generated default will always be used for inserts when the property has the value '0', since this is the CLR default for the 'SubmissionStatus' type. Consider using a nullable type, using a nullable backing field, or setting the sentinel value for the property to ensure the database default is used when, and only when, appropriate. See https://aka.ms/efcore-docs-default-values for more information.
+2025-09-29 01:11:44.665 +07:00 [WRN] The 'NotificationTypes' property 'Type' on entity type 'SystemNotification' is configured with a database-generated default, but has no configured sentinel value. The database-generated default will always be used for inserts when the property has the value '0', since this is the CLR default for the 'NotificationTypes' type. Consider using a nullable type, using a nullable backing field, or setting the sentinel value for the property to ensure the database default is used when, and only when, appropriate. See https://aka.ms/efcore-docs-default-values for more information.
+2025-09-29 01:11:44.665 +07:00 [WRN] The 'TopicStatus' property 'Status' on entity type 'TopicVersion' is configured with a database-generated default, but has no configured sentinel value. The database-generated default will always be used for inserts when the property has the value '0', since this is the CLR default for the 'TopicStatus' type. Consider using a nullable type, using a nullable backing field, or setting the sentinel value for the property to ensure the database default is used when, and only when, appropriate. See https://aka.ms/efcore-docs-default-values for more information.
+2025-09-29 01:11:44.779 +07:00 [DBG] Entity Framework Core 8.0.16 initialized 'MyDbContext' using provider 'Microsoft.EntityFrameworkCore.SqlServer:8.0.13' with options: MigrationsAssembly=App.DAL 
+2025-09-29 01:11:44.818 +07:00 [DBG] Compiling query expression: 
+'DbSet<Role>()
+    .FirstOrDefault(r => r.NormalizedName == __normalizedName_0)'
+2025-09-29 01:11:44.926 +07:00 [DBG] Generated query execution expression: 
+'queryContext => ShapedQueryCompilingExpressionVisitor.SingleOrDefaultAsync<Role>(
+    asyncEnumerable: new SingleQueryingEnumerable<Role>(
+        (RelationalQueryContext)queryContext, 
+        RelationalCommandCache.QueryExpression(
+            Projection Mapping:
+                EmptyProjectionMember -> Dictionary<IProperty, int> { [Property: Role.Id (int) Required PK AfterSave:Throw ValueGenerated.OnAdd, 0], [Property: Role.ConcurrencyStamp (string), 1], [Property: Role.IsAdmin (bool) Required, 2], [Property: Role.Name (string), 3], [Property: Role.NormalizedName (string), 4] }
+            SELECT TOP(1) r.Id, r.ConcurrencyStamp, r.IsAdmin, r.Name, r.NormalizedName
+            FROM roles AS r
+            WHERE r.NormalizedName == @__normalizedName_0), 
+        null, 
+        Func<QueryContext, DbDataReader, ResultContext, SingleQueryResultCoordinator, Role>, 
+        App.DAL.Context.MyDbContext, 
+        False, 
+        False, 
+        True
+    ), 
+    cancellationToken: queryContext.CancellationToken)'
+2025-09-29 01:11:44.947 +07:00 [DBG] Creating DbConnection.
+2025-09-29 01:11:44.958 +07:00 [DBG] Created DbConnection. (8ms).
+2025-09-29 01:11:44.961 +07:00 [DBG] Opening connection to database 'capbot_db' on server 'localhost'.
+2025-09-29 01:11:45.061 +07:00 [DBG] Opened connection to database 'capbot_db' on server 'localhost'.
+2025-09-29 01:11:45.063 +07:00 [DBG] Creating DbCommand for 'ExecuteReader'.
+2025-09-29 01:11:45.067 +07:00 [DBG] Created DbCommand for 'ExecuteReader' (1ms).
+2025-09-29 01:11:45.072 +07:00 [DBG] Initialized DbCommand for 'ExecuteReader' (9ms).
+2025-09-29 01:11:45.077 +07:00 [DBG] Executing DbCommand [Parameters=[@__normalizedName_0='?' (Size = 4000)], CommandType='"Text"', CommandTimeout='30']
+SELECT TOP(1) [r].[Id], [r].[ConcurrencyStamp], [r].[IsAdmin], [r].[Name], [r].[NormalizedName]
+FROM [roles] AS [r]
+WHERE [r].[NormalizedName] = @__normalizedName_0
+2025-09-29 01:11:45.109 +07:00 [INF] Executed DbCommand (32ms) [Parameters=[@__normalizedName_0='?' (Size = 4000)], CommandType='"Text"', CommandTimeout='30']
+SELECT TOP(1) [r].[Id], [r].[ConcurrencyStamp], [r].[IsAdmin], [r].[Name], [r].[NormalizedName]
+FROM [roles] AS [r]
+WHERE [r].[NormalizedName] = @__normalizedName_0
+2025-09-29 01:11:45.137 +07:00 [DBG] Context 'MyDbContext' started tracking 'Role' entity. Consider using 'DbContextOptionsBuilder.EnableSensitiveDataLogging' to see key values.
+2025-09-29 01:11:45.153 +07:00 [DBG] Closing data reader to 'capbot_db' on server 'localhost'.
+2025-09-29 01:11:45.157 +07:00 [DBG] A data reader for 'capbot_db' on server 'localhost' is being disposed after spending 45ms reading results.
+2025-09-29 01:11:45.159 +07:00 [DBG] Closing connection to database 'capbot_db' on server 'localhost'.
+2025-09-29 01:11:45.162 +07:00 [DBG] Closed connection to database 'capbot_db' on server 'localhost' (3ms).
+2025-09-29 01:11:45.164 +07:00 [DBG] Opening connection to database 'capbot_db' on server 'localhost'.
+2025-09-29 01:11:45.165 +07:00 [DBG] Opened connection to database 'capbot_db' on server 'localhost'.
+2025-09-29 01:11:45.165 +07:00 [DBG] Creating DbCommand for 'ExecuteReader'.
+2025-09-29 01:11:45.166 +07:00 [DBG] Created DbCommand for 'ExecuteReader' (0ms).
+2025-09-29 01:11:45.166 +07:00 [DBG] Initialized DbCommand for 'ExecuteReader' (0ms).
+2025-09-29 01:11:45.166 +07:00 [DBG] Executing DbCommand [Parameters=[@__normalizedName_0='?' (Size = 4000)], CommandType='"Text"', CommandTimeout='30']
+SELECT TOP(1) [r].[Id], [r].[ConcurrencyStamp], [r].[IsAdmin], [r].[Name], [r].[NormalizedName]
+FROM [roles] AS [r]
+WHERE [r].[NormalizedName] = @__normalizedName_0
+2025-09-29 01:11:45.169 +07:00 [INF] Executed DbCommand (3ms) [Parameters=[@__normalizedName_0='?' (Size = 4000)], CommandType='"Text"', CommandTimeout='30']
+SELECT TOP(1) [r].[Id], [r].[ConcurrencyStamp], [r].[IsAdmin], [r].[Name], [r].[NormalizedName]
+FROM [roles] AS [r]
+WHERE [r].[NormalizedName] = @__normalizedName_0
+2025-09-29 01:11:45.169 +07:00 [DBG] Context 'MyDbContext' started tracking 'Role' entity. Consider using 'DbContextOptionsBuilder.EnableSensitiveDataLogging' to see key values.
+2025-09-29 01:11:45.169 +07:00 [DBG] Closing data reader to 'capbot_db' on server 'localhost'.
+2025-09-29 01:11:45.170 +07:00 [DBG] A data reader for 'capbot_db' on server 'localhost' is being disposed after spending 0ms reading results.
+2025-09-29 01:11:45.170 +07:00 [DBG] Closing connection to database 'capbot_db' on server 'localhost'.
+2025-09-29 01:11:45.170 +07:00 [DBG] Closed connection to database 'capbot_db' on server 'localhost' (0ms).
+2025-09-29 01:11:45.170 +07:00 [DBG] Opening connection to database 'capbot_db' on server 'localhost'.
+2025-09-29 01:11:45.170 +07:00 [DBG] Opened connection to database 'capbot_db' on server 'localhost'.
+2025-09-29 01:11:45.170 +07:00 [DBG] Creating DbCommand for 'ExecuteReader'.
+2025-09-29 01:11:45.170 +07:00 [DBG] Created DbCommand for 'ExecuteReader' (0ms).
+2025-09-29 01:11:45.170 +07:00 [DBG] Initialized DbCommand for 'ExecuteReader' (0ms).
+2025-09-29 01:11:45.170 +07:00 [DBG] Executing DbCommand [Parameters=[@__normalizedName_0='?' (Size = 4000)], CommandType='"Text"', CommandTimeout='30']
+SELECT TOP(1) [r].[Id], [r].[ConcurrencyStamp], [r].[IsAdmin], [r].[Name], [r].[NormalizedName]
+FROM [roles] AS [r]
+WHERE [r].[NormalizedName] = @__normalizedName_0
+2025-09-29 01:11:45.171 +07:00 [INF] Executed DbCommand (1ms) [Parameters=[@__normalizedName_0='?' (Size = 4000)], CommandType='"Text"', CommandTimeout='30']
+SELECT TOP(1) [r].[Id], [r].[ConcurrencyStamp], [r].[IsAdmin], [r].[Name], [r].[NormalizedName]
+FROM [roles] AS [r]
+WHERE [r].[NormalizedName] = @__normalizedName_0
+2025-09-29 01:11:45.172 +07:00 [DBG] Context 'MyDbContext' started tracking 'Role' entity. Consider using 'DbContextOptionsBuilder.EnableSensitiveDataLogging' to see key values.
+2025-09-29 01:11:45.172 +07:00 [DBG] Closing data reader to 'capbot_db' on server 'localhost'.
+2025-09-29 01:11:45.172 +07:00 [DBG] A data reader for 'capbot_db' on server 'localhost' is being disposed after spending 0ms reading results.
+2025-09-29 01:11:45.172 +07:00 [DBG] Closing connection to database 'capbot_db' on server 'localhost'.
+2025-09-29 01:11:45.172 +07:00 [DBG] Closed connection to database 'capbot_db' on server 'localhost' (0ms).
+2025-09-29 01:11:45.173 +07:00 [DBG] Opening connection to database 'capbot_db' on server 'localhost'.
+2025-09-29 01:11:45.173 +07:00 [DBG] Opened connection to database 'capbot_db' on server 'localhost'.
+2025-09-29 01:11:45.174 +07:00 [DBG] Creating DbCommand for 'ExecuteReader'.
+2025-09-29 01:11:45.174 +07:00 [DBG] Created DbCommand for 'ExecuteReader' (0ms).
+2025-09-29 01:11:45.174 +07:00 [DBG] Initialized DbCommand for 'ExecuteReader' (0ms).
+2025-09-29 01:11:45.174 +07:00 [DBG] Executing DbCommand [Parameters=[@__normalizedName_0='?' (Size = 4000)], CommandType='"Text"', CommandTimeout='30']
+SELECT TOP(1) [r].[Id], [r].[ConcurrencyStamp], [r].[IsAdmin], [r].[Name], [r].[NormalizedName]
+FROM [roles] AS [r]
+WHERE [r].[NormalizedName] = @__normalizedName_0
+2025-09-29 01:11:45.175 +07:00 [INF] Executed DbCommand (1ms) [Parameters=[@__normalizedName_0='?' (Size = 4000)], CommandType='"Text"', CommandTimeout='30']
+SELECT TOP(1) [r].[Id], [r].[ConcurrencyStamp], [r].[IsAdmin], [r].[Name], [r].[NormalizedName]
+FROM [roles] AS [r]
+WHERE [r].[NormalizedName] = @__normalizedName_0
+2025-09-29 01:11:45.176 +07:00 [DBG] Context 'MyDbContext' started tracking 'Role' entity. Consider using 'DbContextOptionsBuilder.EnableSensitiveDataLogging' to see key values.
+2025-09-29 01:11:45.176 +07:00 [DBG] Closing data reader to 'capbot_db' on server 'localhost'.
+2025-09-29 01:11:45.176 +07:00 [DBG] A data reader for 'capbot_db' on server 'localhost' is being disposed after spending 0ms reading results.
+2025-09-29 01:11:45.176 +07:00 [DBG] Closing connection to database 'capbot_db' on server 'localhost'.
+2025-09-29 01:11:45.176 +07:00 [DBG] Closed connection to database 'capbot_db' on server 'localhost' (0ms).
+2025-09-29 01:11:45.179 +07:00 [DBG] Compiling query expression: 
+'DbSet<User>()
+    .SingleOrDefault(u => u.NormalizedEmail == __normalizedEmail_0)'
+2025-09-29 01:11:45.185 +07:00 [DBG] Generated query execution expression: 
+'queryContext => ShapedQueryCompilingExpressionVisitor.SingleOrDefaultAsync<User>(
+    asyncEnumerable: new SingleQueryingEnumerable<User>(
+        (RelationalQueryContext)queryContext, 
+        RelationalCommandCache.QueryExpression(
+            Projection Mapping:
+                EmptyProjectionMember -> Dictionary<IProperty, int> { [Property: User.Id (int) Required PK AfterSave:Throw ValueGenerated.OnAdd, 0], [Property: User.AccessFailedCount (int) Required, 1], [Property: User.ConcurrencyStamp (string), 2], [Property: User.CreatedAt (DateTime) Required, 3], [Property: User.DeletedAt (DateTime?), 4], [Property: User.Email (string), 5], [Property: User.EmailConfirmed (bool) Required, 6], [Property: User.LastModifiedAt (DateTime) Required, 7], [Property: User.LastModifiedBy (string), 8], [Property: User.LockoutEnabled (bool) Required, 9], [Property: User.LockoutEnd (DateTimeOffset?), 10], [Property: User.NormalizedEmail (string), 11], [Property: User.NormalizedUserName (string), 12], [Property: User.PasswordHash (string), 13], [Property: User.PhoneNumber (string), 14], [Property: User.PhoneNumberConfirmed (bool) Required, 15], [Property: User.SecurityStamp (string), 16], [Property: User.TwoFactorEnabled (bool) Required, 17], [Property: User.UserName (string), 18] }
+            SELECT TOP(2) u.Id, u.AccessFailedCount, u.ConcurrencyStamp, u.CreatedAt, u.DeletedAt, u.Email, u.EmailConfirmed, u.LastModifiedAt, u.LastModifiedBy, u.LockoutEnabled, u.LockoutEnd, u.NormalizedEmail, u.NormalizedUserName, u.PasswordHash, u.PhoneNumber, u.PhoneNumberConfirmed, u.SecurityStamp, u.TwoFactorEnabled, u.UserName
+            FROM users AS u
+            WHERE u.NormalizedEmail == @__normalizedEmail_0), 
+        null, 
+        Func<QueryContext, DbDataReader, ResultContext, SingleQueryResultCoordinator, User>, 
+        App.DAL.Context.MyDbContext, 
+        False, 
+        False, 
+        True
+    ), 
+    cancellationToken: queryContext.CancellationToken)'
+2025-09-29 01:11:45.186 +07:00 [DBG] Opening connection to database 'capbot_db' on server 'localhost'.
+2025-09-29 01:11:45.187 +07:00 [DBG] Opened connection to database 'capbot_db' on server 'localhost'.
+2025-09-29 01:11:45.187 +07:00 [DBG] Creating DbCommand for 'ExecuteReader'.
+2025-09-29 01:11:45.187 +07:00 [DBG] Created DbCommand for 'ExecuteReader' (0ms).
+2025-09-29 01:11:45.187 +07:00 [DBG] Initialized DbCommand for 'ExecuteReader' (0ms).
+2025-09-29 01:11:45.188 +07:00 [DBG] Executing DbCommand [Parameters=[@__normalizedEmail_0='?' (Size = 4000)], CommandType='"Text"', CommandTimeout='30']
+SELECT TOP(2) [u].[Id], [u].[AccessFailedCount], [u].[ConcurrencyStamp], [u].[CreatedAt], [u].[DeletedAt], [u].[Email], [u].[EmailConfirmed], [u].[LastModifiedAt], [u].[LastModifiedBy], [u].[LockoutEnabled], [u].[LockoutEnd], [u].[NormalizedEmail], [u].[NormalizedUserName], [u].[PasswordHash], [u].[PhoneNumber], [u].[PhoneNumberConfirmed], [u].[SecurityStamp], [u].[TwoFactorEnabled], [u].[UserName]
+FROM [users] AS [u]
+WHERE [u].[NormalizedEmail] = @__normalizedEmail_0
+2025-09-29 01:11:45.190 +07:00 [INF] Executed DbCommand (3ms) [Parameters=[@__normalizedEmail_0='?' (Size = 4000)], CommandType='"Text"', CommandTimeout='30']
+SELECT TOP(2) [u].[Id], [u].[AccessFailedCount], [u].[ConcurrencyStamp], [u].[CreatedAt], [u].[DeletedAt], [u].[Email], [u].[EmailConfirmed], [u].[LastModifiedAt], [u].[LastModifiedBy], [u].[LockoutEnabled], [u].[LockoutEnd], [u].[NormalizedEmail], [u].[NormalizedUserName], [u].[PasswordHash], [u].[PhoneNumber], [u].[PhoneNumberConfirmed], [u].[SecurityStamp], [u].[TwoFactorEnabled], [u].[UserName]
+FROM [users] AS [u]
+WHERE [u].[NormalizedEmail] = @__normalizedEmail_0
+2025-09-29 01:11:45.209 +07:00 [DBG] Context 'MyDbContext' started tracking 'User' entity. Consider using 'DbContextOptionsBuilder.EnableSensitiveDataLogging' to see key values.
+2025-09-29 01:11:45.231 +07:00 [DBG] Closing data reader to 'capbot_db' on server 'localhost'.
+2025-09-29 01:11:45.231 +07:00 [DBG] A data reader for 'capbot_db' on server 'localhost' is being disposed after spending 40ms reading results.
+2025-09-29 01:11:45.231 +07:00 [DBG] Closing connection to database 'capbot_db' on server 'localhost'.
+2025-09-29 01:11:45.231 +07:00 [DBG] Closed connection to database 'capbot_db' on server 'localhost' (0ms).
+2025-09-29 01:11:45.233 +07:00 [INF] Admin user 'fptslayer@gmail.com' already exists
+2025-09-29 01:11:45.236 +07:00 [DBG] Opening connection to database 'capbot_db' on server 'localhost'.
+2025-09-29 01:11:45.236 +07:00 [DBG] Opened connection to database 'capbot_db' on server 'localhost'.
+2025-09-29 01:11:45.236 +07:00 [DBG] Creating DbCommand for 'ExecuteReader'.
+2025-09-29 01:11:45.236 +07:00 [DBG] Created DbCommand for 'ExecuteReader' (0ms).
+2025-09-29 01:11:45.236 +07:00 [DBG] Initialized DbCommand for 'ExecuteReader' (0ms).
+2025-09-29 01:11:45.237 +07:00 [DBG] Executing DbCommand [Parameters=[@__normalizedEmail_0='?' (Size = 4000)], CommandType='"Text"', CommandTimeout='30']
+SELECT TOP(2) [u].[Id], [u].[AccessFailedCount], [u].[ConcurrencyStamp], [u].[CreatedAt], [u].[DeletedAt], [u].[Email], [u].[EmailConfirmed], [u].[LastModifiedAt], [u].[LastModifiedBy], [u].[LockoutEnabled], [u].[LockoutEnd], [u].[NormalizedEmail], [u].[NormalizedUserName], [u].[PasswordHash], [u].[PhoneNumber], [u].[PhoneNumberConfirmed], [u].[SecurityStamp], [u].[TwoFactorEnabled], [u].[UserName]
+FROM [users] AS [u]
+WHERE [u].[NormalizedEmail] = @__normalizedEmail_0
+2025-09-29 01:11:45.238 +07:00 [INF] Executed DbCommand (1ms) [Parameters=[@__normalizedEmail_0='?' (Size = 4000)], CommandType='"Text"', CommandTimeout='30']
+SELECT TOP(2) [u].[Id], [u].[AccessFailedCount], [u].[ConcurrencyStamp], [u].[CreatedAt], [u].[DeletedAt], [u].[Email], [u].[EmailConfirmed], [u].[LastModifiedAt], [u].[LastModifiedBy], [u].[LockoutEnabled], [u].[LockoutEnd], [u].[NormalizedEmail], [u].[NormalizedUserName], [u].[PasswordHash], [u].[PhoneNumber], [u].[PhoneNumberConfirmed], [u].[SecurityStamp], [u].[TwoFactorEnabled], [u].[UserName]
+FROM [users] AS [u]
+WHERE [u].[NormalizedEmail] = @__normalizedEmail_0
+2025-09-29 01:11:45.238 +07:00 [DBG] Context 'MyDbContext' started tracking 'User' entity. Consider using 'DbContextOptionsBuilder.EnableSensitiveDataLogging' to see key values.
+2025-09-29 01:11:45.238 +07:00 [DBG] Closing data reader to 'capbot_db' on server 'localhost'.
+2025-09-29 01:11:45.238 +07:00 [DBG] A data reader for 'capbot_db' on server 'localhost' is being disposed after spending 0ms reading results.
+2025-09-29 01:11:45.238 +07:00 [DBG] Closing connection to database 'capbot_db' on server 'localhost'.
+2025-09-29 01:11:45.238 +07:00 [DBG] Closed connection to database 'capbot_db' on server 'localhost' (0ms).
+2025-09-29 01:11:45.239 +07:00 [INF] Sample moderator 'moderator@example.com' already exists
+2025-09-29 01:11:45.239 +07:00 [DBG] Opening connection to database 'capbot_db' on server 'localhost'.
+2025-09-29 01:11:45.239 +07:00 [DBG] Opened connection to database 'capbot_db' on server 'localhost'.
+2025-09-29 01:11:45.239 +07:00 [DBG] Creating DbCommand for 'ExecuteReader'.
+2025-09-29 01:11:45.239 +07:00 [DBG] Created DbCommand for 'ExecuteReader' (0ms).
+2025-09-29 01:11:45.239 +07:00 [DBG] Initialized DbCommand for 'ExecuteReader' (0ms).
+2025-09-29 01:11:45.239 +07:00 [DBG] Executing DbCommand [Parameters=[@__normalizedEmail_0='?' (Size = 4000)], CommandType='"Text"', CommandTimeout='30']
+SELECT TOP(2) [u].[Id], [u].[AccessFailedCount], [u].[ConcurrencyStamp], [u].[CreatedAt], [u].[DeletedAt], [u].[Email], [u].[EmailConfirmed], [u].[LastModifiedAt], [u].[LastModifiedBy], [u].[LockoutEnabled], [u].[LockoutEnd], [u].[NormalizedEmail], [u].[NormalizedUserName], [u].[PasswordHash], [u].[PhoneNumber], [u].[PhoneNumberConfirmed], [u].[SecurityStamp], [u].[TwoFactorEnabled], [u].[UserName]
+FROM [users] AS [u]
+WHERE [u].[NormalizedEmail] = @__normalizedEmail_0
+2025-09-29 01:11:45.240 +07:00 [INF] Executed DbCommand (1ms) [Parameters=[@__normalizedEmail_0='?' (Size = 4000)], CommandType='"Text"', CommandTimeout='30']
+SELECT TOP(2) [u].[Id], [u].[AccessFailedCount], [u].[ConcurrencyStamp], [u].[CreatedAt], [u].[DeletedAt], [u].[Email], [u].[EmailConfirmed], [u].[LastModifiedAt], [u].[LastModifiedBy], [u].[LockoutEnabled], [u].[LockoutEnd], [u].[NormalizedEmail], [u].[NormalizedUserName], [u].[PasswordHash], [u].[PhoneNumber], [u].[PhoneNumberConfirmed], [u].[SecurityStamp], [u].[TwoFactorEnabled], [u].[UserName]
+FROM [users] AS [u]
+WHERE [u].[NormalizedEmail] = @__normalizedEmail_0
+2025-09-29 01:11:45.240 +07:00 [DBG] Context 'MyDbContext' started tracking 'User' entity. Consider using 'DbContextOptionsBuilder.EnableSensitiveDataLogging' to see key values.
+2025-09-29 01:11:45.240 +07:00 [DBG] Closing data reader to 'capbot_db' on server 'localhost'.
+2025-09-29 01:11:45.241 +07:00 [DBG] A data reader for 'capbot_db' on server 'localhost' is being disposed after spending 0ms reading results.
+2025-09-29 01:11:45.241 +07:00 [DBG] Closing connection to database 'capbot_db' on server 'localhost'.
+2025-09-29 01:11:45.241 +07:00 [DBG] Closed connection to database 'capbot_db' on server 'localhost' (0ms).
+2025-09-29 01:11:45.241 +07:00 [DBG] Opening connection to database 'capbot_db' on server 'localhost'.
+2025-09-29 01:11:45.241 +07:00 [DBG] Opened connection to database 'capbot_db' on server 'localhost'.
+2025-09-29 01:11:45.242 +07:00 [DBG] Creating DbCommand for 'ExecuteReader'.
+2025-09-29 01:11:45.242 +07:00 [DBG] Created DbCommand for 'ExecuteReader' (0ms).
+2025-09-29 01:11:45.242 +07:00 [DBG] Initialized DbCommand for 'ExecuteReader' (0ms).
+2025-09-29 01:11:45.242 +07:00 [DBG] Executing DbCommand [Parameters=[@__normalizedEmail_0='?' (Size = 4000)], CommandType='"Text"', CommandTimeout='30']
+SELECT TOP(2) [u].[Id], [u].[AccessFailedCount], [u].[ConcurrencyStamp], [u].[CreatedAt], [u].[DeletedAt], [u].[Email], [u].[EmailConfirmed], [u].[LastModifiedAt], [u].[LastModifiedBy], [u].[LockoutEnabled], [u].[LockoutEnd], [u].[NormalizedEmail], [u].[NormalizedUserName], [u].[PasswordHash], [u].[PhoneNumber], [u].[PhoneNumberConfirmed], [u].[SecurityStamp], [u].[TwoFactorEnabled], [u].[UserName]
+FROM [users] AS [u]
+WHERE [u].[NormalizedEmail] = @__normalizedEmail_0
+2025-09-29 01:11:45.244 +07:00 [INF] Executed DbCommand (1ms) [Parameters=[@__normalizedEmail_0='?' (Size = 4000)], CommandType='"Text"', CommandTimeout='30']
+SELECT TOP(2) [u].[Id], [u].[AccessFailedCount], [u].[ConcurrencyStamp], [u].[CreatedAt], [u].[DeletedAt], [u].[Email], [u].[EmailConfirmed], [u].[LastModifiedAt], [u].[LastModifiedBy], [u].[LockoutEnabled], [u].[LockoutEnd], [u].[NormalizedEmail], [u].[NormalizedUserName], [u].[PasswordHash], [u].[PhoneNumber], [u].[PhoneNumberConfirmed], [u].[SecurityStamp], [u].[TwoFactorEnabled], [u].[UserName]
+FROM [users] AS [u]
+WHERE [u].[NormalizedEmail] = @__normalizedEmail_0
+2025-09-29 01:11:45.245 +07:00 [DBG] Context 'MyDbContext' started tracking 'User' entity. Consider using 'DbContextOptionsBuilder.EnableSensitiveDataLogging' to see key values.
+2025-09-29 01:11:45.245 +07:00 [DBG] Closing data reader to 'capbot_db' on server 'localhost'.
+2025-09-29 01:11:45.245 +07:00 [DBG] A data reader for 'capbot_db' on server 'localhost' is being disposed after spending 0ms reading results.
+2025-09-29 01:11:45.245 +07:00 [DBG] Closing connection to database 'capbot_db' on server 'localhost'.
+2025-09-29 01:11:45.245 +07:00 [DBG] Closed connection to database 'capbot_db' on server 'localhost' (0ms).
+2025-09-29 01:11:45.245 +07:00 [INF] Data seeding completed successfully
+2025-09-29 01:11:45.246 +07:00 [DBG] 'MyDbContext' disposed.
+2025-09-29 01:11:45.248 +07:00 [DBG] Disposing connection to database 'capbot_db' on server 'localhost'.
+2025-09-29 01:11:45.249 +07:00 [DBG] Disposed connection to database '' on server '' (1ms).
+2025-09-29 01:11:45.259 +07:00 [DBG] Registered SignalR Protocol: json, implemented by Microsoft.AspNetCore.SignalR.Protocol.JsonHubProtocol.
+2025-09-29 01:11:45.374 +07:00 [DBG] Registered model binder providers, in the following order: ["Microsoft.AspNetCore.Mvc.ModelBinding.Binders.BinderTypeModelBinderProvider","Microsoft.AspNetCore.Mvc.ModelBinding.Binders.ServicesModelBinderProvider","Microsoft.AspNetCore.Mvc.ModelBinding.Binders.BodyModelBinderProvider","Microsoft.AspNetCore.Mvc.ModelBinding.Binders.HeaderModelBinderProvider","Microsoft.AspNetCore.Mvc.ModelBinding.Binders.FloatingPointTypeModelBinderProvider","Microsoft.AspNetCore.Mvc.ModelBinding.Binders.EnumTypeModelBinderProvider","Microsoft.AspNetCore.Mvc.ModelBinding.Binders.DateTimeModelBinderProvider","Microsoft.AspNetCore.Mvc.ModelBinding.Binders.SimpleTypeModelBinderProvider","Microsoft.AspNetCore.Mvc.ModelBinding.Binders.TryParseModelBinderProvider","Microsoft.AspNetCore.Mvc.ModelBinding.Binders.CancellationTokenModelBinderProvider"]
+2025-09-29 01:11:45.450 +07:00 [DBG] Hosting starting
+2025-09-29 01:11:45.456 +07:00 [DBG] Reading data from file 'C:\Users\Admin\AppData\Local\ASP.NET\DataProtection-Keys\key-1d6bcff1-a155-4167-8a22-de35a5f05047.xml'.
+2025-09-29 01:11:45.458 +07:00 [DBG] Reading data from file 'C:\Users\Admin\AppData\Local\ASP.NET\DataProtection-Keys\key-2459dd29-32d5-4c49-ac9d-33896047bb78.xml'.
+2025-09-29 01:11:45.458 +07:00 [DBG] Reading data from file 'C:\Users\Admin\AppData\Local\ASP.NET\DataProtection-Keys\key-374624f1-e856-4617-8ae6-fe6a81ce6346.xml'.
+2025-09-29 01:11:45.460 +07:00 [DBG] Found key {1d6bcff1-a155-4167-8a22-de35a5f05047}.
+2025-09-29 01:11:45.462 +07:00 [DBG] Found key {2459dd29-32d5-4c49-ac9d-33896047bb78}.
+2025-09-29 01:11:45.462 +07:00 [DBG] Found key {374624f1-e856-4617-8ae6-fe6a81ce6346}.
+2025-09-29 01:11:45.465 +07:00 [DBG] Considering key {2459dd29-32d5-4c49-ac9d-33896047bb78} with expiration date 2025-11-03 12:40:53Z as default key.
+2025-09-29 01:11:45.467 +07:00 [DBG] Forwarded activator type request from Microsoft.AspNetCore.DataProtection.XmlEncryption.DpapiXmlDecryptor, Microsoft.AspNetCore.DataProtection, Version=8.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60 to Microsoft.AspNetCore.DataProtection.XmlEncryption.DpapiXmlDecryptor, Microsoft.AspNetCore.DataProtection, Culture=neutral, PublicKeyToken=adb9793829ddae60
+2025-09-29 01:11:45.467 +07:00 [DBG] Decrypting secret element using Windows DPAPI.
+2025-09-29 01:11:45.468 +07:00 [DBG] Forwarded activator type request from Microsoft.AspNetCore.DataProtection.AuthenticatedEncryption.ConfigurationModel.AuthenticatedEncryptorDescriptorDeserializer, Microsoft.AspNetCore.DataProtection, Version=8.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60 to Microsoft.AspNetCore.DataProtection.AuthenticatedEncryption.ConfigurationModel.AuthenticatedEncryptorDescriptorDeserializer, Microsoft.AspNetCore.DataProtection, Culture=neutral, PublicKeyToken=adb9793829ddae60
+2025-09-29 01:11:45.469 +07:00 [DBG] Opening CNG algorithm 'AES' from provider 'null' with chaining mode CBC.
+2025-09-29 01:11:45.469 +07:00 [DBG] Opening CNG algorithm 'SHA256' from provider 'null' with HMAC.
+2025-09-29 01:11:45.470 +07:00 [DBG] Using key {2459dd29-32d5-4c49-ac9d-33896047bb78} as the default key.
+2025-09-29 01:11:45.470 +07:00 [DBG] Key ring with default key {2459dd29-32d5-4c49-ac9d-33896047bb78} was loaded during application startup.
+2025-09-29 01:11:45.473 +07:00 [DBG] Middleware loaded
+2025-09-29 01:11:45.474 +07:00 [DBG] Middleware loaded. Script /_framework/aspnetcore-browser-refresh.js (16481 B).
+2025-09-29 01:11:45.475 +07:00 [DBG] Middleware loaded. Script /_framework/blazor-hotreload.js (799 B).
+2025-09-29 01:11:45.494 +07:00 [DBG] Middleware loaded: DOTNET_MODIFIABLE_ASSEMBLIES=debug, __ASPNETCORE_BROWSER_TOOLS=true
+2025-09-29 01:11:45.504 +07:00 [INF] Now listening on: http://localhost:5207
+2025-09-29 01:11:45.504 +07:00 [DBG] Loaded hosting startup assembly CapBot.api
+2025-09-29 01:11:45.504 +07:00 [DBG] Loaded hosting startup assembly Microsoft.AspNetCore.Watch.BrowserRefresh
+2025-09-29 01:11:45.504 +07:00 [INF] Application started. Press Ctrl+C to shut down.
+2025-09-29 01:11:45.504 +07:00 [INF] Hosting environment: Development
+2025-09-29 01:11:45.504 +07:00 [INF] Content root path: C:\Users\Admin\Downloads\CBAI_API\capbot.api
+2025-09-29 01:11:45.505 +07:00 [DBG] Hosting started
+2025-09-29 01:11:45.569 +07:00 [DBG] Connection id "0HNFUN9U1CO8T" accepted.
+2025-09-29 01:11:45.570 +07:00 [DBG] Connection id "0HNFUN9U1CO8T" started.
+2025-09-29 01:11:45.593 +07:00 [INF] Request starting HTTP/1.1 GET http://localhost:5207/index.html - null null
+2025-09-29 01:11:45.598 +07:00 [DBG] Connection id "0HNFUN9U1CO8U" accepted.
+2025-09-29 01:11:45.598 +07:00 [DBG] Connection id "0HNFUN9U1CO8U" started.
+2025-09-29 01:11:45.601 +07:00 [DBG] Wildcard detected, all requests with hosts will be allowed.
+2025-09-29 01:11:45.676 +07:00 [DBG] Response markup is scheduled to include browser refresh script injection.
+2025-09-29 01:11:45.683 +07:00 [DBG] Response markup was updated to include browser refresh script injection.
+2025-09-29 01:11:45.684 +07:00 [DBG] Connection id "0HNFUN9U1CO8T" completed keep alive response.
+2025-09-29 01:11:45.687 +07:00 [INF] Request finished HTTP/1.1 GET http://localhost:5207/index.html - 200 null text/html;charset=utf-8 93.6554ms
+2025-09-29 01:11:45.691 +07:00 [INF] Request starting HTTP/1.1 GET http://localhost:5207/_framework/aspnetcore-browser-refresh.js - null null
+2025-09-29 01:11:45.694 +07:00 [DBG] Script injected: /_framework/aspnetcore-browser-refresh.js
+2025-09-29 01:11:45.694 +07:00 [DBG] Connection id "0HNFUN9U1CO8T" completed keep alive response.
+2025-09-29 01:11:45.695 +07:00 [INF] Request finished HTTP/1.1 GET http://localhost:5207/_framework/aspnetcore-browser-refresh.js - 200 16481 application/javascript; charset=utf-8 3.7531ms
+2025-09-29 01:11:45.742 +07:00 [INF] Request starting HTTP/1.1 GET http://localhost:5207/swagger/v1/swagger.json - null null
+2025-09-29 01:11:46.008 +07:00 [DBG] Connection id "0HNFUN9U1CO8T" completed keep alive response.
+2025-09-29 01:11:46.009 +07:00 [INF] Request finished HTTP/1.1 GET http://localhost:5207/swagger/v1/swagger.json - 200 null application/json;charset=utf-8 266.7952ms
+2025-09-29 01:11:47.311 +07:00 [DBG] Connection id "0HNFUN9U1CO8V" accepted.
+2025-09-29 01:11:47.312 +07:00 [DBG] Connection id "0HNFUN9U1CO8V" started.
+2025-09-29 01:11:47.312 +07:00 [DBG] Connection id "0HNFUN9U1CO90" accepted.
+2025-09-29 01:11:47.312 +07:00 [DBG] Connection id "0HNFUN9U1CO90" started.
+2025-09-29 01:11:47.313 +07:00 [INF] Request starting HTTP/1.1 OPTIONS http://localhost:5207/api/user-profiles/me - null null
+2025-09-29 01:11:47.313 +07:00 [INF] Request starting HTTP/1.1 OPTIONS http://localhost:5207/api/submission/list?PageNumber=1&PageSize=10 - null null
+2025-09-29 01:11:47.317 +07:00 [DBG] OPTIONS requests are not supported
+2025-09-29 01:11:47.317 +07:00 [DBG] OPTIONS requests are not supported
+2025-09-29 01:11:47.319 +07:00 [WRN] Failed to determine the https port for redirect.
+2025-09-29 01:11:47.319 +07:00 [DBG] OPTIONS requests are not supported
+2025-09-29 01:11:47.319 +07:00 [DBG] OPTIONS requests are not supported
+2025-09-29 01:11:47.320 +07:00 [DBG] The request has an origin header: 'http://localhost:3000'.
+2025-09-29 01:11:47.320 +07:00 [DBG] The request has an origin header: 'http://localhost:3000'.
+2025-09-29 01:11:47.321 +07:00 [INF] CORS policy execution successful.
+2025-09-29 01:11:47.321 +07:00 [INF] CORS policy execution successful.
+2025-09-29 01:11:47.322 +07:00 [DBG] The request is a preflight request.
+2025-09-29 01:11:47.322 +07:00 [DBG] The request is a preflight request.
+2025-09-29 01:11:47.324 +07:00 [DBG] Connection id "0HNFUN9U1CO8V" completed keep alive response.
+2025-09-29 01:11:47.324 +07:00 [DBG] Connection id "0HNFUN9U1CO90" completed keep alive response.
+2025-09-29 01:11:47.324 +07:00 [INF] Request finished HTTP/1.1 OPTIONS http://localhost:5207/api/user-profiles/me - 204 null null 11.386ms
+2025-09-29 01:11:47.324 +07:00 [INF] Request finished HTTP/1.1 OPTIONS http://localhost:5207/api/submission/list?PageNumber=1&PageSize=10 - 204 null null 11.3093ms
+2025-09-29 01:11:47.327 +07:00 [INF] Request starting HTTP/1.1 GET http://localhost:5207/api/submission/list?PageNumber=1&PageSize=10 - null null
+2025-09-29 01:11:47.327 +07:00 [INF] Request starting HTTP/1.1 GET http://localhost:5207/api/user-profiles/me - null null
+2025-09-29 01:11:47.327 +07:00 [DBG] The request path /api/submission/list does not match a supported file type
+2025-09-29 01:11:47.327 +07:00 [DBG] The request path /api/user-profiles/me does not match a supported file type
+2025-09-29 01:11:47.328 +07:00 [DBG] The request path /api/submission/list does not match a supported file type
+2025-09-29 01:11:47.328 +07:00 [DBG] The request path /api/user-profiles/me does not match a supported file type
+2025-09-29 01:11:47.328 +07:00 [DBG] The request has an origin header: 'http://localhost:3000'.
+2025-09-29 01:11:47.328 +07:00 [DBG] The request has an origin header: 'http://localhost:3000'.
+2025-09-29 01:11:47.329 +07:00 [INF] CORS policy execution successful.
+2025-09-29 01:11:47.329 +07:00 [INF] CORS policy execution successful.
+2025-09-29 01:11:47.355 +07:00 [DBG] 1 candidate(s) found for the request path '/api/submission/list'
+2025-09-29 01:11:47.355 +07:00 [DBG] 2 candidate(s) found for the request path '/api/user-profiles/me'
+2025-09-29 01:11:47.355 +07:00 [DBG] Endpoint 'CapBot.api.Controllers.SubmissionController.List (CapBot.api)' with route pattern 'api/submission/list' is valid for the request path '/api/submission/list'
+2025-09-29 01:11:47.355 +07:00 [DBG] Endpoint 'CapBot.api.Controllers.UserProfileController.GetMyProfile (CapBot.api)' with route pattern 'api/user-profiles/me' is valid for the request path '/api/user-profiles/me'
+2025-09-29 01:11:47.356 +07:00 [DBG] Endpoint 'CapBot.api.Controllers.UserProfileController.GetById (CapBot.api)' with route pattern 'api/user-profiles/{id}' is valid for the request path '/api/user-profiles/me'
+2025-09-29 01:11:47.356 +07:00 [DBG] Request matched endpoint 'CapBot.api.Controllers.SubmissionController.List (CapBot.api)'
+2025-09-29 01:11:47.356 +07:00 [DBG] Request matched endpoint 'CapBot.api.Controllers.UserProfileController.GetMyProfile (CapBot.api)'
+2025-09-29 01:11:47.403 +07:00 [DBG] Successfully validated the token.
+2025-09-29 01:11:47.403 +07:00 [DBG] Successfully validated the token.
+2025-09-29 01:11:47.403 +07:00 [DBG] AuthenticationScheme: Bearer was successfully authenticated.
+2025-09-29 01:11:47.403 +07:00 [DBG] AuthenticationScheme: Bearer was successfully authenticated.
+2025-09-29 01:11:47.407 +07:00 [DBG] Authorization was successful.
+2025-09-29 01:11:47.407 +07:00 [DBG] Authorization was successful.
+2025-09-29 01:11:47.411 +07:00 [INF] Executing endpoint 'CapBot.api.Controllers.SubmissionController.List (CapBot.api)'
+2025-09-29 01:11:47.411 +07:00 [INF] Executing endpoint 'CapBot.api.Controllers.UserProfileController.GetMyProfile (CapBot.api)'
+2025-09-29 01:11:47.419 +07:00 [INF] Route matched with {action = "GetMyProfile", controller = "UserProfile"}. Executing controller action with signature System.Threading.Tasks.Task`1[Microsoft.AspNetCore.Mvc.IActionResult] GetMyProfile() on controller CapBot.api.Controllers.UserProfileController (CapBot.api).
+2025-09-29 01:11:47.421 +07:00 [DBG] Execution plan of authorization filters (in the following order): ["None"]
+2025-09-29 01:11:47.421 +07:00 [DBG] Execution plan of resource filters (in the following order): ["None"]
+2025-09-29 01:11:47.422 +07:00 [DBG] Execution plan of action filters (in the following order): ["Microsoft.AspNetCore.Mvc.ModelBinding.UnsupportedContentTypeFilter (Order: -3000)"]
+2025-09-29 01:11:47.422 +07:00 [DBG] Execution plan of exception filters (in the following order): ["None"]
+2025-09-29 01:11:47.422 +07:00 [DBG] Execution plan of result filters (in the following order): ["Microsoft.AspNetCore.Mvc.Infrastructure.ClientErrorResultFilter (Order: -2000)"]
+2025-09-29 01:11:47.422 +07:00 [INF] Route matched with {action = "List", controller = "Submission"}. Executing controller action with signature System.Threading.Tasks.Task`1[Microsoft.AspNetCore.Mvc.IActionResult] List(App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO) on controller CapBot.api.Controllers.SubmissionController (CapBot.api).
+2025-09-29 01:11:47.422 +07:00 [DBG] Execution plan of authorization filters (in the following order): ["None"]
+2025-09-29 01:11:47.422 +07:00 [DBG] Execution plan of resource filters (in the following order): ["None"]
+2025-09-29 01:11:47.422 +07:00 [DBG] Execution plan of action filters (in the following order): ["Microsoft.AspNetCore.Mvc.ModelBinding.UnsupportedContentTypeFilter (Order: -3000)"]
+2025-09-29 01:11:47.422 +07:00 [DBG] Execution plan of exception filters (in the following order): ["None"]
+2025-09-29 01:11:47.423 +07:00 [DBG] Execution plan of result filters (in the following order): ["Microsoft.AspNetCore.Mvc.Infrastructure.ClientErrorResultFilter (Order: -2000)","Microsoft.AspNetCore.Mvc.ProducesAttribute (Order: 0)"]
+2025-09-29 01:11:47.423 +07:00 [DBG] Executing controller factory for controller CapBot.api.Controllers.UserProfileController (CapBot.api)
+2025-09-29 01:11:47.423 +07:00 [DBG] Executing controller factory for controller CapBot.api.Controllers.SubmissionController (CapBot.api)
+2025-09-29 01:11:47.425 +07:00 [DBG] Executed controller factory for controller CapBot.api.Controllers.UserProfileController (CapBot.api)
+2025-09-29 01:11:47.432 +07:00 [DBG] Executed controller factory for controller CapBot.api.Controllers.SubmissionController (CapBot.api)
+2025-09-29 01:11:47.437 +07:00 [DBG] Attempting to bind parameter 'query' of type 'App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO' ...
+2025-09-29 01:11:47.439 +07:00 [DBG] Attempting to bind parameter 'query' of type 'App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO' using the name '' in request data ...
+2025-09-29 01:11:47.441 +07:00 [DBG] Attempting to bind property 'App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO.TopicVersionId' of type 'System.Nullable`1[System.Int32]' using the name 'TopicVersionId' in request data ...
+2025-09-29 01:11:47.442 +07:00 [DBG] Could not find a value in the request with name 'TopicVersionId' for binding property 'App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO.TopicVersionId' of type 'System.Nullable`1[System.Int32]'.
+2025-09-29 01:11:47.442 +07:00 [DBG] Done attempting to bind property 'App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO.TopicVersionId' of type 'System.Nullable`1[System.Int32]'.
+2025-09-29 01:11:47.443 +07:00 [DBG] Attempting to bind property 'App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO.PhaseId' of type 'System.Nullable`1[System.Int32]' using the name 'PhaseId' in request data ...
+2025-09-29 01:11:47.443 +07:00 [DBG] Could not find a value in the request with name 'PhaseId' for binding property 'App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO.PhaseId' of type 'System.Nullable`1[System.Int32]'.
+2025-09-29 01:11:47.443 +07:00 [DBG] Done attempting to bind property 'App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO.PhaseId' of type 'System.Nullable`1[System.Int32]'.
+2025-09-29 01:11:47.443 +07:00 [DBG] Attempting to bind property 'App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO.SemesterId' of type 'System.Nullable`1[System.Int32]' using the name 'SemesterId' in request data ...
+2025-09-29 01:11:47.443 +07:00 [DBG] Could not find a value in the request with name 'SemesterId' for binding property 'App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO.SemesterId' of type 'System.Nullable`1[System.Int32]'.
+2025-09-29 01:11:47.443 +07:00 [DBG] Done attempting to bind property 'App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO.SemesterId' of type 'System.Nullable`1[System.Int32]'.
+2025-09-29 01:11:47.443 +07:00 [DBG] Attempting to bind property 'App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO.Status' of type 'System.Nullable`1[App.Entities.Enums.SubmissionStatus]' using the name 'Status' in request data ...
+2025-09-29 01:11:47.443 +07:00 [DBG] Could not find a value in the request with name 'Status' for binding property 'App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO.Status' of type 'System.Nullable`1[App.Entities.Enums.SubmissionStatus]'.
+2025-09-29 01:11:47.443 +07:00 [DBG] Done attempting to bind property 'App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO.Status' of type 'System.Nullable`1[App.Entities.Enums.SubmissionStatus]'.
+2025-09-29 01:11:47.443 +07:00 [DBG] Attempting to bind property 'App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO.PageNumber' of type 'System.Int32' using the name 'PageNumber' in request data ...
+2025-09-29 01:11:47.444 +07:00 [DBG] Done attempting to bind property 'App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO.PageNumber' of type 'System.Int32'.
+2025-09-29 01:11:47.444 +07:00 [DBG] Attempting to bind property 'App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO.PageSize' of type 'System.Int32' using the name 'PageSize' in request data ...
+2025-09-29 01:11:47.444 +07:00 [DBG] Done attempting to bind property 'App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO.PageSize' of type 'System.Int32'.
+2025-09-29 01:11:47.444 +07:00 [DBG] Attempting to bind property 'App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO.Keyword' of type 'System.String' using the name 'Keyword' in request data ...
+2025-09-29 01:11:47.444 +07:00 [DBG] Could not find a value in the request with name 'Keyword' for binding property 'App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO.Keyword' of type 'System.String'.
+2025-09-29 01:11:47.444 +07:00 [DBG] Done attempting to bind property 'App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO.Keyword' of type 'System.String'.
+2025-09-29 01:11:47.444 +07:00 [DBG] Attempting to bind property 'App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO.TotalRecord' of type 'System.Int32' using the name 'TotalRecord' in request data ...
+2025-09-29 01:11:47.444 +07:00 [DBG] Could not find a value in the request with name 'TotalRecord' for binding property 'App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO.TotalRecord' of type 'System.Int32'.
+2025-09-29 01:11:47.444 +07:00 [DBG] Done attempting to bind property 'App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO.TotalRecord' of type 'System.Int32'.
+2025-09-29 01:11:47.445 +07:00 [DBG] Done attempting to bind parameter 'query' of type 'App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO'.
+2025-09-29 01:11:47.445 +07:00 [DBG] Done attempting to bind parameter 'query' of type 'App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO'.
+2025-09-29 01:11:47.445 +07:00 [DBG] Attempting to validate the bound parameter 'query' of type 'App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO' ...
+2025-09-29 01:11:47.448 +07:00 [DBG] Done attempting to validate the bound parameter 'query' of type 'App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO'.
+2025-09-29 01:11:47.465 +07:00 [DBG] Entity Framework Core 8.0.16 initialized 'MyDbContext' using provider 'Microsoft.EntityFrameworkCore.SqlServer:8.0.13' with options: MigrationsAssembly=App.DAL 
+2025-09-29 01:11:47.465 +07:00 [DBG] Entity Framework Core 8.0.16 initialized 'MyDbContext' using provider 'Microsoft.EntityFrameworkCore.SqlServer:8.0.13' with options: MigrationsAssembly=App.DAL 
+2025-09-29 01:11:47.470 +07:00 [DBG] Compiling query expression: 
+'DbSet<UserProfile>()
+    .AsNoTracking()
+    .Where(x => x.UserId == __targetUserId_0 && x.IsActive && x.DeletedAt == null && x.DeletedAt == null)
+    .FirstOrDefault()'
+2025-09-29 01:11:47.470 +07:00 [DBG] Compiling query expression: 
+'DbSet<Submission>()
+    .AsNoTracking()
+    .Include(x => x.SubmittedByUser)
+    .Include(x => x.Topic)
+    .Where(x => True)
+    .Count()'
+2025-09-29 01:11:47.476 +07:00 [DBG] Generated query execution expression: 
+'queryContext => ShapedQueryCompilingExpressionVisitor.SingleOrDefaultAsync<UserProfile>(
+    asyncEnumerable: new SingleQueryingEnumerable<UserProfile>(
+        (RelationalQueryContext)queryContext, 
+        RelationalCommandCache.QueryExpression(
+            Projection Mapping:
+                EmptyProjectionMember -> Dictionary<IProperty, int> { [Property: UserProfile.Id (int) Required PK AfterSave:Throw ValueGenerated.OnAdd, 0], [Property: UserProfile.Address (string), 1], [Property: UserProfile.Avatar (string), 2], [Property: UserProfile.CoverImage (string), 3], [Property: UserProfile.CreatedAt (DateTime) Required, 4], [Property: UserProfile.CreatedBy (string), 5], [Property: UserProfile.DeletedAt (DateTime?), 6], [Property: UserProfile.FullName (string), 7], [Property: UserProfile.IsActive (bool) Required, 8], [Property: UserProfile.LastModifiedAt (DateTime?), 9], [Property: UserProfile.LastModifiedBy (string), 10], [Property: UserProfile.UserId (int) Required FK Index, 11] }
+            SELECT TOP(1) p.Id, p.Address, p.Avatar, p.CoverImage, p.CreatedAt, p.CreatedBy, p.DeletedAt, p.FullName, p.IsActive, p.LastModifiedAt, p.LastModifiedBy, p.UserId
+            FROM profiles AS p
+            WHERE (((p.UserId == @__targetUserId_0) && p.IsActive) && (p.DeletedAt == NULL)) && (p.DeletedAt == NULL)), 
+        null, 
+        Func<QueryContext, DbDataReader, ResultContext, SingleQueryResultCoordinator, UserProfile>, 
+        App.DAL.Context.MyDbContext, 
+        False, 
+        False, 
+        True
+    ), 
+    cancellationToken: queryContext.CancellationToken)'
+2025-09-29 01:11:47.479 +07:00 [DBG] Creating DbConnection.
+2025-09-29 01:11:47.480 +07:00 [DBG] Created DbConnection. (0ms).
+2025-09-29 01:11:47.480 +07:00 [DBG] Opening connection to database 'capbot_db' on server 'localhost'.
+2025-09-29 01:11:47.480 +07:00 [DBG] Opened connection to database 'capbot_db' on server 'localhost'.
+2025-09-29 01:11:47.480 +07:00 [DBG] Creating DbCommand for 'ExecuteReader'.
+2025-09-29 01:11:47.480 +07:00 [DBG] Created DbCommand for 'ExecuteReader' (0ms).
+2025-09-29 01:11:47.480 +07:00 [DBG] Initialized DbCommand for 'ExecuteReader' (0ms).
+2025-09-29 01:11:47.481 +07:00 [DBG] Executing DbCommand [Parameters=[@__targetUserId_0='?' (DbType = Int32)], CommandType='"Text"', CommandTimeout='30']
+SELECT TOP(1) [p].[Id], [p].[Address], [p].[Avatar], [p].[CoverImage], [p].[CreatedAt], [p].[CreatedBy], [p].[DeletedAt], [p].[FullName], [p].[IsActive], [p].[LastModifiedAt], [p].[LastModifiedBy], [p].[UserId]
+FROM [profiles] AS [p]
+WHERE [p].[UserId] = @__targetUserId_0 AND [p].[IsActive] = CAST(1 AS bit) AND [p].[DeletedAt] IS NULL AND [p].[DeletedAt] IS NULL
+2025-09-29 01:11:47.484 +07:00 [INF] Executed DbCommand (3ms) [Parameters=[@__targetUserId_0='?' (DbType = Int32)], CommandType='"Text"', CommandTimeout='30']
+SELECT TOP(1) [p].[Id], [p].[Address], [p].[Avatar], [p].[CoverImage], [p].[CreatedAt], [p].[CreatedBy], [p].[DeletedAt], [p].[FullName], [p].[IsActive], [p].[LastModifiedAt], [p].[LastModifiedBy], [p].[UserId]
+FROM [profiles] AS [p]
+WHERE [p].[UserId] = @__targetUserId_0 AND [p].[IsActive] = CAST(1 AS bit) AND [p].[DeletedAt] IS NULL AND [p].[DeletedAt] IS NULL
+2025-09-29 01:11:47.484 +07:00 [DBG] Closing data reader to 'capbot_db' on server 'localhost'.
+2025-09-29 01:11:47.485 +07:00 [DBG] A data reader for 'capbot_db' on server 'localhost' is being disposed after spending 0ms reading results.
+2025-09-29 01:11:47.485 +07:00 [DBG] Closing connection to database 'capbot_db' on server 'localhost'.
+2025-09-29 01:11:47.485 +07:00 [DBG] Closed connection to database 'capbot_db' on server 'localhost' (0ms).
+2025-09-29 01:11:47.487 +07:00 [DBG] List of registered output formatters, in the following order: ["Microsoft.AspNetCore.OData.Formatter.ODataOutputFormatter","Microsoft.AspNetCore.OData.Formatter.ODataOutputFormatter","Microsoft.AspNetCore.OData.Formatter.ODataOutputFormatter","Microsoft.AspNetCore.Mvc.Formatters.HttpNoContentOutputFormatter","Microsoft.AspNetCore.Mvc.Formatters.StringOutputFormatter","Microsoft.AspNetCore.Mvc.Formatters.StreamOutputFormatter","Microsoft.AspNetCore.Mvc.Formatters.SystemTextJsonOutputFormatter"]
+2025-09-29 01:11:47.488 +07:00 [DBG] No information found on request to perform content negotiation.
+2025-09-29 01:11:47.488 +07:00 [DBG] Attempting to select an output formatter without using a content type as no explicit content types were specified for the response.
+2025-09-29 01:11:47.488 +07:00 [DBG] Attempting to select the first formatter in the output formatters list which can write the result.
+2025-09-29 01:11:47.490 +07:00 [DBG] Selected output formatter 'Microsoft.AspNetCore.Mvc.Formatters.SystemTextJsonOutputFormatter' and content type 'application/json' to write the response.
+2025-09-29 01:11:47.491 +07:00 [INF] Executing ObjectResult, writing value of type 'FS.Commons.FSResponse'.
+2025-09-29 01:11:47.494 +07:00 [DBG] Generated query execution expression: 
+'queryContext => ShapedQueryCompilingExpressionVisitor.SingleAsync<int>(
+    asyncEnumerable: new SingleQueryingEnumerable<int>(
+        (RelationalQueryContext)queryContext, 
+        RelationalCommandCache.QueryExpression(
+            Projection Mapping:
+                EmptyProjectionMember -> 0
+            SELECT COUNT(*)
+            FROM submissions AS s), 
+        null, 
+        Func<QueryContext, DbDataReader, ResultContext, SingleQueryResultCoordinator, int>, 
+        App.DAL.Context.MyDbContext, 
+        False, 
+        False, 
+        True
+    ), 
+    cancellationToken: queryContext.CancellationToken)'
+2025-09-29 01:11:47.498 +07:00 [DBG] Creating DbConnection.
+2025-09-29 01:11:47.498 +07:00 [DBG] Created DbConnection. (0ms).
+2025-09-29 01:11:47.498 +07:00 [DBG] Opening connection to database 'capbot_db' on server 'localhost'.
+2025-09-29 01:11:47.499 +07:00 [DBG] Opened connection to database 'capbot_db' on server 'localhost'.
+2025-09-29 01:11:47.499 +07:00 [DBG] Creating DbCommand for 'ExecuteReader'.
+2025-09-29 01:11:47.499 +07:00 [DBG] Created DbCommand for 'ExecuteReader' (0ms).
+2025-09-29 01:11:47.499 +07:00 [DBG] Initialized DbCommand for 'ExecuteReader' (0ms).
+2025-09-29 01:11:47.499 +07:00 [DBG] Executing DbCommand [Parameters=[], CommandType='"Text"', CommandTimeout='30']
+SELECT COUNT(*)
+FROM [submissions] AS [s]
+2025-09-29 01:11:47.502 +07:00 [INF] Executed DbCommand (3ms) [Parameters=[], CommandType='"Text"', CommandTimeout='30']
+SELECT COUNT(*)
+FROM [submissions] AS [s]
+2025-09-29 01:11:47.503 +07:00 [DBG] Closing data reader to 'capbot_db' on server 'localhost'.
+2025-09-29 01:11:47.503 +07:00 [DBG] A data reader for 'capbot_db' on server 'localhost' is being disposed after spending 1ms reading results.
+2025-09-29 01:11:47.503 +07:00 [DBG] Closing connection to database 'capbot_db' on server 'localhost'.
+2025-09-29 01:11:47.504 +07:00 [DBG] Closed connection to database 'capbot_db' on server 'localhost' (0ms).
+2025-09-29 01:11:47.506 +07:00 [DBG] Compiling query expression: 
+'DbSet<Submission>()
+    .AsNoTracking()
+    .Include(x => x.SubmittedByUser)
+    .Include(x => x.Topic)
+    .Where(x => True)
+    .OrderByDescending(x => x.SubmittedAt)
+    .Skip(__p_0)
+    .Take(__p_1)'
+2025-09-29 01:11:47.513 +07:00 [DBG] Including navigation: 'Submission.SubmittedByUser'.
+2025-09-29 01:11:47.514 +07:00 [DBG] Including navigation: 'Submission.Topic'.
+2025-09-29 01:11:47.516 +07:00 [INF] Executed action CapBot.api.Controllers.UserProfileController.GetMyProfile (CapBot.api) in 92.0126ms
+2025-09-29 01:11:47.516 +07:00 [INF] Executed endpoint 'CapBot.api.Controllers.UserProfileController.GetMyProfile (CapBot.api)'
+2025-09-29 01:11:47.518 +07:00 [DBG] Connection id "0HNFUN9U1CO90" completed keep alive response.
+2025-09-29 01:11:47.518 +07:00 [DBG] 'MyDbContext' disposed.
+2025-09-29 01:11:47.519 +07:00 [DBG] Disposing connection to database 'capbot_db' on server 'localhost'.
+2025-09-29 01:11:47.519 +07:00 [DBG] Disposed connection to database '' on server '' (0ms).
+2025-09-29 01:11:47.519 +07:00 [INF] Request finished HTTP/1.1 GET http://localhost:5207/api/user-profiles/me - 200 null application/json; charset=utf-8 192.825ms
+2025-09-29 01:11:47.527 +07:00 [INF] Request starting HTTP/1.1 GET http://localhost:5207/images/entities/11111111.png - null null
+2025-09-29 01:11:47.528 +07:00 [DBG] The request path /images/entities/11111111.png does not match an existing file
+2025-09-29 01:11:47.529 +07:00 [DBG] The request path /images/entities/11111111.png does not match an existing file
+2025-09-29 01:11:47.529 +07:00 [DBG] No candidates found for the request path '/images/entities/11111111.png'
+2025-09-29 01:11:47.530 +07:00 [DBG] Request did not match any endpoints
+2025-09-29 01:11:47.533 +07:00 [DBG] AuthenticationScheme: Bearer was not authenticated.
+2025-09-29 01:11:47.533 +07:00 [DBG] Connection id "0HNFUN9U1CO8T" completed keep alive response.
+2025-09-29 01:11:47.533 +07:00 [INF] Request finished HTTP/1.1 GET http://localhost:5207/images/entities/11111111.png - 404 0 null 6.1958ms
+2025-09-29 01:11:47.534 +07:00 [INF] Request reached the end of the middleware pipeline without being handled by application code. Request path: GET http://localhost:5207/images/entities/11111111.png, Response status code: 404
+2025-09-29 01:11:47.550 +07:00 [DBG] Generated query execution expression: 
+'queryContext => new SingleQueryingEnumerable<Submission>(
+    (RelationalQueryContext)queryContext, 
+    RelationalCommandCache.QueryExpression(
+        Client Projections:
+            0 -> Dictionary<IProperty, int> { [Property: Submission.Id (int) Required PK AfterSave:Throw ValueGenerated.OnAdd, 0], [Property: Submission.AdditionalNotes (string), 1], [Property: Submission.AiCheckDetails (string), 2], [Property: Submission.AiCheckScore (decimal?), 3], [Property: Submission.AiCheckStatus (AiCheckStatus) Required ValueGenerated.OnAdd, 4], [Property: Submission.CreatedAt (DateTime) Required, 5], [Property: Submission.CreatedBy (string), 6], [Property: Submission.DeletedAt (DateTime?), 7], [Property: Submission.DocumentUrl (string) MaxLength(500), 8], [Property: Submission.IsActive (bool) Required, 9], [Property: Submission.LastModifiedAt (DateTime?), 10], [Property: Submission.LastModifiedBy (string), 11], [Property: Submission.PhaseId (int) Required FK Index, 12], [Property: Submission.Status (SubmissionStatus) Required Index ValueGenerated.OnAdd, 13], [Property: Submission.SubmissionRound (int) Required Index ValueGenerated.OnAdd, 14], [Property: Submission.SubmittedAt (DateTime?) Index ValueGenerated.OnAdd, 15], [Property: Submission.SubmittedBy (int) Required FK Index, 16], [Property: Submission.TopicId (int) Required FK Index, 17], [Property: Submission.TopicVersionId (int?) FK Index, 18] }
+            1 -> Dictionary<IProperty, int> { [Property: User.Id (int) Required PK AfterSave:Throw ValueGenerated.OnAdd, 19], [Property: User.AccessFailedCount (int) Required, 20], [Property: User.ConcurrencyStamp (string), 21], [Property: User.CreatedAt (DateTime) Required, 22], [Property: User.DeletedAt (DateTime?), 23], [Property: User.Email (string), 24], [Property: User.EmailConfirmed (bool) Required, 25], [Property: User.LastModifiedAt (DateTime) Required, 26], [Property: User.LastModifiedBy (string), 27], [Property: User.LockoutEnabled (bool) Required, 28], [Property: User.LockoutEnd (DateTimeOffset?), 29], [Property: User.NormalizedEmail (string), 30], [Property: User.NormalizedUserName (string), 31], [Property: User.PasswordHash (string), 32], [Property: User.PhoneNumber (string), 33], [Property: User.PhoneNumberConfirmed (bool) Required, 34], [Property: User.SecurityStamp (string), 35], [Property: User.TwoFactorEnabled (bool) Required, 36], [Property: User.UserName (string), 37] }
+            2 -> Dictionary<IProperty, int> { [Property: Topic.Id (int) Required PK AfterSave:Throw ValueGenerated.OnAdd, 38], [Property: Topic.Abbreviation (string), 39], [Property: Topic.CategoryId (int?) FK Index, 40], [Property: Topic.Content (string), 41], [Property: Topic.Context (string), 42], [Property: Topic.CreatedAt (DateTime) Required ValueGenerated.OnAdd, 43], [Property: Topic.CreatedBy (string), 44], [Property: Topic.DeletedAt (DateTime?), 45], [Property: Topic.Description (string), 46], [Property: Topic.EN_Title (string) Required MaxLength(500), 47], [Property: Topic.IsActive (bool) Required, 48], [Property: Topic.IsApproved (bool) Required Index Sentinel:True ValueGenerated.OnAdd, 49], [Property: Topic.IsLegacy (bool) Required Index ValueGenerated.OnAdd, 50], [Property: Topic.LastModifiedAt (DateTime?), 51], [Property: Topic.LastModifiedBy (string), 52], [Property: Topic.MaxStudents (int) Required ValueGenerated.OnAdd, 53], [Property: Topic.Objectives (string), 54], [Property: Topic.PotentialDuplicate (string), 55], [Property: Topic.Problem (string), 56], [Property: Topic.SemesterId (int) Required FK Index, 57], [Property: Topic.SupervisorId (int) Required FK Index, 58], [Property: Topic.VN_title (string), 59] }
+        SELECT t.Id, t.AdditionalNotes, t.AiCheckDetails, t.AiCheckScore, t.AiCheckStatus, t.CreatedAt, t.CreatedBy, t.DeletedAt, t.DocumentUrl, t.IsActive, t.LastModifiedAt, t.LastModifiedBy, t.PhaseId, t.Status, t.SubmissionRound, t.SubmittedAt, t.SubmittedBy, t.TopicId, t.TopicVersionId, u.Id, u.AccessFailedCount, u.ConcurrencyStamp, u.CreatedAt, u.DeletedAt, u.Email, u.EmailConfirmed, u.LastModifiedAt, u.LastModifiedBy, u.LockoutEnabled, u.LockoutEnd, u.NormalizedEmail, u.NormalizedUserName, u.PasswordHash, u.PhoneNumber, u.PhoneNumberConfirmed, u.SecurityStamp, u.TwoFactorEnabled, u.UserName, t0.Id, t0.Abbreviation, t0.CategoryId, t0.Content, t0.Context, t0.CreatedAt, t0.CreatedBy, t0.DeletedAt, t0.Description, t0.EN_Title, t0.IsActive, t0.IsApproved, t0.IsLegacy, t0.LastModifiedAt, t0.LastModifiedBy, t0.MaxStudents, t0.Objectives, t0.PotentialDuplicate, t0.Problem, t0.SemesterId, t0.SupervisorId, t0.VN_title
+        FROM 
+        (
+            SELECT s.Id, s.AdditionalNotes, s.AiCheckDetails, s.AiCheckScore, s.AiCheckStatus, s.CreatedAt, s.CreatedBy, s.DeletedAt, s.DocumentUrl, s.IsActive, s.LastModifiedAt, s.LastModifiedBy, s.PhaseId, s.Status, s.SubmissionRound, s.SubmittedAt, s.SubmittedBy, s.TopicId, s.TopicVersionId
+            FROM submissions AS s
+            ORDER BY s.SubmittedAt DESC
+            OFFSET @__p_0 ROWS FETCH NEXT @__p_1 ROWS ONLY
+        ) AS t
+        INNER JOIN users AS u ON t.SubmittedBy == u.Id
+        LEFT JOIN topics AS t0 ON t.TopicId == t0.Id
+        ORDER BY t.SubmittedAt DESC), 
+    null, 
+    Func<QueryContext, DbDataReader, ResultContext, SingleQueryResultCoordinator, Submission>, 
+    App.DAL.Context.MyDbContext, 
+    False, 
+    False, 
+    True
+)'
+2025-09-29 01:11:47.555 +07:00 [DBG] Opening connection to database 'capbot_db' on server 'localhost'.
+2025-09-29 01:11:47.555 +07:00 [DBG] Opened connection to database 'capbot_db' on server 'localhost'.
+2025-09-29 01:11:47.555 +07:00 [DBG] Creating DbCommand for 'ExecuteReader'.
+2025-09-29 01:11:47.555 +07:00 [DBG] Created DbCommand for 'ExecuteReader' (0ms).
+2025-09-29 01:11:47.555 +07:00 [DBG] Initialized DbCommand for 'ExecuteReader' (0ms).
+2025-09-29 01:11:47.555 +07:00 [DBG] Executing DbCommand [Parameters=[@__p_0='?' (DbType = Int32), @__p_1='?' (DbType = Int32)], CommandType='"Text"', CommandTimeout='30']
+SELECT [t].[Id], [t].[AdditionalNotes], [t].[AiCheckDetails], [t].[AiCheckScore], [t].[AiCheckStatus], [t].[CreatedAt], [t].[CreatedBy], [t].[DeletedAt], [t].[DocumentUrl], [t].[IsActive], [t].[LastModifiedAt], [t].[LastModifiedBy], [t].[PhaseId], [t].[Status], [t].[SubmissionRound], [t].[SubmittedAt], [t].[SubmittedBy], [t].[TopicId], [t].[TopicVersionId], [u].[Id], [u].[AccessFailedCount], [u].[ConcurrencyStamp], [u].[CreatedAt], [u].[DeletedAt], [u].[Email], [u].[EmailConfirmed], [u].[LastModifiedAt], [u].[LastModifiedBy], [u].[LockoutEnabled], [u].[LockoutEnd], [u].[NormalizedEmail], [u].[NormalizedUserName], [u].[PasswordHash], [u].[PhoneNumber], [u].[PhoneNumberConfirmed], [u].[SecurityStamp], [u].[TwoFactorEnabled], [u].[UserName], [t0].[Id], [t0].[Abbreviation], [t0].[CategoryId], [t0].[Content], [t0].[Context], [t0].[CreatedAt], [t0].[CreatedBy], [t0].[DeletedAt], [t0].[Description], [t0].[EN_Title], [t0].[IsActive], [t0].[IsApproved], [t0].[IsLegacy], [t0].[LastModifiedAt], [t0].[LastModifiedBy], [t0].[MaxStudents], [t0].[Objectives], [t0].[PotentialDuplicate], [t0].[Problem], [t0].[SemesterId], [t0].[SupervisorId], [t0].[VN_title]
+FROM (
+    SELECT [s].[Id], [s].[AdditionalNotes], [s].[AiCheckDetails], [s].[AiCheckScore], [s].[AiCheckStatus], [s].[CreatedAt], [s].[CreatedBy], [s].[DeletedAt], [s].[DocumentUrl], [s].[IsActive], [s].[LastModifiedAt], [s].[LastModifiedBy], [s].[PhaseId], [s].[Status], [s].[SubmissionRound], [s].[SubmittedAt], [s].[SubmittedBy], [s].[TopicId], [s].[TopicVersionId]
+    FROM [submissions] AS [s]
+    ORDER BY [s].[SubmittedAt] DESC
+    OFFSET @__p_0 ROWS FETCH NEXT @__p_1 ROWS ONLY
+) AS [t]
+INNER JOIN [users] AS [u] ON [t].[SubmittedBy] = [u].[Id]
+LEFT JOIN [topics] AS [t0] ON [t].[TopicId] = [t0].[Id]
+ORDER BY [t].[SubmittedAt] DESC
+2025-09-29 01:11:47.564 +07:00 [INF] Executed DbCommand (9ms) [Parameters=[@__p_0='?' (DbType = Int32), @__p_1='?' (DbType = Int32)], CommandType='"Text"', CommandTimeout='30']
+SELECT [t].[Id], [t].[AdditionalNotes], [t].[AiCheckDetails], [t].[AiCheckScore], [t].[AiCheckStatus], [t].[CreatedAt], [t].[CreatedBy], [t].[DeletedAt], [t].[DocumentUrl], [t].[IsActive], [t].[LastModifiedAt], [t].[LastModifiedBy], [t].[PhaseId], [t].[Status], [t].[SubmissionRound], [t].[SubmittedAt], [t].[SubmittedBy], [t].[TopicId], [t].[TopicVersionId], [u].[Id], [u].[AccessFailedCount], [u].[ConcurrencyStamp], [u].[CreatedAt], [u].[DeletedAt], [u].[Email], [u].[EmailConfirmed], [u].[LastModifiedAt], [u].[LastModifiedBy], [u].[LockoutEnabled], [u].[LockoutEnd], [u].[NormalizedEmail], [u].[NormalizedUserName], [u].[PasswordHash], [u].[PhoneNumber], [u].[PhoneNumberConfirmed], [u].[SecurityStamp], [u].[TwoFactorEnabled], [u].[UserName], [t0].[Id], [t0].[Abbreviation], [t0].[CategoryId], [t0].[Content], [t0].[Context], [t0].[CreatedAt], [t0].[CreatedBy], [t0].[DeletedAt], [t0].[Description], [t0].[EN_Title], [t0].[IsActive], [t0].[IsApproved], [t0].[IsLegacy], [t0].[LastModifiedAt], [t0].[LastModifiedBy], [t0].[MaxStudents], [t0].[Objectives], [t0].[PotentialDuplicate], [t0].[Problem], [t0].[SemesterId], [t0].[SupervisorId], [t0].[VN_title]
+FROM (
+    SELECT [s].[Id], [s].[AdditionalNotes], [s].[AiCheckDetails], [s].[AiCheckScore], [s].[AiCheckStatus], [s].[CreatedAt], [s].[CreatedBy], [s].[DeletedAt], [s].[DocumentUrl], [s].[IsActive], [s].[LastModifiedAt], [s].[LastModifiedBy], [s].[PhaseId], [s].[Status], [s].[SubmissionRound], [s].[SubmittedAt], [s].[SubmittedBy], [s].[TopicId], [s].[TopicVersionId]
+    FROM [submissions] AS [s]
+    ORDER BY [s].[SubmittedAt] DESC
+    OFFSET @__p_0 ROWS FETCH NEXT @__p_1 ROWS ONLY
+) AS [t]
+INNER JOIN [users] AS [u] ON [t].[SubmittedBy] = [u].[Id]
+LEFT JOIN [topics] AS [t0] ON [t].[TopicId] = [t0].[Id]
+ORDER BY [t].[SubmittedAt] DESC
+2025-09-29 01:11:47.568 +07:00 [DBG] Closing data reader to 'capbot_db' on server 'localhost'.
+2025-09-29 01:11:47.569 +07:00 [DBG] A data reader for 'capbot_db' on server 'localhost' is being disposed after spending 4ms reading results.
+2025-09-29 01:11:47.569 +07:00 [DBG] Closing connection to database 'capbot_db' on server 'localhost'.
+2025-09-29 01:11:47.569 +07:00 [DBG] Closed connection to database 'capbot_db' on server 'localhost' (0ms).
+2025-09-29 01:11:47.570 +07:00 [DBG] List of registered output formatters, in the following order: ["Microsoft.AspNetCore.OData.Formatter.ODataOutputFormatter","Microsoft.AspNetCore.OData.Formatter.ODataOutputFormatter","Microsoft.AspNetCore.OData.Formatter.ODataOutputFormatter","Microsoft.AspNetCore.Mvc.Formatters.HttpNoContentOutputFormatter","Microsoft.AspNetCore.Mvc.Formatters.StringOutputFormatter","Microsoft.AspNetCore.Mvc.Formatters.StreamOutputFormatter","Microsoft.AspNetCore.Mvc.Formatters.SystemTextJsonOutputFormatter"]
+2025-09-29 01:11:47.570 +07:00 [DBG] No information found on request to perform content negotiation.
+2025-09-29 01:11:47.570 +07:00 [DBG] Attempting to select the first output formatter in the output formatters list which supports a content type from the explicitly specified content types '["application/json"]'.
+2025-09-29 01:11:47.571 +07:00 [DBG] Selected output formatter 'Microsoft.AspNetCore.Mvc.Formatters.SystemTextJsonOutputFormatter' and content type 'application/json' to write the response.
+2025-09-29 01:11:47.571 +07:00 [INF] Executing ObjectResult, writing value of type 'FS.Commons.FSResponse'.
+2025-09-29 01:11:47.579 +07:00 [INF] Executed action CapBot.api.Controllers.SubmissionController.List (CapBot.api) in 156.1432ms
+2025-09-29 01:11:47.579 +07:00 [INF] Executed endpoint 'CapBot.api.Controllers.SubmissionController.List (CapBot.api)'
+2025-09-29 01:11:47.580 +07:00 [DBG] Connection id "0HNFUN9U1CO8V" completed keep alive response.
+2025-09-29 01:11:47.581 +07:00 [DBG] 'MyDbContext' disposed.
+2025-09-29 01:11:47.581 +07:00 [DBG] Disposing connection to database 'capbot_db' on server 'localhost'.
+2025-09-29 01:11:47.581 +07:00 [DBG] Disposed connection to database '' on server '' (0ms).
+2025-09-29 01:11:47.581 +07:00 [INF] Request finished HTTP/1.1 GET http://localhost:5207/api/submission/list?PageNumber=1&PageSize=10 - 200 null application/json; charset=utf-8 254.7378ms
+2025-09-29 01:11:49.357 +07:00 [INF] Request starting HTTP/1.1 POST http://localhost:5207/api/submission-reviews/process-overdue - null 0
+2025-09-29 01:11:49.358 +07:00 [DBG] POST requests are not supported
+2025-09-29 01:11:49.358 +07:00 [DBG] POST requests are not supported
+2025-09-29 01:11:49.358 +07:00 [DBG] The request has an origin header: 'http://localhost:5207'.
+2025-09-29 01:11:49.358 +07:00 [INF] CORS policy execution successful.
+2025-09-29 01:11:49.365 +07:00 [DBG] 1 candidate(s) found for the request path '/api/submission-reviews/process-overdue'
+2025-09-29 01:11:49.366 +07:00 [DBG] Endpoint 'CapBot.api.Controllers.SubmissionReviewController.ProcessOverdueRevisions (CapBot.api)' with route pattern 'api/submission-reviews/process-overdue' is valid for the request path '/api/submission-reviews/process-overdue'
+2025-09-29 01:11:49.366 +07:00 [DBG] Request matched endpoint 'CapBot.api.Controllers.SubmissionReviewController.ProcessOverdueRevisions (CapBot.api)'
+2025-09-29 01:11:49.368 +07:00 [DBG] Successfully validated the token.
+2025-09-29 01:11:49.368 +07:00 [DBG] AuthenticationScheme: Bearer was successfully authenticated.
+2025-09-29 01:11:49.374 +07:00 [DBG] Authorization was successful.
+2025-09-29 01:11:49.374 +07:00 [INF] Executing endpoint 'CapBot.api.Controllers.SubmissionReviewController.ProcessOverdueRevisions (CapBot.api)'
+2025-09-29 01:11:49.379 +07:00 [INF] Route matched with {action = "ProcessOverdueRevisions", controller = "SubmissionReview"}. Executing controller action with signature System.Threading.Tasks.Task`1[Microsoft.AspNetCore.Mvc.IActionResult] ProcessOverdueRevisions() on controller CapBot.api.Controllers.SubmissionReviewController (CapBot.api).
+2025-09-29 01:11:49.380 +07:00 [DBG] Execution plan of authorization filters (in the following order): ["None"]
+2025-09-29 01:11:49.380 +07:00 [DBG] Execution plan of resource filters (in the following order): ["None"]
+2025-09-29 01:11:49.380 +07:00 [DBG] Execution plan of action filters (in the following order): ["Microsoft.AspNetCore.Mvc.ModelBinding.UnsupportedContentTypeFilter (Order: -3000)"]
+2025-09-29 01:11:49.381 +07:00 [DBG] Execution plan of exception filters (in the following order): ["None"]
+2025-09-29 01:11:49.381 +07:00 [DBG] Execution plan of result filters (in the following order): ["Microsoft.AspNetCore.Mvc.Infrastructure.ClientErrorResultFilter (Order: -2000)"]
+2025-09-29 01:11:49.381 +07:00 [DBG] Executing controller factory for controller CapBot.api.Controllers.SubmissionReviewController (CapBot.api)
+2025-09-29 01:11:49.437 +07:00 [DBG] Executed controller factory for controller CapBot.api.Controllers.SubmissionReviewController (CapBot.api)
+2025-09-29 01:11:49.440 +07:00 [DBG] Entity Framework Core 8.0.16 initialized 'MyDbContext' using provider 'Microsoft.EntityFrameworkCore.SqlServer:8.0.13' with options: MigrationsAssembly=App.DAL 
+2025-09-29 01:11:49.442 +07:00 [DBG] Compiling query expression: 
+'DbSet<ReviewerAssignment>()
+    .AsNoTracking()
+    .Include(x => x.Submission)
+    .Where(x => x.Deadline.HasValue)'
+2025-09-29 01:11:49.443 +07:00 [DBG] Including navigation: 'ReviewerAssignment.Submission'.
+2025-09-29 01:11:49.450 +07:00 [DBG] Generated query execution expression: 
+'queryContext => new SingleQueryingEnumerable<ReviewerAssignment>(
+    (RelationalQueryContext)queryContext, 
+    RelationalCommandCache.QueryExpression(
+        Client Projections:
+            0 -> Dictionary<IProperty, int> { [Property: ReviewerAssignment.Id (int) Required PK AfterSave:Throw ValueGenerated.OnAdd, 0], [Property: ReviewerAssignment.AssignedAt (DateTime) Required ValueGenerated.OnAdd, 1], [Property: ReviewerAssignment.AssignedBy (int) Required FK Index, 2], [Property: ReviewerAssignment.AssignmentType (AssignmentTypes) Required ValueGenerated.OnAdd, 3], [Property: ReviewerAssignment.CompletedAt (DateTime?), 4], [Property: ReviewerAssignment.Deadline (DateTime?) Index, 5], [Property: ReviewerAssignment.ReviewerId (int) Required FK Index, 6], [Property: ReviewerAssignment.SkillMatchScore (decimal?), 7], [Property: ReviewerAssignment.StartedAt (DateTime?), 8], [Property: ReviewerAssignment.Status (AssignmentStatus) Required Index ValueGenerated.OnAdd, 9], [Property: ReviewerAssignment.SubmissionId (int) Required FK Index, 10] }
+            1 -> Dictionary<IProperty, int> { [Property: Submission.Id (int) Required PK AfterSave:Throw ValueGenerated.OnAdd, 11], [Property: Submission.AdditionalNotes (string), 12], [Property: Submission.AiCheckDetails (string), 13], [Property: Submission.AiCheckScore (decimal?), 14], [Property: Submission.AiCheckStatus (AiCheckStatus) Required ValueGenerated.OnAdd, 15], [Property: Submission.CreatedAt (DateTime) Required, 16], [Property: Submission.CreatedBy (string), 17], [Property: Submission.DeletedAt (DateTime?), 18], [Property: Submission.DocumentUrl (string) MaxLength(500), 19], [Property: Submission.IsActive (bool) Required, 20], [Property: Submission.LastModifiedAt (DateTime?), 21], [Property: Submission.LastModifiedBy (string), 22], [Property: Submission.PhaseId (int) Required FK Index, 23], [Property: Submission.Status (SubmissionStatus) Required Index ValueGenerated.OnAdd, 24], [Property: Submission.SubmissionRound (int) Required Index ValueGenerated.OnAdd, 25], [Property: Submission.SubmittedAt (DateTime?) Index ValueGenerated.OnAdd, 26], [Property: Submission.SubmittedBy (int) Required FK Index, 27], [Property: Submission.TopicId (int) Required FK Index, 28], [Property: Submission.TopicVersionId (int?) FK Index, 29] }
+        SELECT r.Id, r.AssignedAt, r.AssignedBy, r.AssignmentType, r.CompletedAt, r.Deadline, r.ReviewerId, r.SkillMatchScore, r.StartedAt, r.Status, r.SubmissionId, s.Id, s.AdditionalNotes, s.AiCheckDetails, s.AiCheckScore, s.AiCheckStatus, s.CreatedAt, s.CreatedBy, s.DeletedAt, s.DocumentUrl, s.IsActive, s.LastModifiedAt, s.LastModifiedBy, s.PhaseId, s.Status, s.SubmissionRound, s.SubmittedAt, s.SubmittedBy, s.TopicId, s.TopicVersionId
+        FROM reviewer_assignments AS r
+        INNER JOIN submissions AS s ON r.SubmissionId == s.Id
+        WHERE r.Deadline IS NOT NULL), 
+    null, 
+    Func<QueryContext, DbDataReader, ResultContext, SingleQueryResultCoordinator, ReviewerAssignment>, 
+    App.DAL.Context.MyDbContext, 
+    False, 
+    False, 
+    True
+)'
+2025-09-29 01:11:49.451 +07:00 [DBG] Creating DbConnection.
+2025-09-29 01:11:49.451 +07:00 [DBG] Created DbConnection. (0ms).
+2025-09-29 01:11:49.451 +07:00 [DBG] Opening connection to database 'capbot_db' on server 'localhost'.
+2025-09-29 01:11:49.451 +07:00 [DBG] Opened connection to database 'capbot_db' on server 'localhost'.
+2025-09-29 01:11:49.451 +07:00 [DBG] Creating DbCommand for 'ExecuteReader'.
+2025-09-29 01:11:49.451 +07:00 [DBG] Created DbCommand for 'ExecuteReader' (0ms).
+2025-09-29 01:11:49.451 +07:00 [DBG] Initialized DbCommand for 'ExecuteReader' (0ms).
+2025-09-29 01:11:49.451 +07:00 [DBG] Executing DbCommand [Parameters=[], CommandType='"Text"', CommandTimeout='30']
+SELECT [r].[Id], [r].[AssignedAt], [r].[AssignedBy], [r].[AssignmentType], [r].[CompletedAt], [r].[Deadline], [r].[ReviewerId], [r].[SkillMatchScore], [r].[StartedAt], [r].[Status], [r].[SubmissionId], [s].[Id], [s].[AdditionalNotes], [s].[AiCheckDetails], [s].[AiCheckScore], [s].[AiCheckStatus], [s].[CreatedAt], [s].[CreatedBy], [s].[DeletedAt], [s].[DocumentUrl], [s].[IsActive], [s].[LastModifiedAt], [s].[LastModifiedBy], [s].[PhaseId], [s].[Status], [s].[SubmissionRound], [s].[SubmittedAt], [s].[SubmittedBy], [s].[TopicId], [s].[TopicVersionId]
+FROM [reviewer_assignments] AS [r]
+INNER JOIN [submissions] AS [s] ON [r].[SubmissionId] = [s].[Id]
+WHERE [r].[Deadline] IS NOT NULL
+2025-09-29 01:11:49.457 +07:00 [INF] Executed DbCommand (6ms) [Parameters=[], CommandType='"Text"', CommandTimeout='30']
+SELECT [r].[Id], [r].[AssignedAt], [r].[AssignedBy], [r].[AssignmentType], [r].[CompletedAt], [r].[Deadline], [r].[ReviewerId], [r].[SkillMatchScore], [r].[StartedAt], [r].[Status], [r].[SubmissionId], [s].[Id], [s].[AdditionalNotes], [s].[AiCheckDetails], [s].[AiCheckScore], [s].[AiCheckStatus], [s].[CreatedAt], [s].[CreatedBy], [s].[DeletedAt], [s].[DocumentUrl], [s].[IsActive], [s].[LastModifiedAt], [s].[LastModifiedBy], [s].[PhaseId], [s].[Status], [s].[SubmissionRound], [s].[SubmittedAt], [s].[SubmittedBy], [s].[TopicId], [s].[TopicVersionId]
+FROM [reviewer_assignments] AS [r]
+INNER JOIN [submissions] AS [s] ON [r].[SubmissionId] = [s].[Id]
+WHERE [r].[Deadline] IS NOT NULL
+2025-09-29 01:11:49.458 +07:00 [DBG] Closing data reader to 'capbot_db' on server 'localhost'.
+2025-09-29 01:11:49.459 +07:00 [DBG] A data reader for 'capbot_db' on server 'localhost' is being disposed after spending 1ms reading results.
+2025-09-29 01:11:49.459 +07:00 [DBG] Closing connection to database 'capbot_db' on server 'localhost'.
+2025-09-29 01:11:49.459 +07:00 [DBG] Closed connection to database 'capbot_db' on server 'localhost' (0ms).
+2025-09-29 01:11:49.460 +07:00 [DBG] List of registered output formatters, in the following order: ["Microsoft.AspNetCore.OData.Formatter.ODataOutputFormatter","Microsoft.AspNetCore.OData.Formatter.ODataOutputFormatter","Microsoft.AspNetCore.OData.Formatter.ODataOutputFormatter","Microsoft.AspNetCore.Mvc.Formatters.HttpNoContentOutputFormatter","Microsoft.AspNetCore.Mvc.Formatters.StringOutputFormatter","Microsoft.AspNetCore.Mvc.Formatters.StreamOutputFormatter","Microsoft.AspNetCore.Mvc.Formatters.SystemTextJsonOutputFormatter"]
+2025-09-29 01:11:49.460 +07:00 [DBG] No information found on request to perform content negotiation.
+2025-09-29 01:11:49.460 +07:00 [DBG] Attempting to select an output formatter without using a content type as no explicit content types were specified for the response.
+2025-09-29 01:11:49.460 +07:00 [DBG] Attempting to select the first formatter in the output formatters list which can write the result.
+2025-09-29 01:11:49.460 +07:00 [DBG] Selected output formatter 'Microsoft.AspNetCore.Mvc.Formatters.SystemTextJsonOutputFormatter' and content type 'application/json' to write the response.
+2025-09-29 01:11:49.460 +07:00 [INF] Executing ObjectResult, writing value of type 'FS.Commons.FSResponse'.
+2025-09-29 01:11:49.460 +07:00 [INF] Executed action CapBot.api.Controllers.SubmissionReviewController.ProcessOverdueRevisions (CapBot.api) in 79.2573ms
+2025-09-29 01:11:49.460 +07:00 [INF] Executed endpoint 'CapBot.api.Controllers.SubmissionReviewController.ProcessOverdueRevisions (CapBot.api)'
+2025-09-29 01:11:49.461 +07:00 [DBG] Connection id "0HNFUN9U1CO8T" completed keep alive response.
+2025-09-29 01:11:49.461 +07:00 [DBG] 'MyDbContext' disposed.
+2025-09-29 01:11:49.461 +07:00 [DBG] Disposing connection to database 'capbot_db' on server 'localhost'.
+2025-09-29 01:11:49.461 +07:00 [DBG] Disposed connection to database '' on server '' (0ms).
+2025-09-29 01:11:49.461 +07:00 [INF] Request finished HTTP/1.1 POST http://localhost:5207/api/submission-reviews/process-overdue - 200 null application/json; charset=utf-8 103.5454ms
+2025-09-29 01:13:47.436 +07:00 [DBG] HttpMessageHandler expired after 120000ms for client ''
+2025-09-29 01:13:57.403 +07:00 [DBG] Connection id "0HNFUN9U1CO8U" disconnecting.
+2025-09-29 01:13:57.404 +07:00 [DBG] Connection id "0HNFUN9U1CO8U" stopped.
+2025-09-29 01:13:57.406 +07:00 [DBG] Connection id "0HNFUN9U1CO8U" sending FIN because: "The Socket transport's send loop completed gracefully."
+2025-09-29 01:13:57.450 +07:00 [DBG] Starting HttpMessageHandler cleanup cycle with 1 items
+2025-09-29 01:13:57.454 +07:00 [DBG] Ending HttpMessageHandler cleanup cycle after 0.5438ms - processed: 0 items - remaining: 1 items
+2025-09-29 01:13:59.419 +07:00 [DBG] Connection id "0HNFUN9U1CO90" disconnecting.
+2025-09-29 01:13:59.419 +07:00 [DBG] Connection id "0HNFUN9U1CO8V" disconnecting.
+2025-09-29 01:13:59.419 +07:00 [DBG] Connection id "0HNFUN9U1CO90" stopped.
+2025-09-29 01:13:59.419 +07:00 [DBG] Connection id "0HNFUN9U1CO8V" stopped.
+2025-09-29 01:13:59.419 +07:00 [DBG] Connection id "0HNFUN9U1CO90" sending FIN because: "The Socket transport's send loop completed gracefully."
+2025-09-29 01:13:59.419 +07:00 [DBG] Connection id "0HNFUN9U1CO8V" sending FIN because: "The Socket transport's send loop completed gracefully."
+2025-09-29 01:14:00.426 +07:00 [DBG] Connection id "0HNFUN9U1CO8T" disconnecting.
+2025-09-29 01:14:00.426 +07:00 [DBG] Connection id "0HNFUN9U1CO8T" stopped.
+2025-09-29 01:14:00.426 +07:00 [DBG] Connection id "0HNFUN9U1CO8T" sending FIN because: "The Socket transport's send loop completed gracefully."
+2025-09-29 01:14:07.455 +07:00 [DBG] Starting HttpMessageHandler cleanup cycle with 1 items
+2025-09-29 01:14:07.455 +07:00 [DBG] Ending HttpMessageHandler cleanup cycle after 0.0032ms - processed: 0 items - remaining: 1 items
+2025-09-29 01:14:17.462 +07:00 [DBG] Starting HttpMessageHandler cleanup cycle with 1 items
+2025-09-29 01:14:17.463 +07:00 [DBG] Ending HttpMessageHandler cleanup cycle after 0.0066ms - processed: 0 items - remaining: 1 items
+2025-09-29 01:14:27.476 +07:00 [DBG] Starting HttpMessageHandler cleanup cycle with 1 items
+2025-09-29 01:14:27.476 +07:00 [DBG] Ending HttpMessageHandler cleanup cycle after 0.084ms - processed: 0 items - remaining: 1 items
+2025-09-29 01:14:37.484 +07:00 [DBG] Starting HttpMessageHandler cleanup cycle with 1 items
+2025-09-29 01:14:37.485 +07:00 [DBG] Ending HttpMessageHandler cleanup cycle after 0.1945ms - processed: 0 items - remaining: 1 items
+2025-09-29 01:14:47.486 +07:00 [DBG] Starting HttpMessageHandler cleanup cycle with 1 items
+2025-09-29 01:14:47.486 +07:00 [DBG] Ending HttpMessageHandler cleanup cycle after 0.0028ms - processed: 0 items - remaining: 1 items
+2025-09-29 01:14:57.497 +07:00 [DBG] Starting HttpMessageHandler cleanup cycle with 1 items
+2025-09-29 01:14:57.497 +07:00 [DBG] Ending HttpMessageHandler cleanup cycle after 0.0062ms - processed: 0 items - remaining: 1 items
+2025-09-29 01:15:06.479 +07:00 [DBG] Connection id "0HNFUN9U1CO91" accepted.
+2025-09-29 01:15:06.479 +07:00 [DBG] Connection id "0HNFUN9U1CO91" started.
+2025-09-29 01:15:06.479 +07:00 [INF] Request starting HTTP/1.1 POST http://localhost:5207/api/submission-reviews/process-overdue - null 0
+2025-09-29 01:15:06.479 +07:00 [DBG] POST requests are not supported
+2025-09-29 01:15:06.480 +07:00 [DBG] POST requests are not supported
+2025-09-29 01:15:06.480 +07:00 [DBG] The request has an origin header: 'http://localhost:5207'.
+2025-09-29 01:15:06.480 +07:00 [INF] CORS policy execution successful.
+2025-09-29 01:15:06.485 +07:00 [DBG] 1 candidate(s) found for the request path '/api/submission-reviews/process-overdue'
+2025-09-29 01:15:06.486 +07:00 [DBG] Endpoint 'CapBot.api.Controllers.SubmissionReviewController.ProcessOverdueRevisions (CapBot.api)' with route pattern 'api/submission-reviews/process-overdue' is valid for the request path '/api/submission-reviews/process-overdue'
+2025-09-29 01:15:06.486 +07:00 [DBG] Request matched endpoint 'CapBot.api.Controllers.SubmissionReviewController.ProcessOverdueRevisions (CapBot.api)'
+2025-09-29 01:15:06.487 +07:00 [DBG] Successfully validated the token.
+2025-09-29 01:15:06.487 +07:00 [DBG] AuthenticationScheme: Bearer was successfully authenticated.
+2025-09-29 01:15:06.488 +07:00 [DBG] Authorization was successful.
+2025-09-29 01:15:06.488 +07:00 [INF] Executing endpoint 'CapBot.api.Controllers.SubmissionReviewController.ProcessOverdueRevisions (CapBot.api)'
+2025-09-29 01:15:06.489 +07:00 [INF] Route matched with {action = "ProcessOverdueRevisions", controller = "SubmissionReview"}. Executing controller action with signature System.Threading.Tasks.Task`1[Microsoft.AspNetCore.Mvc.IActionResult] ProcessOverdueRevisions() on controller CapBot.api.Controllers.SubmissionReviewController (CapBot.api).
+2025-09-29 01:15:06.489 +07:00 [DBG] Execution plan of authorization filters (in the following order): ["None"]
+2025-09-29 01:15:06.489 +07:00 [DBG] Execution plan of resource filters (in the following order): ["None"]
+2025-09-29 01:15:06.489 +07:00 [DBG] Execution plan of action filters (in the following order): ["Microsoft.AspNetCore.Mvc.ModelBinding.UnsupportedContentTypeFilter (Order: -3000)"]
+2025-09-29 01:15:06.489 +07:00 [DBG] Execution plan of exception filters (in the following order): ["None"]
+2025-09-29 01:15:06.489 +07:00 [DBG] Execution plan of result filters (in the following order): ["Microsoft.AspNetCore.Mvc.Infrastructure.ClientErrorResultFilter (Order: -2000)"]
+2025-09-29 01:15:06.489 +07:00 [DBG] Executing controller factory for controller CapBot.api.Controllers.SubmissionReviewController (CapBot.api)
+2025-09-29 01:15:06.490 +07:00 [DBG] Executed controller factory for controller CapBot.api.Controllers.SubmissionReviewController (CapBot.api)
+2025-09-29 01:15:06.491 +07:00 [DBG] Entity Framework Core 8.0.16 initialized 'MyDbContext' using provider 'Microsoft.EntityFrameworkCore.SqlServer:8.0.13' with options: MigrationsAssembly=App.DAL 
+2025-09-29 01:15:06.493 +07:00 [DBG] Creating DbConnection.
+2025-09-29 01:15:06.493 +07:00 [DBG] Created DbConnection. (0ms).
+2025-09-29 01:15:06.494 +07:00 [DBG] Opening connection to database 'capbot_db' on server 'localhost'.
+2025-09-29 01:15:06.494 +07:00 [DBG] Opened connection to database 'capbot_db' on server 'localhost'.
+2025-09-29 01:15:06.494 +07:00 [DBG] Creating DbCommand for 'ExecuteReader'.
+2025-09-29 01:15:06.494 +07:00 [DBG] Created DbCommand for 'ExecuteReader' (0ms).
+2025-09-29 01:15:06.494 +07:00 [DBG] Initialized DbCommand for 'ExecuteReader' (0ms).
+2025-09-29 01:15:06.494 +07:00 [DBG] Executing DbCommand [Parameters=[], CommandType='"Text"', CommandTimeout='30']
+SELECT [r].[Id], [r].[AssignedAt], [r].[AssignedBy], [r].[AssignmentType], [r].[CompletedAt], [r].[Deadline], [r].[ReviewerId], [r].[SkillMatchScore], [r].[StartedAt], [r].[Status], [r].[SubmissionId], [s].[Id], [s].[AdditionalNotes], [s].[AiCheckDetails], [s].[AiCheckScore], [s].[AiCheckStatus], [s].[CreatedAt], [s].[CreatedBy], [s].[DeletedAt], [s].[DocumentUrl], [s].[IsActive], [s].[LastModifiedAt], [s].[LastModifiedBy], [s].[PhaseId], [s].[Status], [s].[SubmissionRound], [s].[SubmittedAt], [s].[SubmittedBy], [s].[TopicId], [s].[TopicVersionId]
+FROM [reviewer_assignments] AS [r]
+INNER JOIN [submissions] AS [s] ON [r].[SubmissionId] = [s].[Id]
+WHERE [r].[Deadline] IS NOT NULL
+2025-09-29 01:15:06.504 +07:00 [INF] Executed DbCommand (9ms) [Parameters=[], CommandType='"Text"', CommandTimeout='30']
+SELECT [r].[Id], [r].[AssignedAt], [r].[AssignedBy], [r].[AssignmentType], [r].[CompletedAt], [r].[Deadline], [r].[ReviewerId], [r].[SkillMatchScore], [r].[StartedAt], [r].[Status], [r].[SubmissionId], [s].[Id], [s].[AdditionalNotes], [s].[AiCheckDetails], [s].[AiCheckScore], [s].[AiCheckStatus], [s].[CreatedAt], [s].[CreatedBy], [s].[DeletedAt], [s].[DocumentUrl], [s].[IsActive], [s].[LastModifiedAt], [s].[LastModifiedBy], [s].[PhaseId], [s].[Status], [s].[SubmissionRound], [s].[SubmittedAt], [s].[SubmittedBy], [s].[TopicId], [s].[TopicVersionId]
+FROM [reviewer_assignments] AS [r]
+INNER JOIN [submissions] AS [s] ON [r].[SubmissionId] = [s].[Id]
+WHERE [r].[Deadline] IS NOT NULL
+2025-09-29 01:15:06.504 +07:00 [DBG] Closing data reader to 'capbot_db' on server 'localhost'.
+2025-09-29 01:15:06.504 +07:00 [DBG] A data reader for 'capbot_db' on server 'localhost' is being disposed after spending 0ms reading results.
+2025-09-29 01:15:06.504 +07:00 [DBG] Closing connection to database 'capbot_db' on server 'localhost'.
+2025-09-29 01:15:06.504 +07:00 [DBG] Closed connection to database 'capbot_db' on server 'localhost' (0ms).
+2025-09-29 01:15:06.504 +07:00 [DBG] List of registered output formatters, in the following order: ["Microsoft.AspNetCore.OData.Formatter.ODataOutputFormatter","Microsoft.AspNetCore.OData.Formatter.ODataOutputFormatter","Microsoft.AspNetCore.OData.Formatter.ODataOutputFormatter","Microsoft.AspNetCore.Mvc.Formatters.HttpNoContentOutputFormatter","Microsoft.AspNetCore.Mvc.Formatters.StringOutputFormatter","Microsoft.AspNetCore.Mvc.Formatters.StreamOutputFormatter","Microsoft.AspNetCore.Mvc.Formatters.SystemTextJsonOutputFormatter"]
+2025-09-29 01:15:06.504 +07:00 [DBG] No information found on request to perform content negotiation.
+2025-09-29 01:15:06.504 +07:00 [DBG] Attempting to select an output formatter without using a content type as no explicit content types were specified for the response.
+2025-09-29 01:15:06.504 +07:00 [DBG] Attempting to select the first formatter in the output formatters list which can write the result.
+2025-09-29 01:15:06.504 +07:00 [DBG] Selected output formatter 'Microsoft.AspNetCore.Mvc.Formatters.SystemTextJsonOutputFormatter' and content type 'application/json' to write the response.
+2025-09-29 01:15:06.504 +07:00 [INF] Executing ObjectResult, writing value of type 'FS.Commons.FSResponse'.
+2025-09-29 01:15:06.504 +07:00 [INF] Executed action CapBot.api.Controllers.SubmissionReviewController.ProcessOverdueRevisions (CapBot.api) in 15.1835ms
+2025-09-29 01:15:06.505 +07:00 [INF] Executed endpoint 'CapBot.api.Controllers.SubmissionReviewController.ProcessOverdueRevisions (CapBot.api)'
+2025-09-29 01:15:06.505 +07:00 [DBG] Connection id "0HNFUN9U1CO91" completed keep alive response.
+2025-09-29 01:15:06.505 +07:00 [DBG] 'MyDbContext' disposed.
+2025-09-29 01:15:06.505 +07:00 [DBG] Disposing connection to database 'capbot_db' on server 'localhost'.
+2025-09-29 01:15:06.505 +07:00 [DBG] Disposed connection to database '' on server '' (0ms).
+2025-09-29 01:15:06.505 +07:00 [INF] Request finished HTTP/1.1 POST http://localhost:5207/api/submission-reviews/process-overdue - 200 null application/json; charset=utf-8 25.6284ms
+2025-09-29 01:15:07.502 +07:00 [DBG] Starting HttpMessageHandler cleanup cycle with 1 items
+2025-09-29 01:15:07.502 +07:00 [DBG] Ending HttpMessageHandler cleanup cycle after 0.0034ms - processed: 0 items - remaining: 1 items
+2025-09-29 01:15:09.295 +07:00 [INF] Request starting HTTP/1.1 POST http://localhost:5207/api/submission-reviews/process-overdue - null 0
+2025-09-29 01:15:09.296 +07:00 [DBG] POST requests are not supported
+2025-09-29 01:15:09.296 +07:00 [DBG] POST requests are not supported
+2025-09-29 01:15:09.296 +07:00 [DBG] The request has an origin header: 'http://localhost:5207'.
+2025-09-29 01:15:09.296 +07:00 [INF] CORS policy execution successful.
+2025-09-29 01:15:09.296 +07:00 [DBG] 1 candidate(s) found for the request path '/api/submission-reviews/process-overdue'
+2025-09-29 01:15:09.296 +07:00 [DBG] Endpoint 'CapBot.api.Controllers.SubmissionReviewController.ProcessOverdueRevisions (CapBot.api)' with route pattern 'api/submission-reviews/process-overdue' is valid for the request path '/api/submission-reviews/process-overdue'
+2025-09-29 01:15:09.296 +07:00 [DBG] Request matched endpoint 'CapBot.api.Controllers.SubmissionReviewController.ProcessOverdueRevisions (CapBot.api)'
+2025-09-29 01:15:09.297 +07:00 [DBG] Successfully validated the token.
+2025-09-29 01:15:09.298 +07:00 [DBG] AuthenticationScheme: Bearer was successfully authenticated.
+2025-09-29 01:15:09.298 +07:00 [DBG] Authorization was successful.
+2025-09-29 01:15:09.298 +07:00 [INF] Executing endpoint 'CapBot.api.Controllers.SubmissionReviewController.ProcessOverdueRevisions (CapBot.api)'
+2025-09-29 01:15:09.298 +07:00 [INF] Route matched with {action = "ProcessOverdueRevisions", controller = "SubmissionReview"}. Executing controller action with signature System.Threading.Tasks.Task`1[Microsoft.AspNetCore.Mvc.IActionResult] ProcessOverdueRevisions() on controller CapBot.api.Controllers.SubmissionReviewController (CapBot.api).
+2025-09-29 01:15:09.300 +07:00 [DBG] Execution plan of authorization filters (in the following order): ["None"]
+2025-09-29 01:15:09.305 +07:00 [DBG] Execution plan of resource filters (in the following order): ["None"]
+2025-09-29 01:15:09.306 +07:00 [DBG] Execution plan of action filters (in the following order): ["Microsoft.AspNetCore.Mvc.ModelBinding.UnsupportedContentTypeFilter (Order: -3000)"]
+2025-09-29 01:15:09.307 +07:00 [DBG] Execution plan of exception filters (in the following order): ["None"]
+2025-09-29 01:15:09.307 +07:00 [DBG] Execution plan of result filters (in the following order): ["Microsoft.AspNetCore.Mvc.Infrastructure.ClientErrorResultFilter (Order: -2000)"]
+2025-09-29 01:15:09.307 +07:00 [DBG] Executing controller factory for controller CapBot.api.Controllers.SubmissionReviewController (CapBot.api)
+2025-09-29 01:15:09.314 +07:00 [DBG] Executed controller factory for controller CapBot.api.Controllers.SubmissionReviewController (CapBot.api)
+2025-09-29 01:15:09.316 +07:00 [DBG] Entity Framework Core 8.0.16 initialized 'MyDbContext' using provider 'Microsoft.EntityFrameworkCore.SqlServer:8.0.13' with options: MigrationsAssembly=App.DAL 
+2025-09-29 01:15:09.316 +07:00 [DBG] Creating DbConnection.
+2025-09-29 01:15:09.316 +07:00 [DBG] Created DbConnection. (0ms).
+2025-09-29 01:15:09.316 +07:00 [DBG] Opening connection to database 'capbot_db' on server 'localhost'.
+2025-09-29 01:15:09.317 +07:00 [DBG] Opened connection to database 'capbot_db' on server 'localhost'.
+2025-09-29 01:15:09.317 +07:00 [DBG] Creating DbCommand for 'ExecuteReader'.
+2025-09-29 01:15:09.317 +07:00 [DBG] Created DbCommand for 'ExecuteReader' (0ms).
+2025-09-29 01:15:09.317 +07:00 [DBG] Initialized DbCommand for 'ExecuteReader' (0ms).
+2025-09-29 01:15:09.317 +07:00 [DBG] Executing DbCommand [Parameters=[], CommandType='"Text"', CommandTimeout='30']
+SELECT [r].[Id], [r].[AssignedAt], [r].[AssignedBy], [r].[AssignmentType], [r].[CompletedAt], [r].[Deadline], [r].[ReviewerId], [r].[SkillMatchScore], [r].[StartedAt], [r].[Status], [r].[SubmissionId], [s].[Id], [s].[AdditionalNotes], [s].[AiCheckDetails], [s].[AiCheckScore], [s].[AiCheckStatus], [s].[CreatedAt], [s].[CreatedBy], [s].[DeletedAt], [s].[DocumentUrl], [s].[IsActive], [s].[LastModifiedAt], [s].[LastModifiedBy], [s].[PhaseId], [s].[Status], [s].[SubmissionRound], [s].[SubmittedAt], [s].[SubmittedBy], [s].[TopicId], [s].[TopicVersionId]
+FROM [reviewer_assignments] AS [r]
+INNER JOIN [submissions] AS [s] ON [r].[SubmissionId] = [s].[Id]
+WHERE [r].[Deadline] IS NOT NULL
+2025-09-29 01:15:09.320 +07:00 [INF] Executed DbCommand (2ms) [Parameters=[], CommandType='"Text"', CommandTimeout='30']
+SELECT [r].[Id], [r].[AssignedAt], [r].[AssignedBy], [r].[AssignmentType], [r].[CompletedAt], [r].[Deadline], [r].[ReviewerId], [r].[SkillMatchScore], [r].[StartedAt], [r].[Status], [r].[SubmissionId], [s].[Id], [s].[AdditionalNotes], [s].[AiCheckDetails], [s].[AiCheckScore], [s].[AiCheckStatus], [s].[CreatedAt], [s].[CreatedBy], [s].[DeletedAt], [s].[DocumentUrl], [s].[IsActive], [s].[LastModifiedAt], [s].[LastModifiedBy], [s].[PhaseId], [s].[Status], [s].[SubmissionRound], [s].[SubmittedAt], [s].[SubmittedBy], [s].[TopicId], [s].[TopicVersionId]
+FROM [reviewer_assignments] AS [r]
+INNER JOIN [submissions] AS [s] ON [r].[SubmissionId] = [s].[Id]
+WHERE [r].[Deadline] IS NOT NULL
+2025-09-29 01:15:09.320 +07:00 [DBG] Closing data reader to 'capbot_db' on server 'localhost'.
+2025-09-29 01:15:09.320 +07:00 [DBG] A data reader for 'capbot_db' on server 'localhost' is being disposed after spending 0ms reading results.
+2025-09-29 01:15:09.320 +07:00 [DBG] Closing connection to database 'capbot_db' on server 'localhost'.
+2025-09-29 01:15:09.320 +07:00 [DBG] Closed connection to database 'capbot_db' on server 'localhost' (0ms).
+2025-09-29 01:15:09.320 +07:00 [DBG] List of registered output formatters, in the following order: ["Microsoft.AspNetCore.OData.Formatter.ODataOutputFormatter","Microsoft.AspNetCore.OData.Formatter.ODataOutputFormatter","Microsoft.AspNetCore.OData.Formatter.ODataOutputFormatter","Microsoft.AspNetCore.Mvc.Formatters.HttpNoContentOutputFormatter","Microsoft.AspNetCore.Mvc.Formatters.StringOutputFormatter","Microsoft.AspNetCore.Mvc.Formatters.StreamOutputFormatter","Microsoft.AspNetCore.Mvc.Formatters.SystemTextJsonOutputFormatter"]
+2025-09-29 01:15:09.320 +07:00 [DBG] No information found on request to perform content negotiation.
+2025-09-29 01:15:09.320 +07:00 [DBG] Attempting to select an output formatter without using a content type as no explicit content types were specified for the response.
+2025-09-29 01:15:09.321 +07:00 [DBG] Attempting to select the first formatter in the output formatters list which can write the result.
+2025-09-29 01:15:09.321 +07:00 [DBG] Selected output formatter 'Microsoft.AspNetCore.Mvc.Formatters.SystemTextJsonOutputFormatter' and content type 'application/json' to write the response.
+2025-09-29 01:15:09.321 +07:00 [INF] Executing ObjectResult, writing value of type 'FS.Commons.FSResponse'.
+2025-09-29 01:15:09.321 +07:00 [INF] Executed action CapBot.api.Controllers.SubmissionReviewController.ProcessOverdueRevisions (CapBot.api) in 13.6543ms
+2025-09-29 01:15:09.321 +07:00 [INF] Executed endpoint 'CapBot.api.Controllers.SubmissionReviewController.ProcessOverdueRevisions (CapBot.api)'
+2025-09-29 01:15:09.321 +07:00 [DBG] Connection id "0HNFUN9U1CO91" completed keep alive response.
+2025-09-29 01:15:09.321 +07:00 [DBG] 'MyDbContext' disposed.
+2025-09-29 01:15:09.321 +07:00 [DBG] Disposing connection to database 'capbot_db' on server 'localhost'.
+2025-09-29 01:15:09.321 +07:00 [DBG] Disposed connection to database '' on server '' (0ms).
+2025-09-29 01:15:09.321 +07:00 [INF] Request finished HTTP/1.1 POST http://localhost:5207/api/submission-reviews/process-overdue - 200 null application/json; charset=utf-8 25.9736ms
+2025-09-29 01:15:17.513 +07:00 [DBG] Starting HttpMessageHandler cleanup cycle with 1 items
+2025-09-29 01:15:17.513 +07:00 [DBG] Ending HttpMessageHandler cleanup cycle after 0.0015ms - processed: 0 items - remaining: 1 items
+2025-09-29 01:15:27.521 +07:00 [DBG] Starting HttpMessageHandler cleanup cycle with 1 items
+2025-09-29 01:15:27.521 +07:00 [DBG] Ending HttpMessageHandler cleanup cycle after 0.0024ms - processed: 0 items - remaining: 1 items
+2025-09-29 01:15:37.535 +07:00 [DBG] Starting HttpMessageHandler cleanup cycle with 1 items
+2025-09-29 01:15:37.535 +07:00 [DBG] Ending HttpMessageHandler cleanup cycle after 0.0039ms - processed: 0 items - remaining: 1 items
+2025-09-29 01:15:47.548 +07:00 [DBG] Starting HttpMessageHandler cleanup cycle with 1 items
+2025-09-29 01:15:47.548 +07:00 [DBG] Ending HttpMessageHandler cleanup cycle after 0.003ms - processed: 0 items - remaining: 1 items
+2025-09-29 01:15:57.561 +07:00 [DBG] Starting HttpMessageHandler cleanup cycle with 1 items
+2025-09-29 01:15:57.562 +07:00 [DBG] Ending HttpMessageHandler cleanup cycle after 0.0091ms - processed: 0 items - remaining: 1 items
+2025-09-29 01:16:07.572 +07:00 [DBG] Starting HttpMessageHandler cleanup cycle with 1 items
+2025-09-29 01:16:07.572 +07:00 [DBG] Ending HttpMessageHandler cleanup cycle after 0.0022ms - processed: 0 items - remaining: 1 items
+2025-09-29 01:16:17.581 +07:00 [DBG] Starting HttpMessageHandler cleanup cycle with 1 items
+2025-09-29 01:16:17.582 +07:00 [DBG] Ending HttpMessageHandler cleanup cycle after 0.0036ms - processed: 0 items - remaining: 1 items
+2025-09-29 01:16:27.595 +07:00 [DBG] Starting HttpMessageHandler cleanup cycle with 1 items
+2025-09-29 01:16:27.596 +07:00 [DBG] Ending HttpMessageHandler cleanup cycle after 0.0078ms - processed: 0 items - remaining: 1 items
+2025-09-29 01:16:37.608 +07:00 [DBG] Starting HttpMessageHandler cleanup cycle with 1 items
+2025-09-29 01:16:37.608 +07:00 [DBG] Ending HttpMessageHandler cleanup cycle after 0.0031ms - processed: 0 items - remaining: 1 items
+2025-09-29 01:16:47.623 +07:00 [DBG] Starting HttpMessageHandler cleanup cycle with 1 items
+2025-09-29 01:16:47.623 +07:00 [DBG] Ending HttpMessageHandler cleanup cycle after 0.0028ms - processed: 0 items - remaining: 1 items
+2025-09-29 01:16:57.627 +07:00 [DBG] Starting HttpMessageHandler cleanup cycle with 1 items
+2025-09-29 01:16:57.627 +07:00 [DBG] Ending HttpMessageHandler cleanup cycle after 0.0035ms - processed: 0 items - remaining: 1 items
+2025-09-29 01:17:07.629 +07:00 [DBG] Starting HttpMessageHandler cleanup cycle with 1 items
+2025-09-29 01:17:07.629 +07:00 [DBG] Ending HttpMessageHandler cleanup cycle after 0.003ms - processed: 0 items - remaining: 1 items
+2025-09-29 01:17:17.633 +07:00 [DBG] Starting HttpMessageHandler cleanup cycle with 1 items
+2025-09-29 01:17:17.633 +07:00 [DBG] Ending HttpMessageHandler cleanup cycle after 0.0035ms - processed: 0 items - remaining: 1 items
+2025-09-29 01:17:20.856 +07:00 [DBG] Connection id "0HNFUN9U1CO91" disconnecting.
+2025-09-29 01:17:20.856 +07:00 [DBG] Connection id "0HNFUN9U1CO91" stopped.
+2025-09-29 01:17:20.857 +07:00 [DBG] Connection id "0HNFUN9U1CO91" sending FIN because: "The Socket transport's send loop completed gracefully."
+2025-09-29 01:17:27.645 +07:00 [DBG] Starting HttpMessageHandler cleanup cycle with 1 items
+2025-09-29 01:17:27.645 +07:00 [DBG] Ending HttpMessageHandler cleanup cycle after 0.0035ms - processed: 0 items - remaining: 1 items
+2025-09-29 01:17:37.653 +07:00 [DBG] Starting HttpMessageHandler cleanup cycle with 1 items
+2025-09-29 01:17:37.653 +07:00 [DBG] Ending HttpMessageHandler cleanup cycle after 0.0058ms - processed: 0 items - remaining: 1 items
+2025-09-29 01:17:47.657 +07:00 [DBG] Starting HttpMessageHandler cleanup cycle with 1 items
+2025-09-29 01:17:47.657 +07:00 [DBG] Ending HttpMessageHandler cleanup cycle after 0.0042ms - processed: 0 items - remaining: 1 items
+2025-09-29 01:17:57.664 +07:00 [DBG] Starting HttpMessageHandler cleanup cycle with 1 items
+2025-09-29 01:17:57.664 +07:00 [DBG] Ending HttpMessageHandler cleanup cycle after 0.0042ms - processed: 0 items - remaining: 1 items
+2025-09-29 01:18:07.681 +07:00 [DBG] Starting HttpMessageHandler cleanup cycle with 1 items
+2025-09-29 01:18:07.681 +07:00 [DBG] Ending HttpMessageHandler cleanup cycle after 0.019ms - processed: 0 items - remaining: 1 items
+2025-09-29 01:18:17.684 +07:00 [DBG] Starting HttpMessageHandler cleanup cycle with 1 items
+2025-09-29 01:18:17.684 +07:00 [DBG] Ending HttpMessageHandler cleanup cycle after 0.0013ms - processed: 0 items - remaining: 1 items
+2025-09-29 01:18:27.692 +07:00 [DBG] Starting HttpMessageHandler cleanup cycle with 1 items
+2025-09-29 01:18:27.692 +07:00 [DBG] Ending HttpMessageHandler cleanup cycle after 0.0019ms - processed: 0 items - remaining: 1 items
+2025-09-29 01:18:37.699 +07:00 [DBG] Starting HttpMessageHandler cleanup cycle with 1 items
+2025-09-29 01:18:37.700 +07:00 [DBG] Ending HttpMessageHandler cleanup cycle after 0.0023ms - processed: 0 items - remaining: 1 items
+2025-09-29 01:18:47.699 +07:00 [DBG] Starting HttpMessageHandler cleanup cycle with 1 items
+2025-09-29 01:18:47.699 +07:00 [DBG] Ending HttpMessageHandler cleanup cycle after 0.0021ms - processed: 0 items - remaining: 1 items
+2025-09-29 01:18:57.700 +07:00 [DBG] Starting HttpMessageHandler cleanup cycle with 1 items
+2025-09-29 01:18:57.701 +07:00 [DBG] Ending HttpMessageHandler cleanup cycle after 0.0081ms - processed: 0 items - remaining: 1 items
+2025-09-29 01:19:07.708 +07:00 [DBG] Starting HttpMessageHandler cleanup cycle with 1 items
+2025-09-29 01:19:07.708 +07:00 [DBG] Ending HttpMessageHandler cleanup cycle after 0.0023ms - processed: 0 items - remaining: 1 items
+2025-09-29 01:19:17.712 +07:00 [DBG] Starting HttpMessageHandler cleanup cycle with 1 items
+2025-09-29 01:19:17.712 +07:00 [DBG] Ending HttpMessageHandler cleanup cycle after 0.0026ms - processed: 0 items - remaining: 1 items
+2025-09-29 01:19:27.721 +07:00 [DBG] Starting HttpMessageHandler cleanup cycle with 1 items
+2025-09-29 01:19:27.721 +07:00 [DBG] Ending HttpMessageHandler cleanup cycle after 0.0015ms - processed: 0 items - remaining: 1 items
+2025-09-29 01:19:37.721 +07:00 [DBG] Starting HttpMessageHandler cleanup cycle with 1 items
+2025-09-29 01:19:37.722 +07:00 [DBG] Ending HttpMessageHandler cleanup cycle after 0.0033ms - processed: 0 items - remaining: 1 items
+2025-09-29 01:19:47.734 +07:00 [DBG] Starting HttpMessageHandler cleanup cycle with 1 items
+2025-09-29 01:19:47.734 +07:00 [DBG] Ending HttpMessageHandler cleanup cycle after 0.0035ms - processed: 0 items - remaining: 1 items
+2025-09-29 01:19:57.743 +07:00 [DBG] Starting HttpMessageHandler cleanup cycle with 1 items
+2025-09-29 01:19:57.743 +07:00 [DBG] Ending HttpMessageHandler cleanup cycle after 0.0019ms - processed: 0 items - remaining: 1 items
+2025-09-29 01:20:07.754 +07:00 [DBG] Starting HttpMessageHandler cleanup cycle with 1 items
+2025-09-29 01:20:07.754 +07:00 [DBG] Ending HttpMessageHandler cleanup cycle after 0.0033ms - processed: 0 items - remaining: 1 items
+2025-09-29 01:20:17.768 +07:00 [DBG] Starting HttpMessageHandler cleanup cycle with 1 items
+2025-09-29 01:20:17.769 +07:00 [DBG] Ending HttpMessageHandler cleanup cycle after 0.0029ms - processed: 0 items - remaining: 1 items
+2025-09-29 01:20:27.786 +07:00 [DBG] Starting HttpMessageHandler cleanup cycle with 1 items
+2025-09-29 01:20:27.786 +07:00 [DBG] Ending HttpMessageHandler cleanup cycle after 0.0036ms - processed: 0 items - remaining: 1 items
+2025-09-29 01:20:37.790 +07:00 [DBG] Starting HttpMessageHandler cleanup cycle with 1 items
+2025-09-29 01:20:37.790 +07:00 [DBG] Ending HttpMessageHandler cleanup cycle after 0.0019ms - processed: 0 items - remaining: 1 items
+2025-09-29 01:20:47.794 +07:00 [DBG] Starting HttpMessageHandler cleanup cycle with 1 items
+2025-09-29 01:20:47.795 +07:00 [DBG] Ending HttpMessageHandler cleanup cycle after 0.0058ms - processed: 0 items - remaining: 1 items
+2025-09-29 01:20:57.805 +07:00 [DBG] Starting HttpMessageHandler cleanup cycle with 1 items
+2025-09-29 01:20:57.805 +07:00 [DBG] Ending HttpMessageHandler cleanup cycle after 0.0025ms - processed: 0 items - remaining: 1 items
+2025-09-29 01:21:07.819 +07:00 [DBG] Starting HttpMessageHandler cleanup cycle with 1 items
+2025-09-29 01:21:07.819 +07:00 [DBG] Ending HttpMessageHandler cleanup cycle after 0.0015ms - processed: 0 items - remaining: 1 items
+2025-09-29 01:21:17.824 +07:00 [DBG] Starting HttpMessageHandler cleanup cycle with 1 items
+2025-09-29 01:21:17.824 +07:00 [DBG] Ending HttpMessageHandler cleanup cycle after 0.0026ms - processed: 0 items - remaining: 1 items
+2025-09-29 01:21:27.837 +07:00 [DBG] Starting HttpMessageHandler cleanup cycle with 1 items
+2025-09-29 01:21:27.838 +07:00 [DBG] Ending HttpMessageHandler cleanup cycle after 0.0025ms - processed: 0 items - remaining: 1 items
+2025-09-29 01:21:37.839 +07:00 [DBG] Starting HttpMessageHandler cleanup cycle with 1 items
+2025-09-29 01:21:37.840 +07:00 [DBG] Ending HttpMessageHandler cleanup cycle after 0.0037ms - processed: 0 items - remaining: 1 items
+2025-09-29 01:21:47.851 +07:00 [DBG] Starting HttpMessageHandler cleanup cycle with 1 items
+2025-09-29 01:21:47.851 +07:00 [DBG] Ending HttpMessageHandler cleanup cycle after 0.0037ms - processed: 0 items - remaining: 1 items
+2025-09-29 01:21:57.855 +07:00 [DBG] Starting HttpMessageHandler cleanup cycle with 1 items
+2025-09-29 01:21:57.855 +07:00 [DBG] Ending HttpMessageHandler cleanup cycle after 0.0029ms - processed: 0 items - remaining: 1 items
+2025-09-29 01:22:07.862 +07:00 [DBG] Starting HttpMessageHandler cleanup cycle with 1 items
+2025-09-29 01:22:07.862 +07:00 [DBG] Ending HttpMessageHandler cleanup cycle after 0.0544ms - processed: 0 items - remaining: 1 items
+2025-09-29 01:22:17.872 +07:00 [DBG] Starting HttpMessageHandler cleanup cycle with 1 items
+2025-09-29 01:22:17.872 +07:00 [DBG] Ending HttpMessageHandler cleanup cycle after 0.0029ms - processed: 0 items - remaining: 1 items
+2025-09-29 01:22:27.881 +07:00 [DBG] Starting HttpMessageHandler cleanup cycle with 1 items
+2025-09-29 01:22:27.881 +07:00 [DBG] Ending HttpMessageHandler cleanup cycle after 0.003ms - processed: 0 items - remaining: 1 items
+2025-09-29 01:22:37.891 +07:00 [DBG] Starting HttpMessageHandler cleanup cycle with 1 items
+2025-09-29 01:22:37.891 +07:00 [DBG] Ending HttpMessageHandler cleanup cycle after 0.0029ms - processed: 0 items - remaining: 1 items
+2025-09-29 01:22:47.892 +07:00 [DBG] Starting HttpMessageHandler cleanup cycle with 1 items
+2025-09-29 01:22:47.892 +07:00 [DBG] Ending HttpMessageHandler cleanup cycle after 0.0016ms - processed: 0 items - remaining: 1 items
+2025-09-29 01:22:57.896 +07:00 [DBG] Starting HttpMessageHandler cleanup cycle with 1 items
+2025-09-29 01:22:57.896 +07:00 [DBG] Ending HttpMessageHandler cleanup cycle after 0.0036ms - processed: 0 items - remaining: 1 items
+2025-09-29 01:23:07.907 +07:00 [DBG] Starting HttpMessageHandler cleanup cycle with 1 items
+2025-09-29 01:23:07.908 +07:00 [DBG] Ending HttpMessageHandler cleanup cycle after 0.0032ms - processed: 0 items - remaining: 1 items
+2025-09-29 01:23:17.910 +07:00 [DBG] Starting HttpMessageHandler cleanup cycle with 1 items
+2025-09-29 01:23:17.910 +07:00 [DBG] Ending HttpMessageHandler cleanup cycle after 0.0013ms - processed: 0 items - remaining: 1 items
+2025-09-29 01:23:27.922 +07:00 [DBG] Starting HttpMessageHandler cleanup cycle with 1 items
+2025-09-29 01:23:27.922 +07:00 [DBG] Ending HttpMessageHandler cleanup cycle after 0.0037ms - processed: 0 items - remaining: 1 items
+2025-09-29 01:23:37.935 +07:00 [DBG] Starting HttpMessageHandler cleanup cycle with 1 items
+2025-09-29 01:23:37.935 +07:00 [DBG] Ending HttpMessageHandler cleanup cycle after 0.0012ms - processed: 0 items - remaining: 1 items
+2025-09-29 01:23:47.945 +07:00 [DBG] Starting HttpMessageHandler cleanup cycle with 1 items
+2025-09-29 01:23:47.945 +07:00 [DBG] Ending HttpMessageHandler cleanup cycle after 0.003ms - processed: 0 items - remaining: 1 items
+2025-09-29 01:23:57.946 +07:00 [DBG] Starting HttpMessageHandler cleanup cycle with 1 items
+2025-09-29 01:23:57.946 +07:00 [DBG] Ending HttpMessageHandler cleanup cycle after 0.0081ms - processed: 0 items - remaining: 1 items
+2025-09-29 01:24:07.948 +07:00 [DBG] Starting HttpMessageHandler cleanup cycle with 1 items
+2025-09-29 01:24:07.948 +07:00 [DBG] Ending HttpMessageHandler cleanup cycle after 0.0006ms - processed: 0 items - remaining: 1 items
+2025-09-29 01:24:17.950 +07:00 [DBG] Starting HttpMessageHandler cleanup cycle with 1 items
+2025-09-29 01:24:17.950 +07:00 [DBG] Ending HttpMessageHandler cleanup cycle after 0.0008ms - processed: 0 items - remaining: 1 items
+2025-09-29 01:24:27.956 +07:00 [DBG] Starting HttpMessageHandler cleanup cycle with 1 items
+2025-09-29 01:24:27.956 +07:00 [DBG] Ending HttpMessageHandler cleanup cycle after 0.0007ms - processed: 0 items - remaining: 1 items
+2025-09-29 01:24:37.958 +07:00 [DBG] Starting HttpMessageHandler cleanup cycle with 1 items
+2025-09-29 01:24:37.958 +07:00 [DBG] Ending HttpMessageHandler cleanup cycle after 0.0007ms - processed: 0 items - remaining: 1 items
+2025-09-29 01:24:47.971 +07:00 [DBG] Starting HttpMessageHandler cleanup cycle with 1 items
+2025-09-29 01:24:47.971 +07:00 [DBG] Ending HttpMessageHandler cleanup cycle after 0.001ms - processed: 0 items - remaining: 1 items
+2025-09-29 01:24:57.972 +07:00 [DBG] Starting HttpMessageHandler cleanup cycle with 1 items
+2025-09-29 01:24:57.972 +07:00 [DBG] Ending HttpMessageHandler cleanup cycle after 0.0006ms - processed: 0 items - remaining: 1 items
+2025-09-29 01:25:07.973 +07:00 [DBG] Starting HttpMessageHandler cleanup cycle with 1 items
+2025-09-29 01:25:07.974 +07:00 [DBG] Ending HttpMessageHandler cleanup cycle after 0.0017ms - processed: 0 items - remaining: 1 items
+2025-09-29 01:25:17.977 +07:00 [DBG] Starting HttpMessageHandler cleanup cycle with 1 items
+2025-09-29 01:25:17.977 +07:00 [DBG] Ending HttpMessageHandler cleanup cycle after 0.0009ms - processed: 0 items - remaining: 1 items
+2025-09-29 01:25:27.984 +07:00 [DBG] Starting HttpMessageHandler cleanup cycle with 1 items
+2025-09-29 01:25:27.984 +07:00 [DBG] Ending HttpMessageHandler cleanup cycle after 0.0008ms - processed: 0 items - remaining: 1 items
+2025-09-29 01:25:37.989 +07:00 [DBG] Starting HttpMessageHandler cleanup cycle with 1 items
+2025-09-29 01:25:37.989 +07:00 [DBG] Ending HttpMessageHandler cleanup cycle after 0.0006ms - processed: 0 items - remaining: 1 items
+2025-09-29 01:25:48.001 +07:00 [DBG] Starting HttpMessageHandler cleanup cycle with 1 items
+2025-09-29 01:25:48.001 +07:00 [DBG] Ending HttpMessageHandler cleanup cycle after 0.0006ms - processed: 0 items - remaining: 1 items
+2025-09-29 01:25:58.012 +07:00 [DBG] Starting HttpMessageHandler cleanup cycle with 1 items
+2025-09-29 01:25:58.013 +07:00 [DBG] Ending HttpMessageHandler cleanup cycle after 0.0003ms - processed: 0 items - remaining: 1 items
+2025-09-29 01:26:08.017 +07:00 [DBG] Starting HttpMessageHandler cleanup cycle with 1 items
+2025-09-29 01:26:08.017 +07:00 [DBG] Ending HttpMessageHandler cleanup cycle after 0.0005ms - processed: 0 items - remaining: 1 items
+2025-09-29 01:26:18.024 +07:00 [DBG] Starting HttpMessageHandler cleanup cycle with 1 items
+2025-09-29 01:26:18.024 +07:00 [DBG] Ending HttpMessageHandler cleanup cycle after 0.0006ms - processed: 0 items - remaining: 1 items
+2025-09-29 01:26:28.032 +07:00 [DBG] Starting HttpMessageHandler cleanup cycle with 1 items
+2025-09-29 01:26:28.032 +07:00 [DBG] Ending HttpMessageHandler cleanup cycle after 0.0003ms - processed: 0 items - remaining: 1 items
+2025-09-29 01:26:38.046 +07:00 [DBG] Starting HttpMessageHandler cleanup cycle with 1 items
+2025-09-29 01:26:38.046 +07:00 [DBG] Ending HttpMessageHandler cleanup cycle after 0.0007ms - processed: 0 items - remaining: 1 items
+2025-09-29 01:26:48.058 +07:00 [DBG] Starting HttpMessageHandler cleanup cycle with 1 items
+2025-09-29 01:26:48.058 +07:00 [DBG] Ending HttpMessageHandler cleanup cycle after 0.0006ms - processed: 0 items - remaining: 1 items
+2025-09-29 01:26:58.063 +07:00 [DBG] Starting HttpMessageHandler cleanup cycle with 1 items
+2025-09-29 01:26:58.063 +07:00 [DBG] Ending HttpMessageHandler cleanup cycle after 0.0009ms - processed: 0 items - remaining: 1 items
+2025-09-29 01:27:08.071 +07:00 [DBG] Starting HttpMessageHandler cleanup cycle with 1 items
+2025-09-29 01:27:08.071 +07:00 [DBG] Ending HttpMessageHandler cleanup cycle after 0.0004ms - processed: 0 items - remaining: 1 items
+2025-09-29 01:27:18.081 +07:00 [DBG] Starting HttpMessageHandler cleanup cycle with 1 items
+2025-09-29 01:27:18.081 +07:00 [DBG] Ending HttpMessageHandler cleanup cycle after 0.0005ms - processed: 0 items - remaining: 1 items
+2025-09-29 01:27:28.082 +07:00 [DBG] Starting HttpMessageHandler cleanup cycle with 1 items
+2025-09-29 01:27:28.082 +07:00 [DBG] Ending HttpMessageHandler cleanup cycle after 0.0003ms - processed: 0 items - remaining: 1 items
+2025-09-29 01:27:38.085 +07:00 [DBG] Starting HttpMessageHandler cleanup cycle with 1 items
+2025-09-29 01:27:38.085 +07:00 [DBG] Ending HttpMessageHandler cleanup cycle after 0.0008ms - processed: 0 items - remaining: 1 items
+2025-09-29 01:27:48.095 +07:00 [DBG] Starting HttpMessageHandler cleanup cycle with 1 items
+2025-09-29 01:27:48.095 +07:00 [DBG] Ending HttpMessageHandler cleanup cycle after 0.0008ms - processed: 0 items - remaining: 1 items
+2025-09-29 01:27:58.096 +07:00 [DBG] Starting HttpMessageHandler cleanup cycle with 1 items
+2025-09-29 01:27:58.096 +07:00 [DBG] Ending HttpMessageHandler cleanup cycle after 0.0004ms - processed: 0 items - remaining: 1 items
+2025-09-29 01:28:08.099 +07:00 [DBG] Starting HttpMessageHandler cleanup cycle with 1 items
+2025-09-29 01:28:08.099 +07:00 [DBG] Ending HttpMessageHandler cleanup cycle after 0.0007ms - processed: 0 items - remaining: 1 items
+2025-09-29 01:28:18.106 +07:00 [DBG] Starting HttpMessageHandler cleanup cycle with 1 items
+2025-09-29 01:28:18.106 +07:00 [DBG] Ending HttpMessageHandler cleanup cycle after 0.0008ms - processed: 0 items - remaining: 1 items
+2025-09-29 01:28:28.113 +07:00 [DBG] Starting HttpMessageHandler cleanup cycle with 1 items
+2025-09-29 01:28:28.113 +07:00 [DBG] Ending HttpMessageHandler cleanup cycle after 0.0014ms - processed: 0 items - remaining: 1 items
+2025-09-29 01:28:38.127 +07:00 [DBG] Starting HttpMessageHandler cleanup cycle with 1 items
+2025-09-29 01:28:38.127 +07:00 [DBG] Ending HttpMessageHandler cleanup cycle after 0.0014ms - processed: 0 items - remaining: 1 items
+2025-09-29 01:28:48.143 +07:00 [DBG] Starting HttpMessageHandler cleanup cycle with 1 items
+2025-09-29 01:28:48.143 +07:00 [DBG] Ending HttpMessageHandler cleanup cycle after 0.0005ms - processed: 0 items - remaining: 1 items
+2025-09-29 01:28:58.147 +07:00 [DBG] Starting HttpMessageHandler cleanup cycle with 1 items
+2025-09-29 01:28:58.147 +07:00 [DBG] Ending HttpMessageHandler cleanup cycle after 0.0006ms - processed: 0 items - remaining: 1 items
+2025-09-29 01:29:08.152 +07:00 [DBG] Starting HttpMessageHandler cleanup cycle with 1 items
+2025-09-29 01:29:08.152 +07:00 [DBG] Ending HttpMessageHandler cleanup cycle after 0.0011ms - processed: 0 items - remaining: 1 items
+2025-09-29 01:29:18.156 +07:00 [DBG] Starting HttpMessageHandler cleanup cycle with 1 items
+2025-09-29 01:29:18.156 +07:00 [DBG] Ending HttpMessageHandler cleanup cycle after 0.0008ms - processed: 0 items - remaining: 1 items
+2025-09-29 01:29:28.157 +07:00 [DBG] Starting HttpMessageHandler cleanup cycle with 1 items
+2025-09-29 01:29:28.158 +07:00 [DBG] Ending HttpMessageHandler cleanup cycle after 0.0015ms - processed: 0 items - remaining: 1 items
+2025-09-29 01:29:38.170 +07:00 [DBG] Starting HttpMessageHandler cleanup cycle with 1 items
+2025-09-29 01:29:38.170 +07:00 [DBG] Ending HttpMessageHandler cleanup cycle after 0.0018ms - processed: 0 items - remaining: 1 items
+2025-09-29 01:29:48.171 +07:00 [DBG] Starting HttpMessageHandler cleanup cycle with 1 items
+2025-09-29 01:29:48.171 +07:00 [DBG] Ending HttpMessageHandler cleanup cycle after 0.001ms - processed: 0 items - remaining: 1 items
+2025-09-29 01:29:58.178 +07:00 [DBG] Starting HttpMessageHandler cleanup cycle with 1 items
+2025-09-29 01:29:58.178 +07:00 [DBG] Ending HttpMessageHandler cleanup cycle after 0.0006ms - processed: 0 items - remaining: 1 items
+2025-09-29 01:30:08.181 +07:00 [DBG] Starting HttpMessageHandler cleanup cycle with 1 items
+2025-09-29 01:30:08.181 +07:00 [DBG] Ending HttpMessageHandler cleanup cycle after 0.0005ms - processed: 0 items - remaining: 1 items
+2025-09-29 01:30:18.193 +07:00 [DBG] Starting HttpMessageHandler cleanup cycle with 1 items
+2025-09-29 01:30:18.193 +07:00 [DBG] Ending HttpMessageHandler cleanup cycle after 0.0009ms - processed: 0 items - remaining: 1 items
+2025-09-29 01:30:28.194 +07:00 [DBG] Starting HttpMessageHandler cleanup cycle with 1 items
+2025-09-29 01:30:28.194 +07:00 [DBG] Ending HttpMessageHandler cleanup cycle after 0.0005ms - processed: 0 items - remaining: 1 items
+2025-09-29 01:30:38.202 +07:00 [DBG] Starting HttpMessageHandler cleanup cycle with 1 items
+2025-09-29 01:30:38.202 +07:00 [DBG] Ending HttpMessageHandler cleanup cycle after 0.0015ms - processed: 0 items - remaining: 1 items
+2025-09-29 01:30:48.212 +07:00 [DBG] Starting HttpMessageHandler cleanup cycle with 1 items
+2025-09-29 01:30:48.213 +07:00 [DBG] Ending HttpMessageHandler cleanup cycle after 0.0009ms - processed: 0 items - remaining: 1 items
+2025-09-29 01:30:58.220 +07:00 [DBG] Starting HttpMessageHandler cleanup cycle with 1 items
+2025-09-29 01:30:58.221 +07:00 [DBG] Ending HttpMessageHandler cleanup cycle after 0.0012ms - processed: 0 items - remaining: 1 items
+2025-09-29 01:31:08.227 +07:00 [DBG] Starting HttpMessageHandler cleanup cycle with 1 items
+2025-09-29 01:31:08.227 +07:00 [DBG] Ending HttpMessageHandler cleanup cycle after 0.0007ms - processed: 0 items - remaining: 1 items
+2025-09-29 01:31:18.241 +07:00 [DBG] Starting HttpMessageHandler cleanup cycle with 1 items
+2025-09-29 01:31:18.242 +07:00 [DBG] Ending HttpMessageHandler cleanup cycle after 0.0006ms - processed: 0 items - remaining: 1 items
+2025-09-29 01:31:28.243 +07:00 [DBG] Starting HttpMessageHandler cleanup cycle with 1 items
+2025-09-29 01:31:28.243 +07:00 [DBG] Ending HttpMessageHandler cleanup cycle after 0.0008ms - processed: 0 items - remaining: 1 items
+2025-09-29 01:31:38.257 +07:00 [DBG] Starting HttpMessageHandler cleanup cycle with 1 items
+2025-09-29 01:31:38.258 +07:00 [DBG] Ending HttpMessageHandler cleanup cycle after 0.0009ms - processed: 0 items - remaining: 1 items
+2025-09-29 01:31:48.266 +07:00 [DBG] Starting HttpMessageHandler cleanup cycle with 1 items
+2025-09-29 01:31:48.266 +07:00 [DBG] Ending HttpMessageHandler cleanup cycle after 0.0016ms - processed: 0 items - remaining: 1 items
+2025-09-29 01:31:58.277 +07:00 [DBG] Starting HttpMessageHandler cleanup cycle with 1 items
+2025-09-29 01:31:58.277 +07:00 [DBG] Ending HttpMessageHandler cleanup cycle after 0.0008ms - processed: 0 items - remaining: 1 items
+2025-09-29 01:32:08.292 +07:00 [DBG] Starting HttpMessageHandler cleanup cycle with 1 items
+2025-09-29 01:32:08.292 +07:00 [DBG] Ending HttpMessageHandler cleanup cycle after 0.0006ms - processed: 0 items - remaining: 1 items
+2025-09-29 01:32:18.292 +07:00 [DBG] Starting HttpMessageHandler cleanup cycle with 1 items
+2025-09-29 01:32:18.293 +07:00 [DBG] Ending HttpMessageHandler cleanup cycle after 0.001ms - processed: 0 items - remaining: 1 items
+2025-09-29 01:32:28.298 +07:00 [DBG] Starting HttpMessageHandler cleanup cycle with 1 items
+2025-09-29 01:32:28.298 +07:00 [DBG] Ending HttpMessageHandler cleanup cycle after 0.001ms - processed: 0 items - remaining: 1 items
+2025-09-29 01:32:38.309 +07:00 [DBG] Starting HttpMessageHandler cleanup cycle with 1 items
+2025-09-29 01:32:38.309 +07:00 [DBG] Ending HttpMessageHandler cleanup cycle after 0.0005ms - processed: 0 items - remaining: 1 items
+2025-09-29 01:32:48.318 +07:00 [DBG] Starting HttpMessageHandler cleanup cycle with 1 items
+2025-09-29 01:32:48.318 +07:00 [DBG] Ending HttpMessageHandler cleanup cycle after 0.0007ms - processed: 0 items - remaining: 1 items
+2025-09-29 01:32:58.323 +07:00 [DBG] Starting HttpMessageHandler cleanup cycle with 1 items
+2025-09-29 01:32:58.324 +07:00 [DBG] Ending HttpMessageHandler cleanup cycle after 0.0008ms - processed: 0 items - remaining: 1 items
+2025-09-29 01:33:08.332 +07:00 [DBG] Starting HttpMessageHandler cleanup cycle with 1 items
+2025-09-29 01:33:08.332 +07:00 [DBG] Ending HttpMessageHandler cleanup cycle after 0.0007ms - processed: 0 items - remaining: 1 items
+2025-09-29 01:33:18.349 +07:00 [DBG] Starting HttpMessageHandler cleanup cycle with 1 items
+2025-09-29 01:33:18.349 +07:00 [DBG] Ending HttpMessageHandler cleanup cycle after 0.0011ms - processed: 0 items - remaining: 1 items
+2025-09-29 01:33:28.359 +07:00 [DBG] Starting HttpMessageHandler cleanup cycle with 1 items
+2025-09-29 01:33:28.360 +07:00 [DBG] Ending HttpMessageHandler cleanup cycle after 0.0012ms - processed: 0 items - remaining: 1 items
+2025-09-29 01:33:38.374 +07:00 [DBG] Starting HttpMessageHandler cleanup cycle with 1 items
+2025-09-29 01:33:38.374 +07:00 [DBG] Ending HttpMessageHandler cleanup cycle after 0.001ms - processed: 0 items - remaining: 1 items
+2025-09-29 01:33:48.389 +07:00 [DBG] Starting HttpMessageHandler cleanup cycle with 1 items
+2025-09-29 01:33:48.389 +07:00 [DBG] Ending HttpMessageHandler cleanup cycle after 0.0007ms - processed: 0 items - remaining: 1 items
+2025-09-29 01:33:58.404 +07:00 [DBG] Starting HttpMessageHandler cleanup cycle with 1 items
+2025-09-29 01:33:58.404 +07:00 [DBG] Ending HttpMessageHandler cleanup cycle after 0.0011ms - processed: 0 items - remaining: 1 items
+2025-09-29 01:34:08.414 +07:00 [DBG] Starting HttpMessageHandler cleanup cycle with 1 items
+2025-09-29 01:34:08.414 +07:00 [DBG] Ending HttpMessageHandler cleanup cycle after 0.0015ms - processed: 0 items - remaining: 1 items
+2025-09-29 01:34:18.429 +07:00 [DBG] Starting HttpMessageHandler cleanup cycle with 1 items
+2025-09-29 01:34:18.429 +07:00 [DBG] Ending HttpMessageHandler cleanup cycle after 0.0009ms - processed: 0 items - remaining: 1 items
+2025-09-29 01:34:28.428 +07:00 [DBG] Starting HttpMessageHandler cleanup cycle with 1 items
+2025-09-29 01:34:28.428 +07:00 [DBG] Ending HttpMessageHandler cleanup cycle after 0.0017ms - processed: 0 items - remaining: 1 items
+2025-09-29 01:34:38.431 +07:00 [DBG] Starting HttpMessageHandler cleanup cycle with 1 items
+2025-09-29 01:34:38.432 +07:00 [DBG] Ending HttpMessageHandler cleanup cycle after 0.0007ms - processed: 0 items - remaining: 1 items
+2025-09-29 01:34:48.444 +07:00 [DBG] Starting HttpMessageHandler cleanup cycle with 1 items
+2025-09-29 01:34:48.445 +07:00 [DBG] Ending HttpMessageHandler cleanup cycle after 0.0011ms - processed: 0 items - remaining: 1 items
+2025-09-29 01:34:58.450 +07:00 [DBG] Starting HttpMessageHandler cleanup cycle with 1 items
+2025-09-29 01:34:58.450 +07:00 [DBG] Ending HttpMessageHandler cleanup cycle after 0.0005ms - processed: 0 items - remaining: 1 items
+2025-09-29 01:35:08.453 +07:00 [DBG] Starting HttpMessageHandler cleanup cycle with 1 items
+2025-09-29 01:35:08.453 +07:00 [DBG] Ending HttpMessageHandler cleanup cycle after 0.0014ms - processed: 0 items - remaining: 1 items
+2025-09-29 01:35:18.463 +07:00 [DBG] Starting HttpMessageHandler cleanup cycle with 1 items
+2025-09-29 01:35:18.463 +07:00 [DBG] Ending HttpMessageHandler cleanup cycle after 0.0009ms - processed: 0 items - remaining: 1 items
+2025-09-29 01:35:28.470 +07:00 [DBG] Starting HttpMessageHandler cleanup cycle with 1 items
+2025-09-29 01:35:28.470 +07:00 [DBG] Ending HttpMessageHandler cleanup cycle after 0.0006ms - processed: 0 items - remaining: 1 items
+2025-09-29 01:35:38.478 +07:00 [DBG] Starting HttpMessageHandler cleanup cycle with 1 items
+2025-09-29 01:35:38.478 +07:00 [DBG] Ending HttpMessageHandler cleanup cycle after 0.0013ms - processed: 0 items - remaining: 1 items
+2025-09-29 01:35:48.498 +07:00 [DBG] Starting HttpMessageHandler cleanup cycle with 1 items
+2025-09-29 01:35:48.499 +07:00 [DBG] Ending HttpMessageHandler cleanup cycle after 0.0008ms - processed: 0 items - remaining: 1 items
+2025-09-29 01:35:58.509 +07:00 [DBG] Starting HttpMessageHandler cleanup cycle with 1 items
+2025-09-29 01:35:58.509 +07:00 [DBG] Ending HttpMessageHandler cleanup cycle after 0.0009ms - processed: 0 items - remaining: 1 items
+2025-09-29 01:36:08.513 +07:00 [DBG] Starting HttpMessageHandler cleanup cycle with 1 items
+2025-09-29 01:36:08.513 +07:00 [DBG] Ending HttpMessageHandler cleanup cycle after 0.0006ms - processed: 0 items - remaining: 1 items
+2025-09-29 01:36:18.528 +07:00 [DBG] Starting HttpMessageHandler cleanup cycle with 1 items
+2025-09-29 01:36:18.529 +07:00 [DBG] Ending HttpMessageHandler cleanup cycle after 0.0007ms - processed: 0 items - remaining: 1 items
+2025-09-29 01:36:28.540 +07:00 [DBG] Starting HttpMessageHandler cleanup cycle with 1 items
+2025-09-29 01:36:28.540 +07:00 [DBG] Ending HttpMessageHandler cleanup cycle after 0.0017ms - processed: 0 items - remaining: 1 items
+2025-09-29 01:36:38.547 +07:00 [DBG] Starting HttpMessageHandler cleanup cycle with 1 items
+2025-09-29 01:36:38.547 +07:00 [DBG] Ending HttpMessageHandler cleanup cycle after 0.0014ms - processed: 0 items - remaining: 1 items
+2025-09-29 01:36:48.547 +07:00 [DBG] Starting HttpMessageHandler cleanup cycle with 1 items
+2025-09-29 01:36:48.548 +07:00 [DBG] Ending HttpMessageHandler cleanup cycle after 0.0007ms - processed: 0 items - remaining: 1 items
+2025-09-29 01:36:58.562 +07:00 [DBG] Starting HttpMessageHandler cleanup cycle with 1 items
+2025-09-29 01:36:58.562 +07:00 [DBG] Ending HttpMessageHandler cleanup cycle after 0.0014ms - processed: 0 items - remaining: 1 items
+2025-09-29 01:37:08.577 +07:00 [DBG] Starting HttpMessageHandler cleanup cycle with 1 items
+2025-09-29 01:37:08.577 +07:00 [DBG] Ending HttpMessageHandler cleanup cycle after 0.0012ms - processed: 0 items - remaining: 1 items
+2025-09-29 01:37:18.592 +07:00 [DBG] Starting HttpMessageHandler cleanup cycle with 1 items
+2025-09-29 01:37:18.592 +07:00 [DBG] Ending HttpMessageHandler cleanup cycle after 0.0016ms - processed: 0 items - remaining: 1 items
+2025-09-29 01:37:28.602 +07:00 [DBG] Starting HttpMessageHandler cleanup cycle with 1 items
+2025-09-29 01:37:28.603 +07:00 [DBG] Ending HttpMessageHandler cleanup cycle after 0.0007ms - processed: 0 items - remaining: 1 items
+2025-09-29 01:37:38.614 +07:00 [DBG] Starting HttpMessageHandler cleanup cycle with 1 items
+2025-09-29 01:37:38.614 +07:00 [DBG] Ending HttpMessageHandler cleanup cycle after 0.0011ms - processed: 0 items - remaining: 1 items
+2025-09-29 01:37:48.621 +07:00 [DBG] Starting HttpMessageHandler cleanup cycle with 1 items
+2025-09-29 01:37:48.621 +07:00 [DBG] Ending HttpMessageHandler cleanup cycle after 0.0009ms - processed: 0 items - remaining: 1 items
+2025-09-29 01:37:58.632 +07:00 [DBG] Starting HttpMessageHandler cleanup cycle with 1 items
+2025-09-29 01:37:58.633 +07:00 [DBG] Ending HttpMessageHandler cleanup cycle after 0.001ms - processed: 0 items - remaining: 1 items
+2025-09-29 01:38:08.642 +07:00 [DBG] Starting HttpMessageHandler cleanup cycle with 1 items
+2025-09-29 01:38:08.642 +07:00 [DBG] Ending HttpMessageHandler cleanup cycle after 0.0013ms - processed: 0 items - remaining: 1 items
+2025-09-29 01:38:18.653 +07:00 [DBG] Starting HttpMessageHandler cleanup cycle with 1 items
+2025-09-29 01:38:18.654 +07:00 [DBG] Ending HttpMessageHandler cleanup cycle after 0.0007ms - processed: 0 items - remaining: 1 items
+2025-09-29 01:38:28.664 +07:00 [DBG] Starting HttpMessageHandler cleanup cycle with 1 items
+2025-09-29 01:38:28.664 +07:00 [DBG] Ending HttpMessageHandler cleanup cycle after 0.001ms - processed: 0 items - remaining: 1 items
+2025-09-29 01:38:38.669 +07:00 [DBG] Starting HttpMessageHandler cleanup cycle with 1 items
+2025-09-29 01:38:38.670 +07:00 [DBG] Ending HttpMessageHandler cleanup cycle after 0.0007ms - processed: 0 items - remaining: 1 items
+2025-09-29 01:38:48.685 +07:00 [DBG] Starting HttpMessageHandler cleanup cycle with 1 items
+2025-09-29 01:38:48.685 +07:00 [DBG] Ending HttpMessageHandler cleanup cycle after 0.0007ms - processed: 0 items - remaining: 1 items
+2025-09-29 01:38:58.699 +07:00 [DBG] Starting HttpMessageHandler cleanup cycle with 1 items
+2025-09-29 01:38:58.699 +07:00 [DBG] Ending HttpMessageHandler cleanup cycle after 0.0014ms - processed: 0 items - remaining: 1 items
+2025-09-29 01:39:08.710 +07:00 [DBG] Starting HttpMessageHandler cleanup cycle with 1 items
+2025-09-29 01:39:08.710 +07:00 [DBG] Ending HttpMessageHandler cleanup cycle after 0.0014ms - processed: 0 items - remaining: 1 items
+2025-09-29 01:39:18.716 +07:00 [DBG] Starting HttpMessageHandler cleanup cycle with 1 items
+2025-09-29 01:39:18.716 +07:00 [DBG] Ending HttpMessageHandler cleanup cycle after 0.0014ms - processed: 0 items - remaining: 1 items
+2025-09-29 01:39:28.720 +07:00 [DBG] Starting HttpMessageHandler cleanup cycle with 1 items
+2025-09-29 01:39:28.720 +07:00 [DBG] Ending HttpMessageHandler cleanup cycle after 0.0011ms - processed: 0 items - remaining: 1 items
+2025-09-29 01:39:38.722 +07:00 [DBG] Starting HttpMessageHandler cleanup cycle with 1 items
+2025-09-29 01:39:38.722 +07:00 [DBG] Ending HttpMessageHandler cleanup cycle after 0.0014ms - processed: 0 items - remaining: 1 items
+2025-09-29 01:39:48.731 +07:00 [DBG] Starting HttpMessageHandler cleanup cycle with 1 items
+2025-09-29 01:39:48.731 +07:00 [DBG] Ending HttpMessageHandler cleanup cycle after 0.0005ms - processed: 0 items - remaining: 1 items
+2025-09-29 01:39:58.736 +07:00 [DBG] Starting HttpMessageHandler cleanup cycle with 1 items
+2025-09-29 01:39:58.737 +07:00 [DBG] Ending HttpMessageHandler cleanup cycle after 0.3041ms - processed: 1 items - remaining: 0 items
+2025-09-29 01:50:24.662 +07:00 [DBG] Connection id "0HNFUN9U1CO92" accepted.
+2025-09-29 01:50:24.662 +07:00 [DBG] Connection id "0HNFUN9U1CO92" started.
+2025-09-29 01:50:24.663 +07:00 [INF] Request starting HTTP/1.1 GET http://localhost:5207/api/topic/detail/5 - null null
+2025-09-29 01:50:24.663 +07:00 [DBG] The request path /api/topic/detail/5 does not match a supported file type
+2025-09-29 01:50:24.663 +07:00 [DBG] The request path /api/topic/detail/5 does not match a supported file type
+2025-09-29 01:50:24.666 +07:00 [DBG] 1 candidate(s) found for the request path '/api/topic/detail/5'
+2025-09-29 01:50:24.667 +07:00 [DBG] Endpoint 'CapBot.api.Controllers.TopicController.GetDetail (CapBot.api)' with route pattern 'api/topic/detail/{topicId}' is valid for the request path '/api/topic/detail/5'
+2025-09-29 01:50:24.667 +07:00 [DBG] Request matched endpoint 'CapBot.api.Controllers.TopicController.GetDetail (CapBot.api)'
+2025-09-29 01:50:24.668 +07:00 [DBG] Successfully validated the token.
+2025-09-29 01:50:24.668 +07:00 [DBG] AuthenticationScheme: Bearer was successfully authenticated.
+2025-09-29 01:50:24.669 +07:00 [INF] Executing endpoint 'CapBot.api.Controllers.TopicController.GetDetail (CapBot.api)'
+2025-09-29 01:50:24.676 +07:00 [INF] Route matched with {action = "GetDetail", controller = "Topic"}. Executing controller action with signature System.Threading.Tasks.Task`1[Microsoft.AspNetCore.Mvc.IActionResult] GetDetail(Int32) on controller CapBot.api.Controllers.TopicController (CapBot.api).
+2025-09-29 01:50:24.676 +07:00 [DBG] Execution plan of authorization filters (in the following order): ["None"]
+2025-09-29 01:50:24.676 +07:00 [DBG] Execution plan of resource filters (in the following order): ["Microsoft.AspNetCore.Mvc.ConsumesAttribute"]
+2025-09-29 01:50:24.676 +07:00 [DBG] Execution plan of action filters (in the following order): ["Microsoft.AspNetCore.Mvc.ModelBinding.UnsupportedContentTypeFilter (Order: -3000)"]
+2025-09-29 01:50:24.676 +07:00 [DBG] Execution plan of exception filters (in the following order): ["None"]
+2025-09-29 01:50:24.676 +07:00 [DBG] Execution plan of result filters (in the following order): ["Microsoft.AspNetCore.Mvc.Infrastructure.ClientErrorResultFilter (Order: -2000)","Microsoft.AspNetCore.Mvc.ProducesAttribute (Order: 0)"]
+2025-09-29 01:50:24.677 +07:00 [DBG] Executing controller factory for controller CapBot.api.Controllers.TopicController (CapBot.api)
+2025-09-29 01:50:24.679 +07:00 [DBG] Executed controller factory for controller CapBot.api.Controllers.TopicController (CapBot.api)
+2025-09-29 01:50:24.680 +07:00 [DBG] Attempting to bind parameter 'topicId' of type 'System.Int32' ...
+2025-09-29 01:50:24.681 +07:00 [DBG] Attempting to bind parameter 'topicId' of type 'System.Int32' using the name 'topicId' in request data ...
+2025-09-29 01:50:24.681 +07:00 [DBG] Done attempting to bind parameter 'topicId' of type 'System.Int32'.
+2025-09-29 01:50:24.681 +07:00 [DBG] Done attempting to bind parameter 'topicId' of type 'System.Int32'.
+2025-09-29 01:50:24.681 +07:00 [DBG] Attempting to validate the bound parameter 'topicId' of type 'System.Int32' ...
+2025-09-29 01:50:24.681 +07:00 [DBG] Done attempting to validate the bound parameter 'topicId' of type 'System.Int32'.
+2025-09-29 01:50:24.687 +07:00 [DBG] Entity Framework Core 8.0.16 initialized 'MyDbContext' using provider 'Microsoft.EntityFrameworkCore.SqlServer:8.0.13' with options: MigrationsAssembly=App.DAL 
+2025-09-29 01:50:24.688 +07:00 [DBG] Compiling query expression: 
+'DbSet<Topic>()
+    .AsNoTracking()
+    .Include(x => x.Supervisor)
+    .Include(x => x.Category)
+    .Include(x => x.Semester)
+    .Include(x => x.TopicVersions)
+    .Include(x => x.Submissions)
+    .Where(x => x.Id == __topicId_0 && x.IsActive && x.DeletedAt == null)
+    .FirstOrDefault()'
+2025-09-29 01:50:24.689 +07:00 [DBG] Including navigation: 'Topic.Supervisor'.
+2025-09-29 01:50:24.689 +07:00 [DBG] Including navigation: 'Topic.Category'.
+2025-09-29 01:50:24.689 +07:00 [DBG] Including navigation: 'Topic.Semester'.
+2025-09-29 01:50:24.690 +07:00 [DBG] Including navigation: 'Topic.TopicVersions'.
+2025-09-29 01:50:24.690 +07:00 [DBG] Including navigation: 'Topic.Submissions'.
+2025-09-29 01:50:24.711 +07:00 [WRN] Compiling a query which loads related collections for more than one collection navigation, either via 'Include' or through projection, but no 'QuerySplittingBehavior' has been configured. By default, Entity Framework will use 'QuerySplittingBehavior.SingleQuery', which can potentially result in slow query performance. See https://go.microsoft.com/fwlink/?linkid=2134277 for more information. To identify the query that's triggering this warning call 'ConfigureWarnings(w => w.Throw(RelationalEventId.MultipleCollectionIncludeWarning))'.
+2025-09-29 01:50:24.718 +07:00 [DBG] Generated query execution expression: 
+'queryContext => ShapedQueryCompilingExpressionVisitor.SingleOrDefaultAsync<Topic>(
+    asyncEnumerable: new SingleQueryingEnumerable<Topic>(
+        (RelationalQueryContext)queryContext, 
+        RelationalCommandCache.QueryExpression(
+            Client Projections:
+                0 -> Dictionary<IProperty, int> { [Property: Topic.Id (int) Required PK AfterSave:Throw ValueGenerated.OnAdd, 0], [Property: Topic.Abbreviation (string), 1], [Property: Topic.CategoryId (int?) FK Index, 2], [Property: Topic.Content (string), 3], [Property: Topic.Context (string), 4], [Property: Topic.CreatedAt (DateTime) Required ValueGenerated.OnAdd, 5], [Property: Topic.CreatedBy (string), 6], [Property: Topic.DeletedAt (DateTime?), 7], [Property: Topic.Description (string), 8], [Property: Topic.EN_Title (string) Required MaxLength(500), 9], [Property: Topic.IsActive (bool) Required, 10], [Property: Topic.IsApproved (bool) Required Index Sentinel:True ValueGenerated.OnAdd, 11], [Property: Topic.IsLegacy (bool) Required Index ValueGenerated.OnAdd, 12], [Property: Topic.LastModifiedAt (DateTime?), 13], [Property: Topic.LastModifiedBy (string), 14], [Property: Topic.MaxStudents (int) Required ValueGenerated.OnAdd, 15], [Property: Topic.Objectives (string), 16], [Property: Topic.PotentialDuplicate (string), 17], [Property: Topic.Problem (string), 18], [Property: Topic.SemesterId (int) Required FK Index, 19], [Property: Topic.SupervisorId (int) Required FK Index, 20], [Property: Topic.VN_title (string), 21] }
+                1 -> Dictionary<IProperty, int> { [Property: User.Id (int) Required PK AfterSave:Throw ValueGenerated.OnAdd, 22], [Property: User.AccessFailedCount (int) Required, 23], [Property: User.ConcurrencyStamp (string), 24], [Property: User.CreatedAt (DateTime) Required, 25], [Property: User.DeletedAt (DateTime?), 26], [Property: User.Email (string), 27], [Property: User.EmailConfirmed (bool) Required, 28], [Property: User.LastModifiedAt (DateTime) Required, 29], [Property: User.LastModifiedBy (string), 30], [Property: User.LockoutEnabled (bool) Required, 31], [Property: User.LockoutEnd (DateTimeOffset?), 32], [Property: User.NormalizedEmail (string), 33], [Property: User.NormalizedUserName (string), 34], [Property: User.PasswordHash (string), 35], [Property: User.PhoneNumber (string), 36], [Property: User.PhoneNumberConfirmed (bool) Required, 37], [Property: User.SecurityStamp (string), 38], [Property: User.TwoFactorEnabled (bool) Required, 39], [Property: User.UserName (string), 40] }
+                2 -> Dictionary<IProperty, int> { [Property: TopicCategory.Id (int) Required PK AfterSave:Throw ValueGenerated.OnAdd, 41], [Property: TopicCategory.CreatedAt (DateTime) Required ValueGenerated.OnAdd, 42], [Property: TopicCategory.CreatedBy (string), 43], [Property: TopicCategory.DeletedAt (DateTime?), 44], [Property: TopicCategory.Description (string), 45], [Property: TopicCategory.IsActive (bool) Required, 46], [Property: TopicCategory.LastModifiedAt (DateTime?), 47], [Property: TopicCategory.LastModifiedBy (string), 48], [Property: TopicCategory.Name (string) Required MaxLength(100), 49] }
+                3 -> Dictionary<IProperty, int> { [Property: Semester.Id (int) Required PK AfterSave:Throw ValueGenerated.OnAdd, 50], [Property: Semester.CreatedAt (DateTime) Required, 51], [Property: Semester.CreatedBy (string), 52], [Property: Semester.DeletedAt (DateTime?), 53], [Property: Semester.Description (string), 54], [Property: Semester.EndDate (DateTime) Required, 55], [Property: Semester.IsActive (bool) Required, 56], [Property: Semester.LastModifiedAt (DateTime?), 57], [Property: Semester.LastModifiedBy (string), 58], [Property: Semester.Name (string) Required Index MaxLength(50), 59], [Property: Semester.StartDate (DateTime) Required, 60] }
+                4 -> 0
+                5 -> 22
+                6 -> 41
+                7 -> 50
+                8 -> Dictionary<IProperty, int> { [Property: TopicVersion.Id (int) Required PK AfterSave:Throw ValueGenerated.OnAdd, 61], [Property: TopicVersion.Content (string), 62], [Property: TopicVersion.Context (string), 63], [Property: TopicVersion.CreatedAt (DateTime) Required ValueGenerated.OnAdd, 64], [Property: TopicVersion.CreatedBy (string), 65], [Property: TopicVersion.DeletedAt (DateTime?), 66], [Property: TopicVersion.Description (string), 67], [Property: TopicVersion.DocumentUrl (string) MaxLength(500), 68], [Property: TopicVersion.EN_Title (string) Required MaxLength(500), 69], [Property: TopicVersion.ExpectedOutcomes (string), 70], [Property: TopicVersion.IsActive (bool) Required, 71], [Property: TopicVersion.LastModifiedAt (DateTime?), 72], [Property: TopicVersion.LastModifiedBy (string), 73], [Property: TopicVersion.Methodology (string), 74], [Property: TopicVersion.Objectives (string), 75], [Property: TopicVersion.PotentialDuplicate (string), 76], [Property: TopicVersion.Problem (string), 77], [Property: TopicVersion.Requirements (string), 78], [Property: TopicVersion.Status (TopicStatus) Required Index ValueGenerated.OnAdd, 79], [Property: TopicVersion.SubmittedAt (DateTime?), 80], [Property: TopicVersion.SubmittedBy (int?) FK Index, 81], [Property: TopicVersion.TopicId (int) Required FK Index, 82], [Property: TopicVersion.VN_title (string), 83], [Property: TopicVersion.VersionNumber (int) Required Index, 84] }
+                9 -> 61
+                10 -> Dictionary<IProperty, int> { [Property: Submission.Id (int) Required PK AfterSave:Throw ValueGenerated.OnAdd, 85], [Property: Submission.AdditionalNotes (string), 86], [Property: Submission.AiCheckDetails (string), 87], [Property: Submission.AiCheckScore (decimal?), 88], [Property: Submission.AiCheckStatus (AiCheckStatus) Required ValueGenerated.OnAdd, 89], [Property: Submission.CreatedAt (DateTime) Required, 90], [Property: Submission.CreatedBy (string), 91], [Property: Submission.DeletedAt (DateTime?), 92], [Property: Submission.DocumentUrl (string) MaxLength(500), 93], [Property: Submission.IsActive (bool) Required, 94], [Property: Submission.LastModifiedAt (DateTime?), 95], [Property: Submission.LastModifiedBy (string), 96], [Property: Submission.PhaseId (int) Required FK Index, 97], [Property: Submission.Status (SubmissionStatus) Required Index ValueGenerated.OnAdd, 98], [Property: Submission.SubmissionRound (int) Required Index ValueGenerated.OnAdd, 99], [Property: Submission.SubmittedAt (DateTime?) Index ValueGenerated.OnAdd, 100], [Property: Submission.SubmittedBy (int) Required FK Index, 101], [Property: Submission.TopicId (int) Required FK Index, 102], [Property: Submission.TopicVersionId (int?) FK Index, 103] }
+                11 -> 85
+            SELECT t1.Id, t1.Abbreviation, t1.CategoryId, t1.Content, t1.Context, t1.CreatedAt, t1.CreatedBy, t1.DeletedAt, t1.Description, t1.EN_Title, t1.IsActive, t1.IsApproved, t1.IsLegacy, t1.LastModifiedAt, t1.LastModifiedBy, t1.MaxStudents, t1.Objectives, t1.PotentialDuplicate, t1.Problem, t1.SemesterId, t1.SupervisorId, t1.VN_title, t1.Id0, t1.AccessFailedCount, t1.ConcurrencyStamp, t1.CreatedAt0, t1.DeletedAt0, t1.Email, t1.EmailConfirmed, t1.LastModifiedAt0, t1.LastModifiedBy0, t1.LockoutEnabled, t1.LockoutEnd, t1.NormalizedEmail, t1.NormalizedUserName, t1.PasswordHash, t1.PhoneNumber, t1.PhoneNumberConfirmed, t1.SecurityStamp, t1.TwoFactorEnabled, t1.UserName, t1.Id1, t1.CreatedAt1, t1.CreatedBy0, t1.DeletedAt1, t1.Description0, t1.IsActive0, t1.LastModifiedAt1, t1.LastModifiedBy1, t1.Name, t1.Id2, t1.CreatedAt2, t1.CreatedBy1, t1.DeletedAt2, t1.Description1, t1.EndDate, t1.IsActive1, t1.LastModifiedAt2, t1.LastModifiedBy2, t1.Name0, t1.StartDate, t2.Id, t2.Content, t2.Context, t2.CreatedAt, t2.CreatedBy, t2.DeletedAt, t2.Description, t2.DocumentUrl, t2.EN_Title, t2.ExpectedOutcomes, t2.IsActive, t2.LastModifiedAt, t2.LastModifiedBy, t2.Methodology, t2.Objectives, t2.PotentialDuplicate, t2.Problem, t2.Requirements, t2.Status, t2.SubmittedAt, t2.SubmittedBy, t2.TopicId, t2.VN_title, t2.VersionNumber, s0.Id, s0.AdditionalNotes, s0.AiCheckDetails, s0.AiCheckScore, s0.AiCheckStatus, s0.CreatedAt, s0.CreatedBy, s0.DeletedAt, s0.DocumentUrl, s0.IsActive, s0.LastModifiedAt, s0.LastModifiedBy, s0.PhaseId, s0.Status, s0.SubmissionRound, s0.SubmittedAt, s0.SubmittedBy, s0.TopicId, s0.TopicVersionId
+            FROM 
+            (
+                SELECT TOP(1) t.Id, t.Abbreviation, t.CategoryId, t.Content, t.Context, t.CreatedAt, t.CreatedBy, t.DeletedAt, t.Description, t.EN_Title, t.IsActive, t.IsApproved, t.IsLegacy, t.LastModifiedAt, t.LastModifiedBy, t.MaxStudents, t.Objectives, t.PotentialDuplicate, t.Problem, t.SemesterId, t.SupervisorId, t.VN_title, u.Id AS Id0, u.AccessFailedCount, u.ConcurrencyStamp, u.CreatedAt AS CreatedAt0, u.DeletedAt AS DeletedAt0, u.Email, u.EmailConfirmed, u.LastModifiedAt AS LastModifiedAt0, u.LastModifiedBy AS LastModifiedBy0, u.LockoutEnabled, u.LockoutEnd, u.NormalizedEmail, u.NormalizedUserName, u.PasswordHash, u.PhoneNumber, u.PhoneNumberConfirmed, u.SecurityStamp, u.TwoFactorEnabled, u.UserName, t0.Id AS Id1, t0.CreatedAt AS CreatedAt1, t0.CreatedBy AS CreatedBy0, t0.DeletedAt AS DeletedAt1, t0.Description AS Description0, t0.IsActive AS IsActive0, t0.LastModifiedAt AS LastModifiedAt1, t0.LastModifiedBy AS LastModifiedBy1, t0.Name, s.Id AS Id2, s.CreatedAt AS CreatedAt2, s.CreatedBy AS CreatedBy1, s.DeletedAt AS DeletedAt2, s.Description AS Description1, s.EndDate, s.IsActive AS IsActive1, s.LastModifiedAt AS LastModifiedAt2, s.LastModifiedBy AS LastModifiedBy2, s.Name AS Name0, s.StartDate
+                FROM topics AS t
+                INNER JOIN users AS u ON t.SupervisorId == u.Id
+                LEFT JOIN topic_categories AS t0 ON t.CategoryId == t0.Id
+                INNER JOIN semesters AS s ON t.SemesterId == s.Id
+                WHERE ((t.Id == @__topicId_0) && t.IsActive) && (t.DeletedAt == NULL)
+            ) AS t1
+            LEFT JOIN topic_versions AS t2 ON t1.Id == t2.TopicId
+            LEFT JOIN submissions AS s0 ON t1.Id == s0.TopicId
+            ORDER BY t1.Id ASC, t1.Id0 ASC, t1.Id1 ASC, t1.Id2 ASC, t2.Id ASC), 
+        null, 
+        Func<QueryContext, DbDataReader, ResultContext, SingleQueryResultCoordinator, Topic>, 
+        App.DAL.Context.MyDbContext, 
+        False, 
+        False, 
+        True
+    ), 
+    cancellationToken: queryContext.CancellationToken)'
+2025-09-29 01:50:24.721 +07:00 [DBG] Creating DbConnection.
+2025-09-29 01:50:24.722 +07:00 [DBG] Created DbConnection. (0ms).
+2025-09-29 01:50:24.722 +07:00 [DBG] Opening connection to database 'capbot_db' on server 'localhost'.
+2025-09-29 01:50:24.727 +07:00 [DBG] Opened connection to database 'capbot_db' on server 'localhost'.
+2025-09-29 01:50:24.727 +07:00 [DBG] Creating DbCommand for 'ExecuteReader'.
+2025-09-29 01:50:24.727 +07:00 [DBG] Created DbCommand for 'ExecuteReader' (0ms).
+2025-09-29 01:50:24.727 +07:00 [DBG] Initialized DbCommand for 'ExecuteReader' (0ms).
+2025-09-29 01:50:24.728 +07:00 [DBG] Executing DbCommand [Parameters=[@__topicId_0='?' (DbType = Int32)], CommandType='"Text"', CommandTimeout='30']
+SELECT [t1].[Id], [t1].[Abbreviation], [t1].[CategoryId], [t1].[Content], [t1].[Context], [t1].[CreatedAt], [t1].[CreatedBy], [t1].[DeletedAt], [t1].[Description], [t1].[EN_Title], [t1].[IsActive], [t1].[IsApproved], [t1].[IsLegacy], [t1].[LastModifiedAt], [t1].[LastModifiedBy], [t1].[MaxStudents], [t1].[Objectives], [t1].[PotentialDuplicate], [t1].[Problem], [t1].[SemesterId], [t1].[SupervisorId], [t1].[VN_title], [t1].[Id0], [t1].[AccessFailedCount], [t1].[ConcurrencyStamp], [t1].[CreatedAt0], [t1].[DeletedAt0], [t1].[Email], [t1].[EmailConfirmed], [t1].[LastModifiedAt0], [t1].[LastModifiedBy0], [t1].[LockoutEnabled], [t1].[LockoutEnd], [t1].[NormalizedEmail], [t1].[NormalizedUserName], [t1].[PasswordHash], [t1].[PhoneNumber], [t1].[PhoneNumberConfirmed], [t1].[SecurityStamp], [t1].[TwoFactorEnabled], [t1].[UserName], [t1].[Id1], [t1].[CreatedAt1], [t1].[CreatedBy0], [t1].[DeletedAt1], [t1].[Description0], [t1].[IsActive0], [t1].[LastModifiedAt1], [t1].[LastModifiedBy1], [t1].[Name], [t1].[Id2], [t1].[CreatedAt2], [t1].[CreatedBy1], [t1].[DeletedAt2], [t1].[Description1], [t1].[EndDate], [t1].[IsActive1], [t1].[LastModifiedAt2], [t1].[LastModifiedBy2], [t1].[Name0], [t1].[StartDate], [t2].[Id], [t2].[Content], [t2].[Context], [t2].[CreatedAt], [t2].[CreatedBy], [t2].[DeletedAt], [t2].[Description], [t2].[DocumentUrl], [t2].[EN_Title], [t2].[ExpectedOutcomes], [t2].[IsActive], [t2].[LastModifiedAt], [t2].[LastModifiedBy], [t2].[Methodology], [t2].[Objectives], [t2].[PotentialDuplicate], [t2].[Problem], [t2].[Requirements], [t2].[Status], [t2].[SubmittedAt], [t2].[SubmittedBy], [t2].[TopicId], [t2].[VN_title], [t2].[VersionNumber], [s0].[Id], [s0].[AdditionalNotes], [s0].[AiCheckDetails], [s0].[AiCheckScore], [s0].[AiCheckStatus], [s0].[CreatedAt], [s0].[CreatedBy], [s0].[DeletedAt], [s0].[DocumentUrl], [s0].[IsActive], [s0].[LastModifiedAt], [s0].[LastModifiedBy], [s0].[PhaseId], [s0].[Status], [s0].[SubmissionRound], [s0].[SubmittedAt], [s0].[SubmittedBy], [s0].[TopicId], [s0].[TopicVersionId]
+FROM (
+    SELECT TOP(1) [t].[Id], [t].[Abbreviation], [t].[CategoryId], [t].[Content], [t].[Context], [t].[CreatedAt], [t].[CreatedBy], [t].[DeletedAt], [t].[Description], [t].[EN_Title], [t].[IsActive], [t].[IsApproved], [t].[IsLegacy], [t].[LastModifiedAt], [t].[LastModifiedBy], [t].[MaxStudents], [t].[Objectives], [t].[PotentialDuplicate], [t].[Problem], [t].[SemesterId], [t].[SupervisorId], [t].[VN_title], [u].[Id] AS [Id0], [u].[AccessFailedCount], [u].[ConcurrencyStamp], [u].[CreatedAt] AS [CreatedAt0], [u].[DeletedAt] AS [DeletedAt0], [u].[Email], [u].[EmailConfirmed], [u].[LastModifiedAt] AS [LastModifiedAt0], [u].[LastModifiedBy] AS [LastModifiedBy0], [u].[LockoutEnabled], [u].[LockoutEnd], [u].[NormalizedEmail], [u].[NormalizedUserName], [u].[PasswordHash], [u].[PhoneNumber], [u].[PhoneNumberConfirmed], [u].[SecurityStamp], [u].[TwoFactorEnabled], [u].[UserName], [t0].[Id] AS [Id1], [t0].[CreatedAt] AS [CreatedAt1], [t0].[CreatedBy] AS [CreatedBy0], [t0].[DeletedAt] AS [DeletedAt1], [t0].[Description] AS [Description0], [t0].[IsActive] AS [IsActive0], [t0].[LastModifiedAt] AS [LastModifiedAt1], [t0].[LastModifiedBy] AS [LastModifiedBy1], [t0].[Name], [s].[Id] AS [Id2], [s].[CreatedAt] AS [CreatedAt2], [s].[CreatedBy] AS [CreatedBy1], [s].[DeletedAt] AS [DeletedAt2], [s].[Description] AS [Description1], [s].[EndDate], [s].[IsActive] AS [IsActive1], [s].[LastModifiedAt] AS [LastModifiedAt2], [s].[LastModifiedBy] AS [LastModifiedBy2], [s].[Name] AS [Name0], [s].[StartDate]
+    FROM [topics] AS [t]
+    INNER JOIN [users] AS [u] ON [t].[SupervisorId] = [u].[Id]
+    LEFT JOIN [topic_categories] AS [t0] ON [t].[CategoryId] = [t0].[Id]
+    INNER JOIN [semesters] AS [s] ON [t].[SemesterId] = [s].[Id]
+    WHERE [t].[Id] = @__topicId_0 AND [t].[IsActive] = CAST(1 AS bit) AND [t].[DeletedAt] IS NULL
+) AS [t1]
+LEFT JOIN [topic_versions] AS [t2] ON [t1].[Id] = [t2].[TopicId]
+LEFT JOIN [submissions] AS [s0] ON [t1].[Id] = [s0].[TopicId]
+ORDER BY [t1].[Id], [t1].[Id0], [t1].[Id1], [t1].[Id2], [t2].[Id]
+2025-09-29 01:50:24.756 +07:00 [INF] Executed DbCommand (28ms) [Parameters=[@__topicId_0='?' (DbType = Int32)], CommandType='"Text"', CommandTimeout='30']
+SELECT [t1].[Id], [t1].[Abbreviation], [t1].[CategoryId], [t1].[Content], [t1].[Context], [t1].[CreatedAt], [t1].[CreatedBy], [t1].[DeletedAt], [t1].[Description], [t1].[EN_Title], [t1].[IsActive], [t1].[IsApproved], [t1].[IsLegacy], [t1].[LastModifiedAt], [t1].[LastModifiedBy], [t1].[MaxStudents], [t1].[Objectives], [t1].[PotentialDuplicate], [t1].[Problem], [t1].[SemesterId], [t1].[SupervisorId], [t1].[VN_title], [t1].[Id0], [t1].[AccessFailedCount], [t1].[ConcurrencyStamp], [t1].[CreatedAt0], [t1].[DeletedAt0], [t1].[Email], [t1].[EmailConfirmed], [t1].[LastModifiedAt0], [t1].[LastModifiedBy0], [t1].[LockoutEnabled], [t1].[LockoutEnd], [t1].[NormalizedEmail], [t1].[NormalizedUserName], [t1].[PasswordHash], [t1].[PhoneNumber], [t1].[PhoneNumberConfirmed], [t1].[SecurityStamp], [t1].[TwoFactorEnabled], [t1].[UserName], [t1].[Id1], [t1].[CreatedAt1], [t1].[CreatedBy0], [t1].[DeletedAt1], [t1].[Description0], [t1].[IsActive0], [t1].[LastModifiedAt1], [t1].[LastModifiedBy1], [t1].[Name], [t1].[Id2], [t1].[CreatedAt2], [t1].[CreatedBy1], [t1].[DeletedAt2], [t1].[Description1], [t1].[EndDate], [t1].[IsActive1], [t1].[LastModifiedAt2], [t1].[LastModifiedBy2], [t1].[Name0], [t1].[StartDate], [t2].[Id], [t2].[Content], [t2].[Context], [t2].[CreatedAt], [t2].[CreatedBy], [t2].[DeletedAt], [t2].[Description], [t2].[DocumentUrl], [t2].[EN_Title], [t2].[ExpectedOutcomes], [t2].[IsActive], [t2].[LastModifiedAt], [t2].[LastModifiedBy], [t2].[Methodology], [t2].[Objectives], [t2].[PotentialDuplicate], [t2].[Problem], [t2].[Requirements], [t2].[Status], [t2].[SubmittedAt], [t2].[SubmittedBy], [t2].[TopicId], [t2].[VN_title], [t2].[VersionNumber], [s0].[Id], [s0].[AdditionalNotes], [s0].[AiCheckDetails], [s0].[AiCheckScore], [s0].[AiCheckStatus], [s0].[CreatedAt], [s0].[CreatedBy], [s0].[DeletedAt], [s0].[DocumentUrl], [s0].[IsActive], [s0].[LastModifiedAt], [s0].[LastModifiedBy], [s0].[PhaseId], [s0].[Status], [s0].[SubmissionRound], [s0].[SubmittedAt], [s0].[SubmittedBy], [s0].[TopicId], [s0].[TopicVersionId]
+FROM (
+    SELECT TOP(1) [t].[Id], [t].[Abbreviation], [t].[CategoryId], [t].[Content], [t].[Context], [t].[CreatedAt], [t].[CreatedBy], [t].[DeletedAt], [t].[Description], [t].[EN_Title], [t].[IsActive], [t].[IsApproved], [t].[IsLegacy], [t].[LastModifiedAt], [t].[LastModifiedBy], [t].[MaxStudents], [t].[Objectives], [t].[PotentialDuplicate], [t].[Problem], [t].[SemesterId], [t].[SupervisorId], [t].[VN_title], [u].[Id] AS [Id0], [u].[AccessFailedCount], [u].[ConcurrencyStamp], [u].[CreatedAt] AS [CreatedAt0], [u].[DeletedAt] AS [DeletedAt0], [u].[Email], [u].[EmailConfirmed], [u].[LastModifiedAt] AS [LastModifiedAt0], [u].[LastModifiedBy] AS [LastModifiedBy0], [u].[LockoutEnabled], [u].[LockoutEnd], [u].[NormalizedEmail], [u].[NormalizedUserName], [u].[PasswordHash], [u].[PhoneNumber], [u].[PhoneNumberConfirmed], [u].[SecurityStamp], [u].[TwoFactorEnabled], [u].[UserName], [t0].[Id] AS [Id1], [t0].[CreatedAt] AS [CreatedAt1], [t0].[CreatedBy] AS [CreatedBy0], [t0].[DeletedAt] AS [DeletedAt1], [t0].[Description] AS [Description0], [t0].[IsActive] AS [IsActive0], [t0].[LastModifiedAt] AS [LastModifiedAt1], [t0].[LastModifiedBy] AS [LastModifiedBy1], [t0].[Name], [s].[Id] AS [Id2], [s].[CreatedAt] AS [CreatedAt2], [s].[CreatedBy] AS [CreatedBy1], [s].[DeletedAt] AS [DeletedAt2], [s].[Description] AS [Description1], [s].[EndDate], [s].[IsActive] AS [IsActive1], [s].[LastModifiedAt] AS [LastModifiedAt2], [s].[LastModifiedBy] AS [LastModifiedBy2], [s].[Name] AS [Name0], [s].[StartDate]
+    FROM [topics] AS [t]
+    INNER JOIN [users] AS [u] ON [t].[SupervisorId] = [u].[Id]
+    LEFT JOIN [topic_categories] AS [t0] ON [t].[CategoryId] = [t0].[Id]
+    INNER JOIN [semesters] AS [s] ON [t].[SemesterId] = [s].[Id]
+    WHERE [t].[Id] = @__topicId_0 AND [t].[IsActive] = CAST(1 AS bit) AND [t].[DeletedAt] IS NULL
+) AS [t1]
+LEFT JOIN [topic_versions] AS [t2] ON [t1].[Id] = [t2].[TopicId]
+LEFT JOIN [submissions] AS [s0] ON [t1].[Id] = [s0].[TopicId]
+ORDER BY [t1].[Id], [t1].[Id0], [t1].[Id1], [t1].[Id2], [t2].[Id]
+2025-09-29 01:50:24.758 +07:00 [DBG] Closing data reader to 'capbot_db' on server 'localhost'.
+2025-09-29 01:50:24.759 +07:00 [DBG] A data reader for 'capbot_db' on server 'localhost' is being disposed after spending 2ms reading results.
+2025-09-29 01:50:24.759 +07:00 [DBG] Closing connection to database 'capbot_db' on server 'localhost'.
+2025-09-29 01:50:24.759 +07:00 [DBG] Closed connection to database 'capbot_db' on server 'localhost' (0ms).
+2025-09-29 01:50:24.760 +07:00 [DBG] Compiling query expression: 
+'DbSet<EntityFile>()
+    .AsNoTracking()
+    .Include(x => x.File)
+    .Where(x => x.EntityId == __p_0 && (int)x.EntityType == 1 && x.IsPrimary)
+    .FirstOrDefault()'
+2025-09-29 01:50:24.762 +07:00 [DBG] Including navigation: 'EntityFile.File'.
+2025-09-29 01:50:24.767 +07:00 [DBG] Generated query execution expression: 
+'queryContext => ShapedQueryCompilingExpressionVisitor.SingleOrDefaultAsync<EntityFile>(
+    asyncEnumerable: new SingleQueryingEnumerable<EntityFile>(
+        (RelationalQueryContext)queryContext, 
+        RelationalCommandCache.QueryExpression(
+            Client Projections:
+                0 -> Dictionary<IProperty, int> { [Property: EntityFile.Id (long) Required PK AfterSave:Throw ValueGenerated.OnAdd, 0], [Property: EntityFile.Caption (string) MaxLength(512), 1], [Property: EntityFile.CreatedAt (DateTime) Required, 2], [Property: EntityFile.EntityId (long) Required Index, 3], [Property: EntityFile.EntityType (EntityType) Required Index, 4], [Property: EntityFile.FileId (long) Required FK Index, 5], [Property: EntityFile.IsPrimary (bool) Required, 6] }
+                1 -> Dictionary<IProperty, int> { [Property: AppFile.Id (long) Required PK AfterSave:Throw ValueGenerated.OnAdd, 7], [Property: AppFile.Alt (string) MaxLength(255), 8], [Property: AppFile.Checksum (string) MaxLength(128), 9], [Property: AppFile.CreatedAt (DateTime) Required, 10], [Property: AppFile.CreatedBy (string), 11], [Property: AppFile.DeletedAt (DateTime?), 12], [Property: AppFile.FileName (string) Required MaxLength(255), 13], [Property: AppFile.FilePath (string) Required MaxLength(1024), 14], [Property: AppFile.FileSize (long) Required, 15], [Property: AppFile.FileType (FileType) Required, 16], [Property: AppFile.Height (int?), 17], [Property: AppFile.IsActive (bool) Required, 18], [Property: AppFile.LastModifiedAt (DateTime?), 19], [Property: AppFile.LastModifiedBy (string), 20], [Property: AppFile.MimeType (string) MaxLength(255), 21], [Property: AppFile.ThumbnailUrl (string) MaxLength(2048), 22], [Property: AppFile.Url (string) Required MaxLength(2048), 23], [Property: AppFile.Width (int?), 24] }
+            SELECT TOP(1) e.Id, e.Caption, e.CreatedAt, e.EntityId, e.EntityType, e.FileId, e.IsPrimary, f.Id, f.Alt, f.Checksum, f.CreatedAt, f.CreatedBy, f.DeletedAt, f.FileName, f.FilePath, f.FileSize, f.FileType, f.Height, f.IsActive, f.LastModifiedAt, f.LastModifiedBy, f.MimeType, f.ThumbnailUrl, f.Url, f.Width
+            FROM entity_files AS e
+            INNER JOIN files AS f ON e.FileId == f.Id
+            WHERE ((e.EntityId == @__p_0) && (e.EntityType == 1)) && e.IsPrimary), 
+        null, 
+        Func<QueryContext, DbDataReader, ResultContext, SingleQueryResultCoordinator, EntityFile>, 
+        App.DAL.Context.MyDbContext, 
+        False, 
+        False, 
+        True
+    ), 
+    cancellationToken: queryContext.CancellationToken)'
+2025-09-29 01:50:24.767 +07:00 [DBG] Opening connection to database 'capbot_db' on server 'localhost'.
+2025-09-29 01:50:24.767 +07:00 [DBG] Opened connection to database 'capbot_db' on server 'localhost'.
+2025-09-29 01:50:24.767 +07:00 [DBG] Creating DbCommand for 'ExecuteReader'.
+2025-09-29 01:50:24.768 +07:00 [DBG] Created DbCommand for 'ExecuteReader' (0ms).
+2025-09-29 01:50:24.768 +07:00 [DBG] Initialized DbCommand for 'ExecuteReader' (0ms).
+2025-09-29 01:50:24.768 +07:00 [DBG] Executing DbCommand [Parameters=[@__p_0='?' (DbType = Int64)], CommandType='"Text"', CommandTimeout='30']
+SELECT TOP(1) [e].[Id], [e].[Caption], [e].[CreatedAt], [e].[EntityId], [e].[EntityType], [e].[FileId], [e].[IsPrimary], [f].[Id], [f].[Alt], [f].[Checksum], [f].[CreatedAt], [f].[CreatedBy], [f].[DeletedAt], [f].[FileName], [f].[FilePath], [f].[FileSize], [f].[FileType], [f].[Height], [f].[IsActive], [f].[LastModifiedAt], [f].[LastModifiedBy], [f].[MimeType], [f].[ThumbnailUrl], [f].[Url], [f].[Width]
+FROM [entity_files] AS [e]
+INNER JOIN [files] AS [f] ON [e].[FileId] = [f].[Id]
+WHERE [e].[EntityId] = @__p_0 AND [e].[EntityType] = 1 AND [e].[IsPrimary] = CAST(1 AS bit)
+2025-09-29 01:50:24.779 +07:00 [INF] Executed DbCommand (11ms) [Parameters=[@__p_0='?' (DbType = Int64)], CommandType='"Text"', CommandTimeout='30']
+SELECT TOP(1) [e].[Id], [e].[Caption], [e].[CreatedAt], [e].[EntityId], [e].[EntityType], [e].[FileId], [e].[IsPrimary], [f].[Id], [f].[Alt], [f].[Checksum], [f].[CreatedAt], [f].[CreatedBy], [f].[DeletedAt], [f].[FileName], [f].[FilePath], [f].[FileSize], [f].[FileType], [f].[Height], [f].[IsActive], [f].[LastModifiedAt], [f].[LastModifiedBy], [f].[MimeType], [f].[ThumbnailUrl], [f].[Url], [f].[Width]
+FROM [entity_files] AS [e]
+INNER JOIN [files] AS [f] ON [e].[FileId] = [f].[Id]
+WHERE [e].[EntityId] = @__p_0 AND [e].[EntityType] = 1 AND [e].[IsPrimary] = CAST(1 AS bit)
+2025-09-29 01:50:24.780 +07:00 [DBG] Closing data reader to 'capbot_db' on server 'localhost'.
+2025-09-29 01:50:24.780 +07:00 [DBG] A data reader for 'capbot_db' on server 'localhost' is being disposed after spending 0ms reading results.
+2025-09-29 01:50:24.780 +07:00 [DBG] Closing connection to database 'capbot_db' on server 'localhost'.
+2025-09-29 01:50:24.780 +07:00 [DBG] Closed connection to database 'capbot_db' on server 'localhost' (0ms).
+2025-09-29 01:50:24.788 +07:00 [DBG] List of registered output formatters, in the following order: ["Microsoft.AspNetCore.OData.Formatter.ODataOutputFormatter","Microsoft.AspNetCore.OData.Formatter.ODataOutputFormatter","Microsoft.AspNetCore.OData.Formatter.ODataOutputFormatter","Microsoft.AspNetCore.Mvc.Formatters.HttpNoContentOutputFormatter","Microsoft.AspNetCore.Mvc.Formatters.StringOutputFormatter","Microsoft.AspNetCore.Mvc.Formatters.StreamOutputFormatter","Microsoft.AspNetCore.Mvc.Formatters.SystemTextJsonOutputFormatter"]
+2025-09-29 01:50:24.788 +07:00 [DBG] No information found on request to perform content negotiation.
+2025-09-29 01:50:24.788 +07:00 [DBG] Attempting to select the first output formatter in the output formatters list which supports a content type from the explicitly specified content types '["application/json"]'.
+2025-09-29 01:50:24.788 +07:00 [DBG] Selected output formatter 'Microsoft.AspNetCore.Mvc.Formatters.SystemTextJsonOutputFormatter' and content type 'application/json' to write the response.
+2025-09-29 01:50:24.788 +07:00 [INF] Executing ObjectResult, writing value of type 'FS.Commons.FSResponse'.
+2025-09-29 01:50:24.808 +07:00 [INF] Executed action CapBot.api.Controllers.TopicController.GetDetail (CapBot.api) in 131.857ms
+2025-09-29 01:50:24.808 +07:00 [INF] Executed endpoint 'CapBot.api.Controllers.TopicController.GetDetail (CapBot.api)'
+2025-09-29 01:50:24.808 +07:00 [DBG] Connection id "0HNFUN9U1CO92" completed keep alive response.
+2025-09-29 01:50:24.808 +07:00 [DBG] 'MyDbContext' disposed.
+2025-09-29 01:50:24.808 +07:00 [DBG] Disposing connection to database 'capbot_db' on server 'localhost'.
+2025-09-29 01:50:24.808 +07:00 [DBG] Disposed connection to database '' on server '' (0ms).
+2025-09-29 01:50:24.808 +07:00 [INF] Request finished HTTP/1.1 GET http://localhost:5207/api/topic/detail/5 - 200 null application/json; charset=utf-8 145.9402ms
+2025-09-29 01:51:02.591 +07:00 [INF] Request starting HTTP/1.1 GET http://localhost:5207/api/topic/list - null null
+2025-09-29 01:51:02.594 +07:00 [DBG] The request path /api/topic/list does not match a supported file type
+2025-09-29 01:51:02.595 +07:00 [DBG] The request path /api/topic/list does not match a supported file type
+2025-09-29 01:51:02.597 +07:00 [DBG] 1 candidate(s) found for the request path '/api/topic/list'
+2025-09-29 01:51:02.597 +07:00 [DBG] Endpoint 'CapBot.api.Controllers.TopicController.GetTopicsWithPaging (CapBot.api)' with route pattern 'api/topic/list' is valid for the request path '/api/topic/list'
+2025-09-29 01:51:02.597 +07:00 [DBG] Request matched endpoint 'CapBot.api.Controllers.TopicController.GetTopicsWithPaging (CapBot.api)'
+2025-09-29 01:51:02.598 +07:00 [DBG] Successfully validated the token.
+2025-09-29 01:51:02.598 +07:00 [DBG] AuthenticationScheme: Bearer was successfully authenticated.
+2025-09-29 01:51:02.598 +07:00 [DBG] Authorization was successful.
+2025-09-29 01:51:02.598 +07:00 [INF] Executing endpoint 'CapBot.api.Controllers.TopicController.GetTopicsWithPaging (CapBot.api)'
+2025-09-29 01:51:02.604 +07:00 [INF] Route matched with {action = "GetTopicsWithPaging", controller = "Topic"}. Executing controller action with signature System.Threading.Tasks.Task`1[Microsoft.AspNetCore.Mvc.IActionResult] GetTopicsWithPaging(App.Entities.DTOs.Topics.GetTopicsQueryDTO) on controller CapBot.api.Controllers.TopicController (CapBot.api).
+2025-09-29 01:51:02.604 +07:00 [DBG] Execution plan of authorization filters (in the following order): ["None"]
+2025-09-29 01:51:02.604 +07:00 [DBG] Execution plan of resource filters (in the following order): ["Microsoft.AspNetCore.Mvc.ConsumesAttribute"]
+2025-09-29 01:51:02.604 +07:00 [DBG] Execution plan of action filters (in the following order): ["Microsoft.AspNetCore.Mvc.ModelBinding.UnsupportedContentTypeFilter (Order: -3000)"]
+2025-09-29 01:51:02.605 +07:00 [DBG] Execution plan of exception filters (in the following order): ["None"]
+2025-09-29 01:51:02.605 +07:00 [DBG] Execution plan of result filters (in the following order): ["Microsoft.AspNetCore.Mvc.Infrastructure.ClientErrorResultFilter (Order: -2000)","Microsoft.AspNetCore.Mvc.ProducesAttribute (Order: 0)"]
+2025-09-29 01:51:02.605 +07:00 [DBG] Executing controller factory for controller CapBot.api.Controllers.TopicController (CapBot.api)
+2025-09-29 01:51:02.605 +07:00 [DBG] Executed controller factory for controller CapBot.api.Controllers.TopicController (CapBot.api)
+2025-09-29 01:51:02.606 +07:00 [DBG] Attempting to bind parameter 'query' of type 'App.Entities.DTOs.Topics.GetTopicsQueryDTO' ...
+2025-09-29 01:51:02.606 +07:00 [DBG] Attempting to bind parameter 'query' of type 'App.Entities.DTOs.Topics.GetTopicsQueryDTO' using the name '' in request data ...
+2025-09-29 01:51:02.607 +07:00 [DBG] Attempting to bind property 'App.Entities.DTOs.Topics.GetTopicsQueryDTO.SemesterId' of type 'System.Nullable`1[System.Int32]' using the name 'SemesterId' in request data ...
+2025-09-29 01:51:02.607 +07:00 [DBG] Could not find a value in the request with name 'SemesterId' for binding property 'App.Entities.DTOs.Topics.GetTopicsQueryDTO.SemesterId' of type 'System.Nullable`1[System.Int32]'.
+2025-09-29 01:51:02.607 +07:00 [DBG] Done attempting to bind property 'App.Entities.DTOs.Topics.GetTopicsQueryDTO.SemesterId' of type 'System.Nullable`1[System.Int32]'.
+2025-09-29 01:51:02.607 +07:00 [DBG] Attempting to bind property 'App.Entities.DTOs.Topics.GetTopicsQueryDTO.CategoryId' of type 'System.Nullable`1[System.Int32]' using the name 'CategoryId' in request data ...
+2025-09-29 01:51:02.607 +07:00 [DBG] Could not find a value in the request with name 'CategoryId' for binding property 'App.Entities.DTOs.Topics.GetTopicsQueryDTO.CategoryId' of type 'System.Nullable`1[System.Int32]'.
+2025-09-29 01:51:02.607 +07:00 [DBG] Done attempting to bind property 'App.Entities.DTOs.Topics.GetTopicsQueryDTO.CategoryId' of type 'System.Nullable`1[System.Int32]'.
+2025-09-29 01:51:02.607 +07:00 [DBG] Attempting to bind property 'App.Entities.DTOs.Topics.GetTopicsQueryDTO.PageNumber' of type 'System.Int32' using the name 'PageNumber' in request data ...
+2025-09-29 01:51:02.607 +07:00 [DBG] Could not find a value in the request with name 'PageNumber' for binding property 'App.Entities.DTOs.Topics.GetTopicsQueryDTO.PageNumber' of type 'System.Int32'.
+2025-09-29 01:51:02.607 +07:00 [DBG] Done attempting to bind property 'App.Entities.DTOs.Topics.GetTopicsQueryDTO.PageNumber' of type 'System.Int32'.
+2025-09-29 01:51:02.607 +07:00 [DBG] Attempting to bind property 'App.Entities.DTOs.Topics.GetTopicsQueryDTO.PageSize' of type 'System.Int32' using the name 'PageSize' in request data ...
+2025-09-29 01:51:02.607 +07:00 [DBG] Could not find a value in the request with name 'PageSize' for binding property 'App.Entities.DTOs.Topics.GetTopicsQueryDTO.PageSize' of type 'System.Int32'.
+2025-09-29 01:51:02.607 +07:00 [DBG] Done attempting to bind property 'App.Entities.DTOs.Topics.GetTopicsQueryDTO.PageSize' of type 'System.Int32'.
+2025-09-29 01:51:02.607 +07:00 [DBG] Attempting to bind property 'App.Entities.DTOs.Topics.GetTopicsQueryDTO.Keyword' of type 'System.String' using the name 'Keyword' in request data ...
+2025-09-29 01:51:02.607 +07:00 [DBG] Could not find a value in the request with name 'Keyword' for binding property 'App.Entities.DTOs.Topics.GetTopicsQueryDTO.Keyword' of type 'System.String'.
+2025-09-29 01:51:02.607 +07:00 [DBG] Done attempting to bind property 'App.Entities.DTOs.Topics.GetTopicsQueryDTO.Keyword' of type 'System.String'.
+2025-09-29 01:51:02.608 +07:00 [DBG] Attempting to bind property 'App.Entities.DTOs.Topics.GetTopicsQueryDTO.TotalRecord' of type 'System.Int32' using the name 'TotalRecord' in request data ...
+2025-09-29 01:51:02.608 +07:00 [DBG] Could not find a value in the request with name 'TotalRecord' for binding property 'App.Entities.DTOs.Topics.GetTopicsQueryDTO.TotalRecord' of type 'System.Int32'.
+2025-09-29 01:51:02.608 +07:00 [DBG] Done attempting to bind property 'App.Entities.DTOs.Topics.GetTopicsQueryDTO.TotalRecord' of type 'System.Int32'.
+2025-09-29 01:51:02.608 +07:00 [DBG] Done attempting to bind parameter 'query' of type 'App.Entities.DTOs.Topics.GetTopicsQueryDTO'.
+2025-09-29 01:51:02.608 +07:00 [DBG] Done attempting to bind parameter 'query' of type 'App.Entities.DTOs.Topics.GetTopicsQueryDTO'.
+2025-09-29 01:51:02.608 +07:00 [DBG] Attempting to validate the bound parameter 'query' of type 'App.Entities.DTOs.Topics.GetTopicsQueryDTO' ...
+2025-09-29 01:51:02.609 +07:00 [DBG] Done attempting to validate the bound parameter 'query' of type 'App.Entities.DTOs.Topics.GetTopicsQueryDTO'.
+2025-09-29 01:51:02.611 +07:00 [DBG] Entity Framework Core 8.0.16 initialized 'MyDbContext' using provider 'Microsoft.EntityFrameworkCore.SqlServer:8.0.13' with options: MigrationsAssembly=App.DAL 
+2025-09-29 01:51:02.612 +07:00 [DBG] Compiling query expression: 
+'DbSet<Topic>()
+    .AsNoTracking()
+    .Include(x => x.Supervisor)
+    .Include(x => x.Category)
+    .Include(x => x.Semester)
+    .Include(x => x.Submissions)
+    .Include(x => x.TopicVersions)
+    .Where(x => x.IsActive && x.DeletedAt == null)
+    .Count()'
+2025-09-29 01:51:02.614 +07:00 [DBG] Generated query execution expression: 
+'queryContext => ShapedQueryCompilingExpressionVisitor.SingleAsync<int>(
+    asyncEnumerable: new SingleQueryingEnumerable<int>(
+        (RelationalQueryContext)queryContext, 
+        RelationalCommandCache.QueryExpression(
+            Projection Mapping:
+                EmptyProjectionMember -> 0
+            SELECT COUNT(*)
+            FROM topics AS t
+            WHERE t.IsActive && (t.DeletedAt == NULL)), 
+        null, 
+        Func<QueryContext, DbDataReader, ResultContext, SingleQueryResultCoordinator, int>, 
+        App.DAL.Context.MyDbContext, 
+        False, 
+        False, 
+        True
+    ), 
+    cancellationToken: queryContext.CancellationToken)'
+2025-09-29 01:51:02.615 +07:00 [DBG] Creating DbConnection.
+2025-09-29 01:51:02.615 +07:00 [DBG] Created DbConnection. (0ms).
+2025-09-29 01:51:02.615 +07:00 [DBG] Opening connection to database 'capbot_db' on server 'localhost'.
+2025-09-29 01:51:02.615 +07:00 [DBG] Opened connection to database 'capbot_db' on server 'localhost'.
+2025-09-29 01:51:02.615 +07:00 [DBG] Creating DbCommand for 'ExecuteReader'.
+2025-09-29 01:51:02.615 +07:00 [DBG] Created DbCommand for 'ExecuteReader' (0ms).
+2025-09-29 01:51:02.615 +07:00 [DBG] Initialized DbCommand for 'ExecuteReader' (0ms).
+2025-09-29 01:51:02.615 +07:00 [DBG] Executing DbCommand [Parameters=[], CommandType='"Text"', CommandTimeout='30']
+SELECT COUNT(*)
+FROM [topics] AS [t]
+WHERE [t].[IsActive] = CAST(1 AS bit) AND [t].[DeletedAt] IS NULL
+2025-09-29 01:51:02.619 +07:00 [INF] Executed DbCommand (4ms) [Parameters=[], CommandType='"Text"', CommandTimeout='30']
+SELECT COUNT(*)
+FROM [topics] AS [t]
+WHERE [t].[IsActive] = CAST(1 AS bit) AND [t].[DeletedAt] IS NULL
+2025-09-29 01:51:02.620 +07:00 [DBG] Closing data reader to 'capbot_db' on server 'localhost'.
+2025-09-29 01:51:02.620 +07:00 [DBG] A data reader for 'capbot_db' on server 'localhost' is being disposed after spending 0ms reading results.
+2025-09-29 01:51:02.620 +07:00 [DBG] Closing connection to database 'capbot_db' on server 'localhost'.
+2025-09-29 01:51:02.620 +07:00 [DBG] Closed connection to database 'capbot_db' on server 'localhost' (0ms).
+2025-09-29 01:51:02.621 +07:00 [DBG] Compiling query expression: 
+'DbSet<Topic>()
+    .AsNoTracking()
+    .Include(x => x.Supervisor)
+    .Include(x => x.Category)
+    .Include(x => x.Semester)
+    .Include(x => x.Submissions)
+    .Include(x => x.TopicVersions)
+    .Where(x => x.IsActive && x.DeletedAt == null)
+    .OrderByDescending(x => x.CreatedAt)
+    .Skip(__p_0)
+    .Take(__p_0)'
+2025-09-29 01:51:02.622 +07:00 [DBG] Including navigation: 'Topic.Supervisor'.
+2025-09-29 01:51:02.622 +07:00 [DBG] Including navigation: 'Topic.Category'.
+2025-09-29 01:51:02.622 +07:00 [DBG] Including navigation: 'Topic.Semester'.
+2025-09-29 01:51:02.622 +07:00 [DBG] Including navigation: 'Topic.Submissions'.
+2025-09-29 01:51:02.622 +07:00 [DBG] Including navigation: 'Topic.TopicVersions'.
+2025-09-29 01:51:02.632 +07:00 [WRN] Compiling a query which loads related collections for more than one collection navigation, either via 'Include' or through projection, but no 'QuerySplittingBehavior' has been configured. By default, Entity Framework will use 'QuerySplittingBehavior.SingleQuery', which can potentially result in slow query performance. See https://go.microsoft.com/fwlink/?linkid=2134277 for more information. To identify the query that's triggering this warning call 'ConfigureWarnings(w => w.Throw(RelationalEventId.MultipleCollectionIncludeWarning))'.
+2025-09-29 01:51:02.639 +07:00 [DBG] Generated query execution expression: 
+'queryContext => new SingleQueryingEnumerable<Topic>(
+    (RelationalQueryContext)queryContext, 
+    RelationalCommandCache.QueryExpression(
+        Client Projections:
+            0 -> Dictionary<IProperty, int> { [Property: Topic.Id (int) Required PK AfterSave:Throw ValueGenerated.OnAdd, 0], [Property: Topic.Abbreviation (string), 1], [Property: Topic.CategoryId (int?) FK Index, 2], [Property: Topic.Content (string), 3], [Property: Topic.Context (string), 4], [Property: Topic.CreatedAt (DateTime) Required ValueGenerated.OnAdd, 5], [Property: Topic.CreatedBy (string), 6], [Property: Topic.DeletedAt (DateTime?), 7], [Property: Topic.Description (string), 8], [Property: Topic.EN_Title (string) Required MaxLength(500), 9], [Property: Topic.IsActive (bool) Required, 10], [Property: Topic.IsApproved (bool) Required Index Sentinel:True ValueGenerated.OnAdd, 11], [Property: Topic.IsLegacy (bool) Required Index ValueGenerated.OnAdd, 12], [Property: Topic.LastModifiedAt (DateTime?), 13], [Property: Topic.LastModifiedBy (string), 14], [Property: Topic.MaxStudents (int) Required ValueGenerated.OnAdd, 15], [Property: Topic.Objectives (string), 16], [Property: Topic.PotentialDuplicate (string), 17], [Property: Topic.Problem (string), 18], [Property: Topic.SemesterId (int) Required FK Index, 19], [Property: Topic.SupervisorId (int) Required FK Index, 20], [Property: Topic.VN_title (string), 21] }
+            1 -> Dictionary<IProperty, int> { [Property: User.Id (int) Required PK AfterSave:Throw ValueGenerated.OnAdd, 22], [Property: User.AccessFailedCount (int) Required, 23], [Property: User.ConcurrencyStamp (string), 24], [Property: User.CreatedAt (DateTime) Required, 25], [Property: User.DeletedAt (DateTime?), 26], [Property: User.Email (string), 27], [Property: User.EmailConfirmed (bool) Required, 28], [Property: User.LastModifiedAt (DateTime) Required, 29], [Property: User.LastModifiedBy (string), 30], [Property: User.LockoutEnabled (bool) Required, 31], [Property: User.LockoutEnd (DateTimeOffset?), 32], [Property: User.NormalizedEmail (string), 33], [Property: User.NormalizedUserName (string), 34], [Property: User.PasswordHash (string), 35], [Property: User.PhoneNumber (string), 36], [Property: User.PhoneNumberConfirmed (bool) Required, 37], [Property: User.SecurityStamp (string), 38], [Property: User.TwoFactorEnabled (bool) Required, 39], [Property: User.UserName (string), 40] }
+            2 -> Dictionary<IProperty, int> { [Property: TopicCategory.Id (int) Required PK AfterSave:Throw ValueGenerated.OnAdd, 41], [Property: TopicCategory.CreatedAt (DateTime) Required ValueGenerated.OnAdd, 42], [Property: TopicCategory.CreatedBy (string), 43], [Property: TopicCategory.DeletedAt (DateTime?), 44], [Property: TopicCategory.Description (string), 45], [Property: TopicCategory.IsActive (bool) Required, 46], [Property: TopicCategory.LastModifiedAt (DateTime?), 47], [Property: TopicCategory.LastModifiedBy (string), 48], [Property: TopicCategory.Name (string) Required MaxLength(100), 49] }
+            3 -> Dictionary<IProperty, int> { [Property: Semester.Id (int) Required PK AfterSave:Throw ValueGenerated.OnAdd, 50], [Property: Semester.CreatedAt (DateTime) Required, 51], [Property: Semester.CreatedBy (string), 52], [Property: Semester.DeletedAt (DateTime?), 53], [Property: Semester.Description (string), 54], [Property: Semester.EndDate (DateTime) Required, 55], [Property: Semester.IsActive (bool) Required, 56], [Property: Semester.LastModifiedAt (DateTime?), 57], [Property: Semester.LastModifiedBy (string), 58], [Property: Semester.Name (string) Required Index MaxLength(50), 59], [Property: Semester.StartDate (DateTime) Required, 60] }
+            4 -> 0
+            5 -> 22
+            6 -> 41
+            7 -> 50
+            8 -> Dictionary<IProperty, int> { [Property: Submission.Id (int) Required PK AfterSave:Throw ValueGenerated.OnAdd, 61], [Property: Submission.AdditionalNotes (string), 62], [Property: Submission.AiCheckDetails (string), 63], [Property: Submission.AiCheckScore (decimal?), 64], [Property: Submission.AiCheckStatus (AiCheckStatus) Required ValueGenerated.OnAdd, 65], [Property: Submission.CreatedAt (DateTime) Required, 66], [Property: Submission.CreatedBy (string), 67], [Property: Submission.DeletedAt (DateTime?), 68], [Property: Submission.DocumentUrl (string) MaxLength(500), 69], [Property: Submission.IsActive (bool) Required, 70], [Property: Submission.LastModifiedAt (DateTime?), 71], [Property: Submission.LastModifiedBy (string), 72], [Property: Submission.PhaseId (int) Required FK Index, 73], [Property: Submission.Status (SubmissionStatus) Required Index ValueGenerated.OnAdd, 74], [Property: Submission.SubmissionRound (int) Required Index ValueGenerated.OnAdd, 75], [Property: Submission.SubmittedAt (DateTime?) Index ValueGenerated.OnAdd, 76], [Property: Submission.SubmittedBy (int) Required FK Index, 77], [Property: Submission.TopicId (int) Required FK Index, 78], [Property: Submission.TopicVersionId (int?) FK Index, 79] }
+            9 -> 61
+            10 -> Dictionary<IProperty, int> { [Property: TopicVersion.Id (int) Required PK AfterSave:Throw ValueGenerated.OnAdd, 80], [Property: TopicVersion.Content (string), 81], [Property: TopicVersion.Context (string), 82], [Property: TopicVersion.CreatedAt (DateTime) Required ValueGenerated.OnAdd, 83], [Property: TopicVersion.CreatedBy (string), 84], [Property: TopicVersion.DeletedAt (DateTime?), 85], [Property: TopicVersion.Description (string), 86], [Property: TopicVersion.DocumentUrl (string) MaxLength(500), 87], [Property: TopicVersion.EN_Title (string) Required MaxLength(500), 88], [Property: TopicVersion.ExpectedOutcomes (string), 89], [Property: TopicVersion.IsActive (bool) Required, 90], [Property: TopicVersion.LastModifiedAt (DateTime?), 91], [Property: TopicVersion.LastModifiedBy (string), 92], [Property: TopicVersion.Methodology (string), 93], [Property: TopicVersion.Objectives (string), 94], [Property: TopicVersion.PotentialDuplicate (string), 95], [Property: TopicVersion.Problem (string), 96], [Property: TopicVersion.Requirements (string), 97], [Property: TopicVersion.Status (TopicStatus) Required Index ValueGenerated.OnAdd, 98], [Property: TopicVersion.SubmittedAt (DateTime?), 99], [Property: TopicVersion.SubmittedBy (int?) FK Index, 100], [Property: TopicVersion.TopicId (int) Required FK Index, 101], [Property: TopicVersion.VN_title (string), 102], [Property: TopicVersion.VersionNumber (int) Required Index, 103] }
+            11 -> 80
+        SELECT t0.Id, t0.Abbreviation, t0.CategoryId, t0.Content, t0.Context, t0.CreatedAt, t0.CreatedBy, t0.DeletedAt, t0.Description, t0.EN_Title, t0.IsActive, t0.IsApproved, t0.IsLegacy, t0.LastModifiedAt, t0.LastModifiedBy, t0.MaxStudents, t0.Objectives, t0.PotentialDuplicate, t0.Problem, t0.SemesterId, t0.SupervisorId, t0.VN_title, u.Id, u.AccessFailedCount, u.ConcurrencyStamp, u.CreatedAt, u.DeletedAt, u.Email, u.EmailConfirmed, u.LastModifiedAt, u.LastModifiedBy, u.LockoutEnabled, u.LockoutEnd, u.NormalizedEmail, u.NormalizedUserName, u.PasswordHash, u.PhoneNumber, u.PhoneNumberConfirmed, u.SecurityStamp, u.TwoFactorEnabled, u.UserName, t1.Id, t1.CreatedAt, t1.CreatedBy, t1.DeletedAt, t1.Description, t1.IsActive, t1.LastModifiedAt, t1.LastModifiedBy, t1.Name, s.Id, s.CreatedAt, s.CreatedBy, s.DeletedAt, s.Description, s.EndDate, s.IsActive, s.LastModifiedAt, s.LastModifiedBy, s.Name, s.StartDate, s0.Id, s0.AdditionalNotes, s0.AiCheckDetails, s0.AiCheckScore, s0.AiCheckStatus, s0.CreatedAt, s0.CreatedBy, s0.DeletedAt, s0.DocumentUrl, s0.IsActive, s0.LastModifiedAt, s0.LastModifiedBy, s0.PhaseId, s0.Status, s0.SubmissionRound, s0.SubmittedAt, s0.SubmittedBy, s0.TopicId, s0.TopicVersionId, t2.Id, t2.Content, t2.Context, t2.CreatedAt, t2.CreatedBy, t2.DeletedAt, t2.Description, t2.DocumentUrl, t2.EN_Title, t2.ExpectedOutcomes, t2.IsActive, t2.LastModifiedAt, t2.LastModifiedBy, t2.Methodology, t2.Objectives, t2.PotentialDuplicate, t2.Problem, t2.Requirements, t2.Status, t2.SubmittedAt, t2.SubmittedBy, t2.TopicId, t2.VN_title, t2.VersionNumber
+        FROM 
+        (
+            SELECT t.Id, t.Abbreviation, t.CategoryId, t.Content, t.Context, t.CreatedAt, t.CreatedBy, t.DeletedAt, t.Description, t.EN_Title, t.IsActive, t.IsApproved, t.IsLegacy, t.LastModifiedAt, t.LastModifiedBy, t.MaxStudents, t.Objectives, t.PotentialDuplicate, t.Problem, t.SemesterId, t.SupervisorId, t.VN_title
+            FROM topics AS t
+            WHERE t.IsActive && (t.DeletedAt == NULL)
+            ORDER BY t.CreatedAt DESC
+            OFFSET @__p_0 ROWS FETCH NEXT @__p_0 ROWS ONLY
+        ) AS t0
+        INNER JOIN users AS u ON t0.SupervisorId == u.Id
+        LEFT JOIN topic_categories AS t1 ON t0.CategoryId == t1.Id
+        INNER JOIN semesters AS s ON t0.SemesterId == s.Id
+        LEFT JOIN submissions AS s0 ON t0.Id == s0.TopicId
+        LEFT JOIN topic_versions AS t2 ON t0.Id == t2.TopicId
+        ORDER BY t0.CreatedAt DESC, t0.Id ASC, u.Id ASC, t1.Id ASC, s.Id ASC, s0.Id ASC), 
+    null, 
+    Func<QueryContext, DbDataReader, ResultContext, SingleQueryResultCoordinator, Topic>, 
+    App.DAL.Context.MyDbContext, 
+    False, 
+    False, 
+    True
+)'
+2025-09-29 01:51:02.645 +07:00 [DBG] Opening connection to database 'capbot_db' on server 'localhost'.
+2025-09-29 01:51:02.645 +07:00 [DBG] Opened connection to database 'capbot_db' on server 'localhost'.
+2025-09-29 01:51:02.645 +07:00 [DBG] Creating DbCommand for 'ExecuteReader'.
+2025-09-29 01:51:02.645 +07:00 [DBG] Created DbCommand for 'ExecuteReader' (0ms).
+2025-09-29 01:51:02.645 +07:00 [DBG] Initialized DbCommand for 'ExecuteReader' (0ms).
+2025-09-29 01:51:02.645 +07:00 [DBG] Executing DbCommand [Parameters=[], CommandType='"Text"', CommandTimeout='30']
+SELECT [t0].[Id], [t0].[Abbreviation], [t0].[CategoryId], [t0].[Content], [t0].[Context], [t0].[CreatedAt], [t0].[CreatedBy], [t0].[DeletedAt], [t0].[Description], [t0].[EN_Title], [t0].[IsActive], [t0].[IsApproved], [t0].[IsLegacy], [t0].[LastModifiedAt], [t0].[LastModifiedBy], [t0].[MaxStudents], [t0].[Objectives], [t0].[PotentialDuplicate], [t0].[Problem], [t0].[SemesterId], [t0].[SupervisorId], [t0].[VN_title], [u].[Id], [u].[AccessFailedCount], [u].[ConcurrencyStamp], [u].[CreatedAt], [u].[DeletedAt], [u].[Email], [u].[EmailConfirmed], [u].[LastModifiedAt], [u].[LastModifiedBy], [u].[LockoutEnabled], [u].[LockoutEnd], [u].[NormalizedEmail], [u].[NormalizedUserName], [u].[PasswordHash], [u].[PhoneNumber], [u].[PhoneNumberConfirmed], [u].[SecurityStamp], [u].[TwoFactorEnabled], [u].[UserName], [t1].[Id], [t1].[CreatedAt], [t1].[CreatedBy], [t1].[DeletedAt], [t1].[Description], [t1].[IsActive], [t1].[LastModifiedAt], [t1].[LastModifiedBy], [t1].[Name], [s].[Id], [s].[CreatedAt], [s].[CreatedBy], [s].[DeletedAt], [s].[Description], [s].[EndDate], [s].[IsActive], [s].[LastModifiedAt], [s].[LastModifiedBy], [s].[Name], [s].[StartDate], [s0].[Id], [s0].[AdditionalNotes], [s0].[AiCheckDetails], [s0].[AiCheckScore], [s0].[AiCheckStatus], [s0].[CreatedAt], [s0].[CreatedBy], [s0].[DeletedAt], [s0].[DocumentUrl], [s0].[IsActive], [s0].[LastModifiedAt], [s0].[LastModifiedBy], [s0].[PhaseId], [s0].[Status], [s0].[SubmissionRound], [s0].[SubmittedAt], [s0].[SubmittedBy], [s0].[TopicId], [s0].[TopicVersionId], [t2].[Id], [t2].[Content], [t2].[Context], [t2].[CreatedAt], [t2].[CreatedBy], [t2].[DeletedAt], [t2].[Description], [t2].[DocumentUrl], [t2].[EN_Title], [t2].[ExpectedOutcomes], [t2].[IsActive], [t2].[LastModifiedAt], [t2].[LastModifiedBy], [t2].[Methodology], [t2].[Objectives], [t2].[PotentialDuplicate], [t2].[Problem], [t2].[Requirements], [t2].[Status], [t2].[SubmittedAt], [t2].[SubmittedBy], [t2].[TopicId], [t2].[VN_title], [t2].[VersionNumber]
+FROM (
+    SELECT [t].[Id], [t].[Abbreviation], [t].[CategoryId], [t].[Content], [t].[Context], [t].[CreatedAt], [t].[CreatedBy], [t].[DeletedAt], [t].[Description], [t].[EN_Title], [t].[IsActive], [t].[IsApproved], [t].[IsLegacy], [t].[LastModifiedAt], [t].[LastModifiedBy], [t].[MaxStudents], [t].[Objectives], [t].[PotentialDuplicate], [t].[Problem], [t].[SemesterId], [t].[SupervisorId], [t].[VN_title]
+    FROM [topics] AS [t]
+    WHERE 0 = 1
+) AS [t0]
+INNER JOIN [users] AS [u] ON [t0].[SupervisorId] = [u].[Id]
+LEFT JOIN [topic_categories] AS [t1] ON [t0].[CategoryId] = [t1].[Id]
+INNER JOIN [semesters] AS [s] ON [t0].[SemesterId] = [s].[Id]
+LEFT JOIN [submissions] AS [s0] ON [t0].[Id] = [s0].[TopicId]
+LEFT JOIN [topic_versions] AS [t2] ON [t0].[Id] = [t2].[TopicId]
+ORDER BY [t0].[CreatedAt] DESC, [t0].[Id], [u].[Id], [t1].[Id], [s].[Id], [s0].[Id]
+2025-09-29 01:51:02.654 +07:00 [INF] Executed DbCommand (10ms) [Parameters=[], CommandType='"Text"', CommandTimeout='30']
+SELECT [t0].[Id], [t0].[Abbreviation], [t0].[CategoryId], [t0].[Content], [t0].[Context], [t0].[CreatedAt], [t0].[CreatedBy], [t0].[DeletedAt], [t0].[Description], [t0].[EN_Title], [t0].[IsActive], [t0].[IsApproved], [t0].[IsLegacy], [t0].[LastModifiedAt], [t0].[LastModifiedBy], [t0].[MaxStudents], [t0].[Objectives], [t0].[PotentialDuplicate], [t0].[Problem], [t0].[SemesterId], [t0].[SupervisorId], [t0].[VN_title], [u].[Id], [u].[AccessFailedCount], [u].[ConcurrencyStamp], [u].[CreatedAt], [u].[DeletedAt], [u].[Email], [u].[EmailConfirmed], [u].[LastModifiedAt], [u].[LastModifiedBy], [u].[LockoutEnabled], [u].[LockoutEnd], [u].[NormalizedEmail], [u].[NormalizedUserName], [u].[PasswordHash], [u].[PhoneNumber], [u].[PhoneNumberConfirmed], [u].[SecurityStamp], [u].[TwoFactorEnabled], [u].[UserName], [t1].[Id], [t1].[CreatedAt], [t1].[CreatedBy], [t1].[DeletedAt], [t1].[Description], [t1].[IsActive], [t1].[LastModifiedAt], [t1].[LastModifiedBy], [t1].[Name], [s].[Id], [s].[CreatedAt], [s].[CreatedBy], [s].[DeletedAt], [s].[Description], [s].[EndDate], [s].[IsActive], [s].[LastModifiedAt], [s].[LastModifiedBy], [s].[Name], [s].[StartDate], [s0].[Id], [s0].[AdditionalNotes], [s0].[AiCheckDetails], [s0].[AiCheckScore], [s0].[AiCheckStatus], [s0].[CreatedAt], [s0].[CreatedBy], [s0].[DeletedAt], [s0].[DocumentUrl], [s0].[IsActive], [s0].[LastModifiedAt], [s0].[LastModifiedBy], [s0].[PhaseId], [s0].[Status], [s0].[SubmissionRound], [s0].[SubmittedAt], [s0].[SubmittedBy], [s0].[TopicId], [s0].[TopicVersionId], [t2].[Id], [t2].[Content], [t2].[Context], [t2].[CreatedAt], [t2].[CreatedBy], [t2].[DeletedAt], [t2].[Description], [t2].[DocumentUrl], [t2].[EN_Title], [t2].[ExpectedOutcomes], [t2].[IsActive], [t2].[LastModifiedAt], [t2].[LastModifiedBy], [t2].[Methodology], [t2].[Objectives], [t2].[PotentialDuplicate], [t2].[Problem], [t2].[Requirements], [t2].[Status], [t2].[SubmittedAt], [t2].[SubmittedBy], [t2].[TopicId], [t2].[VN_title], [t2].[VersionNumber]
+FROM (
+    SELECT [t].[Id], [t].[Abbreviation], [t].[CategoryId], [t].[Content], [t].[Context], [t].[CreatedAt], [t].[CreatedBy], [t].[DeletedAt], [t].[Description], [t].[EN_Title], [t].[IsActive], [t].[IsApproved], [t].[IsLegacy], [t].[LastModifiedAt], [t].[LastModifiedBy], [t].[MaxStudents], [t].[Objectives], [t].[PotentialDuplicate], [t].[Problem], [t].[SemesterId], [t].[SupervisorId], [t].[VN_title]
+    FROM [topics] AS [t]
+    WHERE 0 = 1
+) AS [t0]
+INNER JOIN [users] AS [u] ON [t0].[SupervisorId] = [u].[Id]
+LEFT JOIN [topic_categories] AS [t1] ON [t0].[CategoryId] = [t1].[Id]
+INNER JOIN [semesters] AS [s] ON [t0].[SemesterId] = [s].[Id]
+LEFT JOIN [submissions] AS [s0] ON [t0].[Id] = [s0].[TopicId]
+LEFT JOIN [topic_versions] AS [t2] ON [t0].[Id] = [t2].[TopicId]
+ORDER BY [t0].[CreatedAt] DESC, [t0].[Id], [u].[Id], [t1].[Id], [s].[Id], [s0].[Id]
+2025-09-29 01:51:02.655 +07:00 [DBG] Closing data reader to 'capbot_db' on server 'localhost'.
+2025-09-29 01:51:02.655 +07:00 [DBG] A data reader for 'capbot_db' on server 'localhost' is being disposed after spending 0ms reading results.
+2025-09-29 01:51:02.655 +07:00 [DBG] Closing connection to database 'capbot_db' on server 'localhost'.
+2025-09-29 01:51:02.655 +07:00 [DBG] Closed connection to database 'capbot_db' on server 'localhost' (0ms).
+2025-09-29 01:51:02.656 +07:00 [DBG] List of registered output formatters, in the following order: ["Microsoft.AspNetCore.OData.Formatter.ODataOutputFormatter","Microsoft.AspNetCore.OData.Formatter.ODataOutputFormatter","Microsoft.AspNetCore.OData.Formatter.ODataOutputFormatter","Microsoft.AspNetCore.Mvc.Formatters.HttpNoContentOutputFormatter","Microsoft.AspNetCore.Mvc.Formatters.StringOutputFormatter","Microsoft.AspNetCore.Mvc.Formatters.StreamOutputFormatter","Microsoft.AspNetCore.Mvc.Formatters.SystemTextJsonOutputFormatter"]
+2025-09-29 01:51:02.656 +07:00 [DBG] No information found on request to perform content negotiation.
+2025-09-29 01:51:02.656 +07:00 [DBG] Attempting to select the first output formatter in the output formatters list which supports a content type from the explicitly specified content types '["application/json"]'.
+2025-09-29 01:51:02.656 +07:00 [DBG] Selected output formatter 'Microsoft.AspNetCore.Mvc.Formatters.SystemTextJsonOutputFormatter' and content type 'application/json' to write the response.
+2025-09-29 01:51:02.656 +07:00 [INF] Executing ObjectResult, writing value of type 'FS.Commons.FSResponse'.
+2025-09-29 01:51:02.660 +07:00 [INF] Executed action CapBot.api.Controllers.TopicController.GetTopicsWithPaging (CapBot.api) in 55.6087ms
+2025-09-29 01:51:02.660 +07:00 [INF] Executed endpoint 'CapBot.api.Controllers.TopicController.GetTopicsWithPaging (CapBot.api)'
+2025-09-29 01:51:02.660 +07:00 [DBG] Connection id "0HNFUN9U1CO92" completed keep alive response.
+2025-09-29 01:51:02.660 +07:00 [DBG] 'MyDbContext' disposed.
+2025-09-29 01:51:02.660 +07:00 [DBG] Disposing connection to database 'capbot_db' on server 'localhost'.
+2025-09-29 01:51:02.660 +07:00 [DBG] Disposed connection to database '' on server '' (0ms).
+2025-09-29 01:51:02.660 +07:00 [INF] Request finished HTTP/1.1 GET http://localhost:5207/api/topic/list - 200 null application/json; charset=utf-8 69.9711ms
+2025-09-29 01:51:10.700 +07:00 [INF] Request starting HTTP/1.1 GET http://localhost:5207/api/topic/list?PageNumber=1&PageSize=111 - null null
+2025-09-29 01:51:10.700 +07:00 [DBG] The request path /api/topic/list does not match a supported file type
+2025-09-29 01:51:10.700 +07:00 [DBG] The request path /api/topic/list does not match a supported file type
+2025-09-29 01:51:10.700 +07:00 [DBG] 1 candidate(s) found for the request path '/api/topic/list'
+2025-09-29 01:51:10.701 +07:00 [DBG] Endpoint 'CapBot.api.Controllers.TopicController.GetTopicsWithPaging (CapBot.api)' with route pattern 'api/topic/list' is valid for the request path '/api/topic/list'
+2025-09-29 01:51:10.701 +07:00 [DBG] Request matched endpoint 'CapBot.api.Controllers.TopicController.GetTopicsWithPaging (CapBot.api)'
+2025-09-29 01:51:10.702 +07:00 [DBG] Successfully validated the token.
+2025-09-29 01:51:10.702 +07:00 [DBG] AuthenticationScheme: Bearer was successfully authenticated.
+2025-09-29 01:51:10.702 +07:00 [DBG] Authorization was successful.
+2025-09-29 01:51:10.702 +07:00 [INF] Executing endpoint 'CapBot.api.Controllers.TopicController.GetTopicsWithPaging (CapBot.api)'
+2025-09-29 01:51:10.702 +07:00 [INF] Route matched with {action = "GetTopicsWithPaging", controller = "Topic"}. Executing controller action with signature System.Threading.Tasks.Task`1[Microsoft.AspNetCore.Mvc.IActionResult] GetTopicsWithPaging(App.Entities.DTOs.Topics.GetTopicsQueryDTO) on controller CapBot.api.Controllers.TopicController (CapBot.api).
+2025-09-29 01:51:10.702 +07:00 [DBG] Execution plan of authorization filters (in the following order): ["None"]
+2025-09-29 01:51:10.702 +07:00 [DBG] Execution plan of resource filters (in the following order): ["Microsoft.AspNetCore.Mvc.ConsumesAttribute"]
+2025-09-29 01:51:10.702 +07:00 [DBG] Execution plan of action filters (in the following order): ["Microsoft.AspNetCore.Mvc.ModelBinding.UnsupportedContentTypeFilter (Order: -3000)"]
+2025-09-29 01:51:10.702 +07:00 [DBG] Execution plan of exception filters (in the following order): ["None"]
+2025-09-29 01:51:10.702 +07:00 [DBG] Execution plan of result filters (in the following order): ["Microsoft.AspNetCore.Mvc.Infrastructure.ClientErrorResultFilter (Order: -2000)","Microsoft.AspNetCore.Mvc.ProducesAttribute (Order: 0)"]
+2025-09-29 01:51:10.703 +07:00 [DBG] Executing controller factory for controller CapBot.api.Controllers.TopicController (CapBot.api)
+2025-09-29 01:51:10.714 +07:00 [DBG] Executed controller factory for controller CapBot.api.Controllers.TopicController (CapBot.api)
+2025-09-29 01:51:10.715 +07:00 [DBG] Attempting to bind parameter 'query' of type 'App.Entities.DTOs.Topics.GetTopicsQueryDTO' ...
+2025-09-29 01:51:10.715 +07:00 [DBG] Attempting to bind parameter 'query' of type 'App.Entities.DTOs.Topics.GetTopicsQueryDTO' using the name '' in request data ...
+2025-09-29 01:51:10.715 +07:00 [DBG] Attempting to bind property 'App.Entities.DTOs.Topics.GetTopicsQueryDTO.SemesterId' of type 'System.Nullable`1[System.Int32]' using the name 'SemesterId' in request data ...
+2025-09-29 01:51:10.716 +07:00 [DBG] Could not find a value in the request with name 'SemesterId' for binding property 'App.Entities.DTOs.Topics.GetTopicsQueryDTO.SemesterId' of type 'System.Nullable`1[System.Int32]'.
+2025-09-29 01:51:10.716 +07:00 [DBG] Done attempting to bind property 'App.Entities.DTOs.Topics.GetTopicsQueryDTO.SemesterId' of type 'System.Nullable`1[System.Int32]'.
+2025-09-29 01:51:10.716 +07:00 [DBG] Attempting to bind property 'App.Entities.DTOs.Topics.GetTopicsQueryDTO.CategoryId' of type 'System.Nullable`1[System.Int32]' using the name 'CategoryId' in request data ...
+2025-09-29 01:51:10.716 +07:00 [DBG] Could not find a value in the request with name 'CategoryId' for binding property 'App.Entities.DTOs.Topics.GetTopicsQueryDTO.CategoryId' of type 'System.Nullable`1[System.Int32]'.
+2025-09-29 01:51:10.716 +07:00 [DBG] Done attempting to bind property 'App.Entities.DTOs.Topics.GetTopicsQueryDTO.CategoryId' of type 'System.Nullable`1[System.Int32]'.
+2025-09-29 01:51:10.716 +07:00 [DBG] Attempting to bind property 'App.Entities.DTOs.Topics.GetTopicsQueryDTO.PageNumber' of type 'System.Int32' using the name 'PageNumber' in request data ...
+2025-09-29 01:51:10.716 +07:00 [DBG] Done attempting to bind property 'App.Entities.DTOs.Topics.GetTopicsQueryDTO.PageNumber' of type 'System.Int32'.
+2025-09-29 01:51:10.716 +07:00 [DBG] Attempting to bind property 'App.Entities.DTOs.Topics.GetTopicsQueryDTO.PageSize' of type 'System.Int32' using the name 'PageSize' in request data ...
+2025-09-29 01:51:10.716 +07:00 [DBG] Done attempting to bind property 'App.Entities.DTOs.Topics.GetTopicsQueryDTO.PageSize' of type 'System.Int32'.
+2025-09-29 01:51:10.716 +07:00 [DBG] Attempting to bind property 'App.Entities.DTOs.Topics.GetTopicsQueryDTO.Keyword' of type 'System.String' using the name 'Keyword' in request data ...
+2025-09-29 01:51:10.716 +07:00 [DBG] Could not find a value in the request with name 'Keyword' for binding property 'App.Entities.DTOs.Topics.GetTopicsQueryDTO.Keyword' of type 'System.String'.
+2025-09-29 01:51:10.716 +07:00 [DBG] Done attempting to bind property 'App.Entities.DTOs.Topics.GetTopicsQueryDTO.Keyword' of type 'System.String'.
+2025-09-29 01:51:10.716 +07:00 [DBG] Attempting to bind property 'App.Entities.DTOs.Topics.GetTopicsQueryDTO.TotalRecord' of type 'System.Int32' using the name 'TotalRecord' in request data ...
+2025-09-29 01:51:10.716 +07:00 [DBG] Could not find a value in the request with name 'TotalRecord' for binding property 'App.Entities.DTOs.Topics.GetTopicsQueryDTO.TotalRecord' of type 'System.Int32'.
+2025-09-29 01:51:10.717 +07:00 [DBG] Done attempting to bind property 'App.Entities.DTOs.Topics.GetTopicsQueryDTO.TotalRecord' of type 'System.Int32'.
+2025-09-29 01:51:10.717 +07:00 [DBG] Done attempting to bind parameter 'query' of type 'App.Entities.DTOs.Topics.GetTopicsQueryDTO'.
+2025-09-29 01:51:10.717 +07:00 [DBG] Done attempting to bind parameter 'query' of type 'App.Entities.DTOs.Topics.GetTopicsQueryDTO'.
+2025-09-29 01:51:10.717 +07:00 [DBG] Attempting to validate the bound parameter 'query' of type 'App.Entities.DTOs.Topics.GetTopicsQueryDTO' ...
+2025-09-29 01:51:10.717 +07:00 [DBG] Done attempting to validate the bound parameter 'query' of type 'App.Entities.DTOs.Topics.GetTopicsQueryDTO'.
+2025-09-29 01:51:10.719 +07:00 [DBG] Entity Framework Core 8.0.16 initialized 'MyDbContext' using provider 'Microsoft.EntityFrameworkCore.SqlServer:8.0.13' with options: MigrationsAssembly=App.DAL 
+2025-09-29 01:51:10.719 +07:00 [DBG] Creating DbConnection.
+2025-09-29 01:51:10.719 +07:00 [DBG] Created DbConnection. (0ms).
+2025-09-29 01:51:10.719 +07:00 [DBG] Opening connection to database 'capbot_db' on server 'localhost'.
+2025-09-29 01:51:10.719 +07:00 [DBG] Opened connection to database 'capbot_db' on server 'localhost'.
+2025-09-29 01:51:10.719 +07:00 [DBG] Creating DbCommand for 'ExecuteReader'.
+2025-09-29 01:51:10.719 +07:00 [DBG] Created DbCommand for 'ExecuteReader' (0ms).
+2025-09-29 01:51:10.719 +07:00 [DBG] Initialized DbCommand for 'ExecuteReader' (0ms).
+2025-09-29 01:51:10.719 +07:00 [DBG] Executing DbCommand [Parameters=[], CommandType='"Text"', CommandTimeout='30']
+SELECT COUNT(*)
+FROM [topics] AS [t]
+WHERE [t].[IsActive] = CAST(1 AS bit) AND [t].[DeletedAt] IS NULL
+2025-09-29 01:51:10.725 +07:00 [INF] Executed DbCommand (6ms) [Parameters=[], CommandType='"Text"', CommandTimeout='30']
+SELECT COUNT(*)
+FROM [topics] AS [t]
+WHERE [t].[IsActive] = CAST(1 AS bit) AND [t].[DeletedAt] IS NULL
+2025-09-29 01:51:10.725 +07:00 [DBG] Closing data reader to 'capbot_db' on server 'localhost'.
+2025-09-29 01:51:10.725 +07:00 [DBG] A data reader for 'capbot_db' on server 'localhost' is being disposed after spending 0ms reading results.
+2025-09-29 01:51:10.725 +07:00 [DBG] Closing connection to database 'capbot_db' on server 'localhost'.
+2025-09-29 01:51:10.725 +07:00 [DBG] Closed connection to database 'capbot_db' on server 'localhost' (0ms).
+2025-09-29 01:51:10.725 +07:00 [DBG] Compiling query expression: 
+'DbSet<Topic>()
+    .AsNoTracking()
+    .Include(x => x.Supervisor)
+    .Include(x => x.Category)
+    .Include(x => x.Semester)
+    .Include(x => x.Submissions)
+    .Include(x => x.TopicVersions)
+    .Where(x => x.IsActive && x.DeletedAt == null)
+    .OrderByDescending(x => x.CreatedAt)
+    .Skip(__p_0)
+    .Take(__p_1)'
+2025-09-29 01:51:10.726 +07:00 [DBG] Including navigation: 'Topic.Supervisor'.
+2025-09-29 01:51:10.726 +07:00 [DBG] Including navigation: 'Topic.Category'.
+2025-09-29 01:51:10.726 +07:00 [DBG] Including navigation: 'Topic.Semester'.
+2025-09-29 01:51:10.726 +07:00 [DBG] Including navigation: 'Topic.Submissions'.
+2025-09-29 01:51:10.726 +07:00 [DBG] Including navigation: 'Topic.TopicVersions'.
+2025-09-29 01:51:10.735 +07:00 [WRN] Compiling a query which loads related collections for more than one collection navigation, either via 'Include' or through projection, but no 'QuerySplittingBehavior' has been configured. By default, Entity Framework will use 'QuerySplittingBehavior.SingleQuery', which can potentially result in slow query performance. See https://go.microsoft.com/fwlink/?linkid=2134277 for more information. To identify the query that's triggering this warning call 'ConfigureWarnings(w => w.Throw(RelationalEventId.MultipleCollectionIncludeWarning))'.
+2025-09-29 01:51:10.741 +07:00 [DBG] Generated query execution expression: 
+'queryContext => new SingleQueryingEnumerable<Topic>(
+    (RelationalQueryContext)queryContext, 
+    RelationalCommandCache.QueryExpression(
+        Client Projections:
+            0 -> Dictionary<IProperty, int> { [Property: Topic.Id (int) Required PK AfterSave:Throw ValueGenerated.OnAdd, 0], [Property: Topic.Abbreviation (string), 1], [Property: Topic.CategoryId (int?) FK Index, 2], [Property: Topic.Content (string), 3], [Property: Topic.Context (string), 4], [Property: Topic.CreatedAt (DateTime) Required ValueGenerated.OnAdd, 5], [Property: Topic.CreatedBy (string), 6], [Property: Topic.DeletedAt (DateTime?), 7], [Property: Topic.Description (string), 8], [Property: Topic.EN_Title (string) Required MaxLength(500), 9], [Property: Topic.IsActive (bool) Required, 10], [Property: Topic.IsApproved (bool) Required Index Sentinel:True ValueGenerated.OnAdd, 11], [Property: Topic.IsLegacy (bool) Required Index ValueGenerated.OnAdd, 12], [Property: Topic.LastModifiedAt (DateTime?), 13], [Property: Topic.LastModifiedBy (string), 14], [Property: Topic.MaxStudents (int) Required ValueGenerated.OnAdd, 15], [Property: Topic.Objectives (string), 16], [Property: Topic.PotentialDuplicate (string), 17], [Property: Topic.Problem (string), 18], [Property: Topic.SemesterId (int) Required FK Index, 19], [Property: Topic.SupervisorId (int) Required FK Index, 20], [Property: Topic.VN_title (string), 21] }
+            1 -> Dictionary<IProperty, int> { [Property: User.Id (int) Required PK AfterSave:Throw ValueGenerated.OnAdd, 22], [Property: User.AccessFailedCount (int) Required, 23], [Property: User.ConcurrencyStamp (string), 24], [Property: User.CreatedAt (DateTime) Required, 25], [Property: User.DeletedAt (DateTime?), 26], [Property: User.Email (string), 27], [Property: User.EmailConfirmed (bool) Required, 28], [Property: User.LastModifiedAt (DateTime) Required, 29], [Property: User.LastModifiedBy (string), 30], [Property: User.LockoutEnabled (bool) Required, 31], [Property: User.LockoutEnd (DateTimeOffset?), 32], [Property: User.NormalizedEmail (string), 33], [Property: User.NormalizedUserName (string), 34], [Property: User.PasswordHash (string), 35], [Property: User.PhoneNumber (string), 36], [Property: User.PhoneNumberConfirmed (bool) Required, 37], [Property: User.SecurityStamp (string), 38], [Property: User.TwoFactorEnabled (bool) Required, 39], [Property: User.UserName (string), 40] }
+            2 -> Dictionary<IProperty, int> { [Property: TopicCategory.Id (int) Required PK AfterSave:Throw ValueGenerated.OnAdd, 41], [Property: TopicCategory.CreatedAt (DateTime) Required ValueGenerated.OnAdd, 42], [Property: TopicCategory.CreatedBy (string), 43], [Property: TopicCategory.DeletedAt (DateTime?), 44], [Property: TopicCategory.Description (string), 45], [Property: TopicCategory.IsActive (bool) Required, 46], [Property: TopicCategory.LastModifiedAt (DateTime?), 47], [Property: TopicCategory.LastModifiedBy (string), 48], [Property: TopicCategory.Name (string) Required MaxLength(100), 49] }
+            3 -> Dictionary<IProperty, int> { [Property: Semester.Id (int) Required PK AfterSave:Throw ValueGenerated.OnAdd, 50], [Property: Semester.CreatedAt (DateTime) Required, 51], [Property: Semester.CreatedBy (string), 52], [Property: Semester.DeletedAt (DateTime?), 53], [Property: Semester.Description (string), 54], [Property: Semester.EndDate (DateTime) Required, 55], [Property: Semester.IsActive (bool) Required, 56], [Property: Semester.LastModifiedAt (DateTime?), 57], [Property: Semester.LastModifiedBy (string), 58], [Property: Semester.Name (string) Required Index MaxLength(50), 59], [Property: Semester.StartDate (DateTime) Required, 60] }
+            4 -> 0
+            5 -> 22
+            6 -> 41
+            7 -> 50
+            8 -> Dictionary<IProperty, int> { [Property: Submission.Id (int) Required PK AfterSave:Throw ValueGenerated.OnAdd, 61], [Property: Submission.AdditionalNotes (string), 62], [Property: Submission.AiCheckDetails (string), 63], [Property: Submission.AiCheckScore (decimal?), 64], [Property: Submission.AiCheckStatus (AiCheckStatus) Required ValueGenerated.OnAdd, 65], [Property: Submission.CreatedAt (DateTime) Required, 66], [Property: Submission.CreatedBy (string), 67], [Property: Submission.DeletedAt (DateTime?), 68], [Property: Submission.DocumentUrl (string) MaxLength(500), 69], [Property: Submission.IsActive (bool) Required, 70], [Property: Submission.LastModifiedAt (DateTime?), 71], [Property: Submission.LastModifiedBy (string), 72], [Property: Submission.PhaseId (int) Required FK Index, 73], [Property: Submission.Status (SubmissionStatus) Required Index ValueGenerated.OnAdd, 74], [Property: Submission.SubmissionRound (int) Required Index ValueGenerated.OnAdd, 75], [Property: Submission.SubmittedAt (DateTime?) Index ValueGenerated.OnAdd, 76], [Property: Submission.SubmittedBy (int) Required FK Index, 77], [Property: Submission.TopicId (int) Required FK Index, 78], [Property: Submission.TopicVersionId (int?) FK Index, 79] }
+            9 -> 61
+            10 -> Dictionary<IProperty, int> { [Property: TopicVersion.Id (int) Required PK AfterSave:Throw ValueGenerated.OnAdd, 80], [Property: TopicVersion.Content (string), 81], [Property: TopicVersion.Context (string), 82], [Property: TopicVersion.CreatedAt (DateTime) Required ValueGenerated.OnAdd, 83], [Property: TopicVersion.CreatedBy (string), 84], [Property: TopicVersion.DeletedAt (DateTime?), 85], [Property: TopicVersion.Description (string), 86], [Property: TopicVersion.DocumentUrl (string) MaxLength(500), 87], [Property: TopicVersion.EN_Title (string) Required MaxLength(500), 88], [Property: TopicVersion.ExpectedOutcomes (string), 89], [Property: TopicVersion.IsActive (bool) Required, 90], [Property: TopicVersion.LastModifiedAt (DateTime?), 91], [Property: TopicVersion.LastModifiedBy (string), 92], [Property: TopicVersion.Methodology (string), 93], [Property: TopicVersion.Objectives (string), 94], [Property: TopicVersion.PotentialDuplicate (string), 95], [Property: TopicVersion.Problem (string), 96], [Property: TopicVersion.Requirements (string), 97], [Property: TopicVersion.Status (TopicStatus) Required Index ValueGenerated.OnAdd, 98], [Property: TopicVersion.SubmittedAt (DateTime?), 99], [Property: TopicVersion.SubmittedBy (int?) FK Index, 100], [Property: TopicVersion.TopicId (int) Required FK Index, 101], [Property: TopicVersion.VN_title (string), 102], [Property: TopicVersion.VersionNumber (int) Required Index, 103] }
+            11 -> 80
+        SELECT t0.Id, t0.Abbreviation, t0.CategoryId, t0.Content, t0.Context, t0.CreatedAt, t0.CreatedBy, t0.DeletedAt, t0.Description, t0.EN_Title, t0.IsActive, t0.IsApproved, t0.IsLegacy, t0.LastModifiedAt, t0.LastModifiedBy, t0.MaxStudents, t0.Objectives, t0.PotentialDuplicate, t0.Problem, t0.SemesterId, t0.SupervisorId, t0.VN_title, u.Id, u.AccessFailedCount, u.ConcurrencyStamp, u.CreatedAt, u.DeletedAt, u.Email, u.EmailConfirmed, u.LastModifiedAt, u.LastModifiedBy, u.LockoutEnabled, u.LockoutEnd, u.NormalizedEmail, u.NormalizedUserName, u.PasswordHash, u.PhoneNumber, u.PhoneNumberConfirmed, u.SecurityStamp, u.TwoFactorEnabled, u.UserName, t1.Id, t1.CreatedAt, t1.CreatedBy, t1.DeletedAt, t1.Description, t1.IsActive, t1.LastModifiedAt, t1.LastModifiedBy, t1.Name, s.Id, s.CreatedAt, s.CreatedBy, s.DeletedAt, s.Description, s.EndDate, s.IsActive, s.LastModifiedAt, s.LastModifiedBy, s.Name, s.StartDate, s0.Id, s0.AdditionalNotes, s0.AiCheckDetails, s0.AiCheckScore, s0.AiCheckStatus, s0.CreatedAt, s0.CreatedBy, s0.DeletedAt, s0.DocumentUrl, s0.IsActive, s0.LastModifiedAt, s0.LastModifiedBy, s0.PhaseId, s0.Status, s0.SubmissionRound, s0.SubmittedAt, s0.SubmittedBy, s0.TopicId, s0.TopicVersionId, t2.Id, t2.Content, t2.Context, t2.CreatedAt, t2.CreatedBy, t2.DeletedAt, t2.Description, t2.DocumentUrl, t2.EN_Title, t2.ExpectedOutcomes, t2.IsActive, t2.LastModifiedAt, t2.LastModifiedBy, t2.Methodology, t2.Objectives, t2.PotentialDuplicate, t2.Problem, t2.Requirements, t2.Status, t2.SubmittedAt, t2.SubmittedBy, t2.TopicId, t2.VN_title, t2.VersionNumber
+        FROM 
+        (
+            SELECT t.Id, t.Abbreviation, t.CategoryId, t.Content, t.Context, t.CreatedAt, t.CreatedBy, t.DeletedAt, t.Description, t.EN_Title, t.IsActive, t.IsApproved, t.IsLegacy, t.LastModifiedAt, t.LastModifiedBy, t.MaxStudents, t.Objectives, t.PotentialDuplicate, t.Problem, t.SemesterId, t.SupervisorId, t.VN_title
+            FROM topics AS t
+            WHERE t.IsActive && (t.DeletedAt == NULL)
+            ORDER BY t.CreatedAt DESC
+            OFFSET @__p_0 ROWS FETCH NEXT @__p_1 ROWS ONLY
+        ) AS t0
+        INNER JOIN users AS u ON t0.SupervisorId == u.Id
+        LEFT JOIN topic_categories AS t1 ON t0.CategoryId == t1.Id
+        INNER JOIN semesters AS s ON t0.SemesterId == s.Id
+        LEFT JOIN submissions AS s0 ON t0.Id == s0.TopicId
+        LEFT JOIN topic_versions AS t2 ON t0.Id == t2.TopicId
+        ORDER BY t0.CreatedAt DESC, t0.Id ASC, u.Id ASC, t1.Id ASC, s.Id ASC, s0.Id ASC), 
+    null, 
+    Func<QueryContext, DbDataReader, ResultContext, SingleQueryResultCoordinator, Topic>, 
+    App.DAL.Context.MyDbContext, 
+    False, 
+    False, 
+    True
+)'
+2025-09-29 01:51:10.743 +07:00 [DBG] Opening connection to database 'capbot_db' on server 'localhost'.
+2025-09-29 01:51:10.743 +07:00 [DBG] Opened connection to database 'capbot_db' on server 'localhost'.
+2025-09-29 01:51:10.743 +07:00 [DBG] Creating DbCommand for 'ExecuteReader'.
+2025-09-29 01:51:10.743 +07:00 [DBG] Created DbCommand for 'ExecuteReader' (0ms).
+2025-09-29 01:51:10.743 +07:00 [DBG] Initialized DbCommand for 'ExecuteReader' (0ms).
+2025-09-29 01:51:10.743 +07:00 [DBG] Executing DbCommand [Parameters=[@__p_0='?' (DbType = Int32), @__p_1='?' (DbType = Int32)], CommandType='"Text"', CommandTimeout='30']
+SELECT [t0].[Id], [t0].[Abbreviation], [t0].[CategoryId], [t0].[Content], [t0].[Context], [t0].[CreatedAt], [t0].[CreatedBy], [t0].[DeletedAt], [t0].[Description], [t0].[EN_Title], [t0].[IsActive], [t0].[IsApproved], [t0].[IsLegacy], [t0].[LastModifiedAt], [t0].[LastModifiedBy], [t0].[MaxStudents], [t0].[Objectives], [t0].[PotentialDuplicate], [t0].[Problem], [t0].[SemesterId], [t0].[SupervisorId], [t0].[VN_title], [u].[Id], [u].[AccessFailedCount], [u].[ConcurrencyStamp], [u].[CreatedAt], [u].[DeletedAt], [u].[Email], [u].[EmailConfirmed], [u].[LastModifiedAt], [u].[LastModifiedBy], [u].[LockoutEnabled], [u].[LockoutEnd], [u].[NormalizedEmail], [u].[NormalizedUserName], [u].[PasswordHash], [u].[PhoneNumber], [u].[PhoneNumberConfirmed], [u].[SecurityStamp], [u].[TwoFactorEnabled], [u].[UserName], [t1].[Id], [t1].[CreatedAt], [t1].[CreatedBy], [t1].[DeletedAt], [t1].[Description], [t1].[IsActive], [t1].[LastModifiedAt], [t1].[LastModifiedBy], [t1].[Name], [s].[Id], [s].[CreatedAt], [s].[CreatedBy], [s].[DeletedAt], [s].[Description], [s].[EndDate], [s].[IsActive], [s].[LastModifiedAt], [s].[LastModifiedBy], [s].[Name], [s].[StartDate], [s0].[Id], [s0].[AdditionalNotes], [s0].[AiCheckDetails], [s0].[AiCheckScore], [s0].[AiCheckStatus], [s0].[CreatedAt], [s0].[CreatedBy], [s0].[DeletedAt], [s0].[DocumentUrl], [s0].[IsActive], [s0].[LastModifiedAt], [s0].[LastModifiedBy], [s0].[PhaseId], [s0].[Status], [s0].[SubmissionRound], [s0].[SubmittedAt], [s0].[SubmittedBy], [s0].[TopicId], [s0].[TopicVersionId], [t2].[Id], [t2].[Content], [t2].[Context], [t2].[CreatedAt], [t2].[CreatedBy], [t2].[DeletedAt], [t2].[Description], [t2].[DocumentUrl], [t2].[EN_Title], [t2].[ExpectedOutcomes], [t2].[IsActive], [t2].[LastModifiedAt], [t2].[LastModifiedBy], [t2].[Methodology], [t2].[Objectives], [t2].[PotentialDuplicate], [t2].[Problem], [t2].[Requirements], [t2].[Status], [t2].[SubmittedAt], [t2].[SubmittedBy], [t2].[TopicId], [t2].[VN_title], [t2].[VersionNumber]
+FROM (
+    SELECT [t].[Id], [t].[Abbreviation], [t].[CategoryId], [t].[Content], [t].[Context], [t].[CreatedAt], [t].[CreatedBy], [t].[DeletedAt], [t].[Description], [t].[EN_Title], [t].[IsActive], [t].[IsApproved], [t].[IsLegacy], [t].[LastModifiedAt], [t].[LastModifiedBy], [t].[MaxStudents], [t].[Objectives], [t].[PotentialDuplicate], [t].[Problem], [t].[SemesterId], [t].[SupervisorId], [t].[VN_title]
+    FROM [topics] AS [t]
+    WHERE [t].[IsActive] = CAST(1 AS bit) AND [t].[DeletedAt] IS NULL
+    ORDER BY [t].[CreatedAt] DESC
+    OFFSET @__p_0 ROWS FETCH NEXT @__p_1 ROWS ONLY
+) AS [t0]
+INNER JOIN [users] AS [u] ON [t0].[SupervisorId] = [u].[Id]
+LEFT JOIN [topic_categories] AS [t1] ON [t0].[CategoryId] = [t1].[Id]
+INNER JOIN [semesters] AS [s] ON [t0].[SemesterId] = [s].[Id]
+LEFT JOIN [submissions] AS [s0] ON [t0].[Id] = [s0].[TopicId]
+LEFT JOIN [topic_versions] AS [t2] ON [t0].[Id] = [t2].[TopicId]
+ORDER BY [t0].[CreatedAt] DESC, [t0].[Id], [u].[Id], [t1].[Id], [s].[Id], [s0].[Id]
+2025-09-29 01:51:10.766 +07:00 [INF] Executed DbCommand (22ms) [Parameters=[@__p_0='?' (DbType = Int32), @__p_1='?' (DbType = Int32)], CommandType='"Text"', CommandTimeout='30']
+SELECT [t0].[Id], [t0].[Abbreviation], [t0].[CategoryId], [t0].[Content], [t0].[Context], [t0].[CreatedAt], [t0].[CreatedBy], [t0].[DeletedAt], [t0].[Description], [t0].[EN_Title], [t0].[IsActive], [t0].[IsApproved], [t0].[IsLegacy], [t0].[LastModifiedAt], [t0].[LastModifiedBy], [t0].[MaxStudents], [t0].[Objectives], [t0].[PotentialDuplicate], [t0].[Problem], [t0].[SemesterId], [t0].[SupervisorId], [t0].[VN_title], [u].[Id], [u].[AccessFailedCount], [u].[ConcurrencyStamp], [u].[CreatedAt], [u].[DeletedAt], [u].[Email], [u].[EmailConfirmed], [u].[LastModifiedAt], [u].[LastModifiedBy], [u].[LockoutEnabled], [u].[LockoutEnd], [u].[NormalizedEmail], [u].[NormalizedUserName], [u].[PasswordHash], [u].[PhoneNumber], [u].[PhoneNumberConfirmed], [u].[SecurityStamp], [u].[TwoFactorEnabled], [u].[UserName], [t1].[Id], [t1].[CreatedAt], [t1].[CreatedBy], [t1].[DeletedAt], [t1].[Description], [t1].[IsActive], [t1].[LastModifiedAt], [t1].[LastModifiedBy], [t1].[Name], [s].[Id], [s].[CreatedAt], [s].[CreatedBy], [s].[DeletedAt], [s].[Description], [s].[EndDate], [s].[IsActive], [s].[LastModifiedAt], [s].[LastModifiedBy], [s].[Name], [s].[StartDate], [s0].[Id], [s0].[AdditionalNotes], [s0].[AiCheckDetails], [s0].[AiCheckScore], [s0].[AiCheckStatus], [s0].[CreatedAt], [s0].[CreatedBy], [s0].[DeletedAt], [s0].[DocumentUrl], [s0].[IsActive], [s0].[LastModifiedAt], [s0].[LastModifiedBy], [s0].[PhaseId], [s0].[Status], [s0].[SubmissionRound], [s0].[SubmittedAt], [s0].[SubmittedBy], [s0].[TopicId], [s0].[TopicVersionId], [t2].[Id], [t2].[Content], [t2].[Context], [t2].[CreatedAt], [t2].[CreatedBy], [t2].[DeletedAt], [t2].[Description], [t2].[DocumentUrl], [t2].[EN_Title], [t2].[ExpectedOutcomes], [t2].[IsActive], [t2].[LastModifiedAt], [t2].[LastModifiedBy], [t2].[Methodology], [t2].[Objectives], [t2].[PotentialDuplicate], [t2].[Problem], [t2].[Requirements], [t2].[Status], [t2].[SubmittedAt], [t2].[SubmittedBy], [t2].[TopicId], [t2].[VN_title], [t2].[VersionNumber]
+FROM (
+    SELECT [t].[Id], [t].[Abbreviation], [t].[CategoryId], [t].[Content], [t].[Context], [t].[CreatedAt], [t].[CreatedBy], [t].[DeletedAt], [t].[Description], [t].[EN_Title], [t].[IsActive], [t].[IsApproved], [t].[IsLegacy], [t].[LastModifiedAt], [t].[LastModifiedBy], [t].[MaxStudents], [t].[Objectives], [t].[PotentialDuplicate], [t].[Problem], [t].[SemesterId], [t].[SupervisorId], [t].[VN_title]
+    FROM [topics] AS [t]
+    WHERE [t].[IsActive] = CAST(1 AS bit) AND [t].[DeletedAt] IS NULL
+    ORDER BY [t].[CreatedAt] DESC
+    OFFSET @__p_0 ROWS FETCH NEXT @__p_1 ROWS ONLY
+) AS [t0]
+INNER JOIN [users] AS [u] ON [t0].[SupervisorId] = [u].[Id]
+LEFT JOIN [topic_categories] AS [t1] ON [t0].[CategoryId] = [t1].[Id]
+INNER JOIN [semesters] AS [s] ON [t0].[SemesterId] = [s].[Id]
+LEFT JOIN [submissions] AS [s0] ON [t0].[Id] = [s0].[TopicId]
+LEFT JOIN [topic_versions] AS [t2] ON [t0].[Id] = [t2].[TopicId]
+ORDER BY [t0].[CreatedAt] DESC, [t0].[Id], [u].[Id], [t1].[Id], [s].[Id], [s0].[Id]
+2025-09-29 01:51:10.768 +07:00 [DBG] Closing data reader to 'capbot_db' on server 'localhost'.
+2025-09-29 01:51:10.768 +07:00 [DBG] A data reader for 'capbot_db' on server 'localhost' is being disposed after spending 2ms reading results.
+2025-09-29 01:51:10.768 +07:00 [DBG] Closing connection to database 'capbot_db' on server 'localhost'.
+2025-09-29 01:51:10.768 +07:00 [DBG] Closed connection to database 'capbot_db' on server 'localhost' (0ms).
+2025-09-29 01:51:10.769 +07:00 [DBG] List of registered output formatters, in the following order: ["Microsoft.AspNetCore.OData.Formatter.ODataOutputFormatter","Microsoft.AspNetCore.OData.Formatter.ODataOutputFormatter","Microsoft.AspNetCore.OData.Formatter.ODataOutputFormatter","Microsoft.AspNetCore.Mvc.Formatters.HttpNoContentOutputFormatter","Microsoft.AspNetCore.Mvc.Formatters.StringOutputFormatter","Microsoft.AspNetCore.Mvc.Formatters.StreamOutputFormatter","Microsoft.AspNetCore.Mvc.Formatters.SystemTextJsonOutputFormatter"]
+2025-09-29 01:51:10.769 +07:00 [DBG] No information found on request to perform content negotiation.
+2025-09-29 01:51:10.769 +07:00 [DBG] Attempting to select the first output formatter in the output formatters list which supports a content type from the explicitly specified content types '["application/json"]'.
+2025-09-29 01:51:10.769 +07:00 [DBG] Selected output formatter 'Microsoft.AspNetCore.Mvc.Formatters.SystemTextJsonOutputFormatter' and content type 'application/json' to write the response.
+2025-09-29 01:51:10.769 +07:00 [INF] Executing ObjectResult, writing value of type 'FS.Commons.FSResponse'.
+2025-09-29 01:51:10.777 +07:00 [INF] Executed action CapBot.api.Controllers.TopicController.GetTopicsWithPaging (CapBot.api) in 74.1646ms
+2025-09-29 01:51:10.777 +07:00 [INF] Executed endpoint 'CapBot.api.Controllers.TopicController.GetTopicsWithPaging (CapBot.api)'
+2025-09-29 01:51:10.777 +07:00 [DBG] Connection id "0HNFUN9U1CO92" completed keep alive response.
+2025-09-29 01:51:10.777 +07:00 [DBG] 'MyDbContext' disposed.
+2025-09-29 01:51:10.777 +07:00 [DBG] Disposing connection to database 'capbot_db' on server 'localhost'.
+2025-09-29 01:51:10.778 +07:00 [DBG] Disposed connection to database '' on server '' (0ms).
+2025-09-29 01:51:10.778 +07:00 [INF] Request finished HTTP/1.1 GET http://localhost:5207/api/topic/list?PageNumber=1&PageSize=111 - 200 null application/json; charset=utf-8 78.1389ms
+2025-09-29 01:52:24.683 +07:00 [DBG] HttpMessageHandler expired after 120000ms for client ''
+2025-09-29 01:52:34.690 +07:00 [DBG] Starting HttpMessageHandler cleanup cycle with 1 items
+2025-09-29 01:52:34.690 +07:00 [DBG] Ending HttpMessageHandler cleanup cycle after 0.0008ms - processed: 0 items - remaining: 1 items
+2025-09-29 01:52:44.698 +07:00 [DBG] Starting HttpMessageHandler cleanup cycle with 1 items
+2025-09-29 01:52:44.698 +07:00 [DBG] Ending HttpMessageHandler cleanup cycle after 0.0008ms - processed: 0 items - remaining: 1 items
+2025-09-29 01:52:54.708 +07:00 [DBG] Starting HttpMessageHandler cleanup cycle with 1 items
+2025-09-29 01:52:54.708 +07:00 [DBG] Ending HttpMessageHandler cleanup cycle after 0.0014ms - processed: 0 items - remaining: 1 items
+2025-09-29 01:53:04.708 +07:00 [DBG] Starting HttpMessageHandler cleanup cycle with 1 items
+2025-09-29 01:53:04.708 +07:00 [DBG] Ending HttpMessageHandler cleanup cycle after 0.0004ms - processed: 0 items - remaining: 1 items
+2025-09-29 01:53:14.711 +07:00 [DBG] Starting HttpMessageHandler cleanup cycle with 1 items
+2025-09-29 01:53:14.711 +07:00 [DBG] Ending HttpMessageHandler cleanup cycle after 0.0011ms - processed: 0 items - remaining: 1 items
+2025-09-29 01:53:22.210 +07:00 [DBG] Connection id "0HNFUN9U1CO92" disconnecting.
+2025-09-29 01:53:22.210 +07:00 [DBG] Connection id "0HNFUN9U1CO92" stopped.
+2025-09-29 01:53:22.211 +07:00 [DBG] Connection id "0HNFUN9U1CO92" sending FIN because: "The Socket transport's send loop completed gracefully."
+2025-09-29 01:53:24.724 +07:00 [DBG] Starting HttpMessageHandler cleanup cycle with 1 items
+2025-09-29 01:53:24.724 +07:00 [DBG] Ending HttpMessageHandler cleanup cycle after 0.0033ms - processed: 0 items - remaining: 1 items
+2025-09-29 01:53:34.726 +07:00 [DBG] Starting HttpMessageHandler cleanup cycle with 1 items
+2025-09-29 01:53:34.726 +07:00 [DBG] Ending HttpMessageHandler cleanup cycle after 0.0013ms - processed: 0 items - remaining: 1 items
+2025-09-29 01:53:44.733 +07:00 [DBG] Starting HttpMessageHandler cleanup cycle with 1 items
+2025-09-29 01:53:44.734 +07:00 [DBG] Ending HttpMessageHandler cleanup cycle after 0.0016ms - processed: 0 items - remaining: 1 items
+2025-09-29 01:53:54.744 +07:00 [DBG] Starting HttpMessageHandler cleanup cycle with 1 items
+2025-09-29 01:53:54.744 +07:00 [DBG] Ending HttpMessageHandler cleanup cycle after 0.0005ms - processed: 0 items - remaining: 1 items
+2025-09-29 01:54:04.751 +07:00 [DBG] Starting HttpMessageHandler cleanup cycle with 1 items
+2025-09-29 01:54:04.752 +07:00 [DBG] Ending HttpMessageHandler cleanup cycle after 0.0023ms - processed: 0 items - remaining: 1 items
+2025-09-29 01:54:14.763 +07:00 [DBG] Starting HttpMessageHandler cleanup cycle with 1 items
+2025-09-29 01:54:14.764 +07:00 [DBG] Ending HttpMessageHandler cleanup cycle after 0.0007ms - processed: 0 items - remaining: 1 items
+2025-09-29 01:54:24.763 +07:00 [DBG] Starting HttpMessageHandler cleanup cycle with 1 items
+2025-09-29 01:54:24.763 +07:00 [DBG] Ending HttpMessageHandler cleanup cycle after 0.0005ms - processed: 0 items - remaining: 1 items
+2025-09-29 01:54:34.769 +07:00 [DBG] Starting HttpMessageHandler cleanup cycle with 1 items
+2025-09-29 01:54:34.769 +07:00 [DBG] Ending HttpMessageHandler cleanup cycle after 0.0006ms - processed: 0 items - remaining: 1 items
+2025-09-29 01:54:44.775 +07:00 [DBG] Starting HttpMessageHandler cleanup cycle with 1 items
+2025-09-29 01:54:44.775 +07:00 [DBG] Ending HttpMessageHandler cleanup cycle after 0.0008ms - processed: 0 items - remaining: 1 items
+2025-09-29 01:54:54.782 +07:00 [DBG] Starting HttpMessageHandler cleanup cycle with 1 items
+2025-09-29 01:54:54.782 +07:00 [DBG] Ending HttpMessageHandler cleanup cycle after 0.0021ms - processed: 0 items - remaining: 1 items
+2025-09-29 01:55:04.789 +07:00 [DBG] Starting HttpMessageHandler cleanup cycle with 1 items
+2025-09-29 01:55:04.789 +07:00 [DBG] Ending HttpMessageHandler cleanup cycle after 0.0004ms - processed: 0 items - remaining: 1 items
+2025-09-29 01:55:14.801 +07:00 [DBG] Starting HttpMessageHandler cleanup cycle with 1 items
+2025-09-29 01:55:14.801 +07:00 [DBG] Ending HttpMessageHandler cleanup cycle after 0.0015ms - processed: 0 items - remaining: 1 items
+2025-09-29 01:55:24.806 +07:00 [DBG] Starting HttpMessageHandler cleanup cycle with 1 items
+2025-09-29 01:55:24.806 +07:00 [DBG] Ending HttpMessageHandler cleanup cycle after 0.0005ms - processed: 0 items - remaining: 1 items
+2025-09-29 01:55:34.819 +07:00 [DBG] Starting HttpMessageHandler cleanup cycle with 1 items
+2025-09-29 01:55:34.819 +07:00 [DBG] Ending HttpMessageHandler cleanup cycle after 0.0004ms - processed: 0 items - remaining: 1 items
+2025-09-29 01:55:44.825 +07:00 [DBG] Starting HttpMessageHandler cleanup cycle with 1 items
+2025-09-29 01:55:44.825 +07:00 [DBG] Ending HttpMessageHandler cleanup cycle after 0.0013ms - processed: 0 items - remaining: 1 items
+2025-09-29 01:55:54.840 +07:00 [DBG] Starting HttpMessageHandler cleanup cycle with 1 items
+2025-09-29 01:55:54.840 +07:00 [DBG] Ending HttpMessageHandler cleanup cycle after 0.0004ms - processed: 0 items - remaining: 1 items
+2025-09-29 01:56:04.845 +07:00 [DBG] Starting HttpMessageHandler cleanup cycle with 1 items
+2025-09-29 01:56:04.845 +07:00 [DBG] Ending HttpMessageHandler cleanup cycle after 0.0012ms - processed: 0 items - remaining: 1 items
+2025-09-29 01:56:14.845 +07:00 [DBG] Starting HttpMessageHandler cleanup cycle with 1 items
+2025-09-29 01:56:14.845 +07:00 [DBG] Ending HttpMessageHandler cleanup cycle after 0.0004ms - processed: 0 items - remaining: 1 items
+2025-09-29 01:56:24.855 +07:00 [DBG] Starting HttpMessageHandler cleanup cycle with 1 items
+2025-09-29 01:56:24.855 +07:00 [DBG] Ending HttpMessageHandler cleanup cycle after 0.0008ms - processed: 0 items - remaining: 1 items
+2025-09-29 01:56:34.867 +07:00 [DBG] Starting HttpMessageHandler cleanup cycle with 1 items
+2025-09-29 01:56:34.867 +07:00 [DBG] Ending HttpMessageHandler cleanup cycle after 0.0012ms - processed: 0 items - remaining: 1 items
+2025-09-29 01:56:44.877 +07:00 [DBG] Starting HttpMessageHandler cleanup cycle with 1 items
+2025-09-29 01:56:44.877 +07:00 [DBG] Ending HttpMessageHandler cleanup cycle after 0.0017ms - processed: 0 items - remaining: 1 items
+2025-09-29 01:56:54.880 +07:00 [DBG] Starting HttpMessageHandler cleanup cycle with 1 items
+2025-09-29 01:56:54.880 +07:00 [DBG] Ending HttpMessageHandler cleanup cycle after 0.0018ms - processed: 0 items - remaining: 1 items
+2025-09-29 01:57:04.889 +07:00 [DBG] Starting HttpMessageHandler cleanup cycle with 1 items
+2025-09-29 01:57:04.889 +07:00 [DBG] Ending HttpMessageHandler cleanup cycle after 0.0012ms - processed: 0 items - remaining: 1 items
+2025-09-29 01:57:14.892 +07:00 [DBG] Starting HttpMessageHandler cleanup cycle with 1 items
+2025-09-29 01:57:14.892 +07:00 [DBG] Ending HttpMessageHandler cleanup cycle after 0.0012ms - processed: 0 items - remaining: 1 items
+2025-09-29 01:57:24.895 +07:00 [DBG] Starting HttpMessageHandler cleanup cycle with 1 items
+2025-09-29 01:57:24.895 +07:00 [DBG] Ending HttpMessageHandler cleanup cycle after 0.002ms - processed: 0 items - remaining: 1 items
+2025-09-29 01:57:34.898 +07:00 [DBG] Starting HttpMessageHandler cleanup cycle with 1 items
+2025-09-29 01:57:34.898 +07:00 [DBG] Ending HttpMessageHandler cleanup cycle after 0.0016ms - processed: 0 items - remaining: 1 items
+2025-09-29 01:57:44.910 +07:00 [DBG] Starting HttpMessageHandler cleanup cycle with 1 items
+2025-09-29 01:57:44.911 +07:00 [DBG] Ending HttpMessageHandler cleanup cycle after 0.0026ms - processed: 0 items - remaining: 1 items
+2025-09-29 01:57:54.919 +07:00 [DBG] Starting HttpMessageHandler cleanup cycle with 1 items
+2025-09-29 01:57:54.919 +07:00 [DBG] Ending HttpMessageHandler cleanup cycle after 0.0011ms - processed: 0 items - remaining: 1 items
+2025-09-29 01:58:04.934 +07:00 [DBG] Starting HttpMessageHandler cleanup cycle with 1 items
+2025-09-29 01:58:04.934 +07:00 [DBG] Ending HttpMessageHandler cleanup cycle after 0.0006ms - processed: 0 items - remaining: 1 items
+2025-09-29 01:58:14.942 +07:00 [DBG] Starting HttpMessageHandler cleanup cycle with 1 items
+2025-09-29 01:58:14.942 +07:00 [DBG] Ending HttpMessageHandler cleanup cycle after 0.0014ms - processed: 0 items - remaining: 1 items
+2025-09-29 01:58:24.955 +07:00 [DBG] Starting HttpMessageHandler cleanup cycle with 1 items
+2025-09-29 01:58:24.956 +07:00 [DBG] Ending HttpMessageHandler cleanup cycle after 0.0017ms - processed: 0 items - remaining: 1 items
+2025-09-29 01:58:34.964 +07:00 [DBG] Starting HttpMessageHandler cleanup cycle with 1 items
+2025-09-29 01:58:34.964 +07:00 [DBG] Ending HttpMessageHandler cleanup cycle after 0.0016ms - processed: 0 items - remaining: 1 items
+2025-09-29 01:58:44.971 +07:00 [DBG] Starting HttpMessageHandler cleanup cycle with 1 items
+2025-09-29 01:58:44.971 +07:00 [DBG] Ending HttpMessageHandler cleanup cycle after 0.0005ms - processed: 0 items - remaining: 1 items
+2025-09-29 01:58:54.971 +07:00 [DBG] Starting HttpMessageHandler cleanup cycle with 1 items
+2025-09-29 01:58:54.971 +07:00 [DBG] Ending HttpMessageHandler cleanup cycle after 0.0011ms - processed: 0 items - remaining: 1 items
+2025-09-29 01:59:04.973 +07:00 [DBG] Starting HttpMessageHandler cleanup cycle with 1 items
+2025-09-29 01:59:04.973 +07:00 [DBG] Ending HttpMessageHandler cleanup cycle after 0.0016ms - processed: 0 items - remaining: 1 items
+2025-09-29 01:59:14.985 +07:00 [DBG] Starting HttpMessageHandler cleanup cycle with 1 items
+2025-09-29 01:59:14.986 +07:00 [DBG] Ending HttpMessageHandler cleanup cycle after 0.0012ms - processed: 0 items - remaining: 1 items
+2025-09-29 01:59:24.991 +07:00 [DBG] Starting HttpMessageHandler cleanup cycle with 1 items
+2025-09-29 01:59:24.992 +07:00 [DBG] Ending HttpMessageHandler cleanup cycle after 0.0012ms - processed: 0 items - remaining: 1 items
+2025-09-29 01:59:34.993 +07:00 [DBG] Starting HttpMessageHandler cleanup cycle with 1 items
+2025-09-29 01:59:34.993 +07:00 [DBG] Ending HttpMessageHandler cleanup cycle after 0.0004ms - processed: 0 items - remaining: 1 items
+2025-09-29 01:59:45.004 +07:00 [DBG] Starting HttpMessageHandler cleanup cycle with 1 items
+2025-09-29 01:59:45.004 +07:00 [DBG] Ending HttpMessageHandler cleanup cycle after 0.0015ms - processed: 0 items - remaining: 1 items
+2025-09-29 01:59:55.015 +07:00 [DBG] Starting HttpMessageHandler cleanup cycle with 1 items
+2025-09-29 01:59:55.015 +07:00 [DBG] Ending HttpMessageHandler cleanup cycle after 0.0006ms - processed: 0 items - remaining: 1 items
+2025-09-29 02:00:05.017 +07:00 [DBG] Starting HttpMessageHandler cleanup cycle with 1 items
+2025-09-29 02:00:05.017 +07:00 [DBG] Ending HttpMessageHandler cleanup cycle after 0.0012ms - processed: 0 items - remaining: 1 items
+2025-09-29 02:00:15.031 +07:00 [DBG] Starting HttpMessageHandler cleanup cycle with 1 items
+2025-09-29 02:00:15.031 +07:00 [DBG] Ending HttpMessageHandler cleanup cycle after 0.0004ms - processed: 0 items - remaining: 1 items
+2025-09-29 02:00:25.031 +07:00 [DBG] Starting HttpMessageHandler cleanup cycle with 1 items
+2025-09-29 02:00:25.032 +07:00 [DBG] Ending HttpMessageHandler cleanup cycle after 0.0011ms - processed: 0 items - remaining: 1 items
+2025-09-29 02:00:35.035 +07:00 [DBG] Starting HttpMessageHandler cleanup cycle with 1 items
+2025-09-29 02:00:35.035 +07:00 [DBG] Ending HttpMessageHandler cleanup cycle after 0.0014ms - processed: 0 items - remaining: 1 items
+2025-09-29 02:00:45.049 +07:00 [DBG] Starting HttpMessageHandler cleanup cycle with 1 items
+2025-09-29 02:00:45.050 +07:00 [DBG] Ending HttpMessageHandler cleanup cycle after 0.0014ms - processed: 0 items - remaining: 1 items
+2025-09-29 02:00:55.061 +07:00 [DBG] Starting HttpMessageHandler cleanup cycle with 1 items
+2025-09-29 02:00:55.061 +07:00 [DBG] Ending HttpMessageHandler cleanup cycle after 0.0013ms - processed: 0 items - remaining: 1 items
+2025-09-29 02:01:05.071 +07:00 [DBG] Starting HttpMessageHandler cleanup cycle with 1 items
+2025-09-29 02:01:05.072 +07:00 [DBG] Ending HttpMessageHandler cleanup cycle after 0.0011ms - processed: 0 items - remaining: 1 items
+2025-09-29 02:01:15.077 +07:00 [DBG] Starting HttpMessageHandler cleanup cycle with 1 items
+2025-09-29 02:01:15.078 +07:00 [DBG] Ending HttpMessageHandler cleanup cycle after 0.0023ms - processed: 0 items - remaining: 1 items
+2025-09-29 02:01:25.089 +07:00 [DBG] Starting HttpMessageHandler cleanup cycle with 1 items
+2025-09-29 02:01:25.090 +07:00 [DBG] Ending HttpMessageHandler cleanup cycle after 0.0014ms - processed: 0 items - remaining: 1 items
+2025-09-29 02:01:35.097 +07:00 [DBG] Starting HttpMessageHandler cleanup cycle with 1 items
+2025-09-29 02:01:35.098 +07:00 [DBG] Ending HttpMessageHandler cleanup cycle after 0.0015ms - processed: 0 items - remaining: 1 items
+2025-09-29 02:01:45.109 +07:00 [DBG] Starting HttpMessageHandler cleanup cycle with 1 items
+2025-09-29 02:01:45.109 +07:00 [DBG] Ending HttpMessageHandler cleanup cycle after 0.001ms - processed: 0 items - remaining: 1 items
+2025-09-29 02:01:55.121 +07:00 [DBG] Starting HttpMessageHandler cleanup cycle with 1 items
+2025-09-29 02:01:55.121 +07:00 [DBG] Ending HttpMessageHandler cleanup cycle after 0.0006ms - processed: 0 items - remaining: 1 items
+2025-09-29 02:02:05.125 +07:00 [DBG] Starting HttpMessageHandler cleanup cycle with 1 items
+2025-09-29 02:02:05.125 +07:00 [DBG] Ending HttpMessageHandler cleanup cycle after 0.0013ms - processed: 0 items - remaining: 1 items
+2025-09-29 02:02:15.127 +07:00 [DBG] Starting HttpMessageHandler cleanup cycle with 1 items
+2025-09-29 02:02:15.128 +07:00 [DBG] Ending HttpMessageHandler cleanup cycle after 0.0012ms - processed: 0 items - remaining: 1 items
+2025-09-29 02:02:25.135 +07:00 [DBG] Starting HttpMessageHandler cleanup cycle with 1 items
+2025-09-29 02:02:25.135 +07:00 [DBG] Ending HttpMessageHandler cleanup cycle after 0.0007ms - processed: 0 items - remaining: 1 items
+2025-09-29 02:02:35.148 +07:00 [DBG] Starting HttpMessageHandler cleanup cycle with 1 items
+2025-09-29 02:02:35.149 +07:00 [DBG] Ending HttpMessageHandler cleanup cycle after 0.001ms - processed: 0 items - remaining: 1 items
+2025-09-29 02:02:45.151 +07:00 [DBG] Starting HttpMessageHandler cleanup cycle with 1 items
+2025-09-29 02:02:45.151 +07:00 [DBG] Ending HttpMessageHandler cleanup cycle after 0.0019ms - processed: 0 items - remaining: 1 items
+2025-09-29 02:02:55.160 +07:00 [DBG] Starting HttpMessageHandler cleanup cycle with 1 items
+2025-09-29 02:02:55.161 +07:00 [DBG] Ending HttpMessageHandler cleanup cycle after 0.0013ms - processed: 0 items - remaining: 1 items
+2025-09-29 02:03:05.174 +07:00 [DBG] Starting HttpMessageHandler cleanup cycle with 1 items
+2025-09-29 02:03:05.174 +07:00 [DBG] Ending HttpMessageHandler cleanup cycle after 0.0004ms - processed: 0 items - remaining: 1 items
+2025-09-29 02:03:15.175 +07:00 [DBG] Starting HttpMessageHandler cleanup cycle with 1 items
+2025-09-29 02:03:15.175 +07:00 [DBG] Ending HttpMessageHandler cleanup cycle after 0.0015ms - processed: 0 items - remaining: 1 items
+2025-09-29 02:03:25.190 +07:00 [DBG] Starting HttpMessageHandler cleanup cycle with 1 items
+2025-09-29 02:03:25.190 +07:00 [DBG] Ending HttpMessageHandler cleanup cycle after 0.1463ms - processed: 0 items - remaining: 1 items
+2025-09-29 02:03:35.201 +07:00 [DBG] Starting HttpMessageHandler cleanup cycle with 1 items
+2025-09-29 02:03:35.201 +07:00 [DBG] Ending HttpMessageHandler cleanup cycle after 0.0046ms - processed: 0 items - remaining: 1 items
+2025-09-29 02:03:45.215 +07:00 [DBG] Starting HttpMessageHandler cleanup cycle with 1 items
+2025-09-29 02:03:45.215 +07:00 [DBG] Ending HttpMessageHandler cleanup cycle after 0.0006ms - processed: 0 items - remaining: 1 items
+2025-09-29 02:03:55.218 +07:00 [DBG] Starting HttpMessageHandler cleanup cycle with 1 items
+2025-09-29 02:03:55.218 +07:00 [DBG] Ending HttpMessageHandler cleanup cycle after 0.001ms - processed: 0 items - remaining: 1 items
+2025-09-29 02:04:05.229 +07:00 [DBG] Starting HttpMessageHandler cleanup cycle with 1 items
+2025-09-29 02:04:05.229 +07:00 [DBG] Ending HttpMessageHandler cleanup cycle after 0.0011ms - processed: 0 items - remaining: 1 items
+2025-09-29 02:04:15.240 +07:00 [DBG] Starting HttpMessageHandler cleanup cycle with 1 items
+2025-09-29 02:04:15.240 +07:00 [DBG] Ending HttpMessageHandler cleanup cycle after 0.0011ms - processed: 0 items - remaining: 1 items
+2025-09-29 02:04:25.250 +07:00 [DBG] Starting HttpMessageHandler cleanup cycle with 1 items
+2025-09-29 02:04:25.250 +07:00 [DBG] Ending HttpMessageHandler cleanup cycle after 0.0013ms - processed: 0 items - remaining: 1 items
+2025-09-29 02:04:35.250 +07:00 [DBG] Starting HttpMessageHandler cleanup cycle with 1 items
+2025-09-29 02:04:35.250 +07:00 [DBG] Ending HttpMessageHandler cleanup cycle after 0.002ms - processed: 0 items - remaining: 1 items
+2025-09-29 02:04:45.252 +07:00 [DBG] Starting HttpMessageHandler cleanup cycle with 1 items
+2025-09-29 02:04:45.252 +07:00 [DBG] Ending HttpMessageHandler cleanup cycle after 0.0014ms - processed: 0 items - remaining: 1 items
+2025-09-29 02:04:55.267 +07:00 [DBG] Starting HttpMessageHandler cleanup cycle with 1 items
+2025-09-29 02:04:55.267 +07:00 [DBG] Ending HttpMessageHandler cleanup cycle after 0.0007ms - processed: 0 items - remaining: 1 items
+2025-09-29 02:05:05.276 +07:00 [DBG] Starting HttpMessageHandler cleanup cycle with 1 items
+2025-09-29 02:05:05.276 +07:00 [DBG] Ending HttpMessageHandler cleanup cycle after 0.001ms - processed: 0 items - remaining: 1 items
+2025-09-29 02:05:11.918 +07:00 [INF] Application is shutting down...
+2025-09-29 02:05:11.923 +07:00 [DBG] Hosting stopping
+2025-09-29 02:05:11.961 +07:00 [ERR] Lỗi khi kiểm tra deadline notifications
+System.Threading.Tasks.TaskCanceledException: A task was canceled.
+   at CapBot.api.Services.DeadlineNotificationService.ExecuteAsync(CancellationToken stoppingToken) in C:\Users\Admin\Downloads\CBAI_API\capbot.api\Services\DeadlineNotificationService.cs:line 41
+2025-09-29 02:05:11.989 +07:00 [DBG] Hosting stopped
+2025-09-29 03:53:46.621 +07:00 [DBG] An 'IServiceProvider' was created for internal use by Entity Framework.
+2025-09-29 03:53:46.678 +07:00 [INF] User profile is available. Using 'C:\Users\Admin\AppData\Local\ASP.NET\DataProtection-Keys' as key repository and Windows DPAPI to encrypt keys at rest.
+2025-09-29 03:53:46.825 +07:00 [DBG] No relationship from 'ReviewerAssignment' to 'User' has been configured by convention because there are multiple properties on one entity type - {'AssignedByUser', 'Reviewer'} that could be matched with the properties on the other entity type - {'ReviewerAssignments'}. This message can be disregarded if explicit configuration has been specified in 'OnModelCreating'.
+2025-09-29 03:53:46.839 +07:00 [DBG] No relationship from 'SubmissionWorkflowLog' to 'WorkflowState' has been configured by convention because there are multiple properties on one entity type - {'FromState', 'ToState'} that could be matched with the properties on the other entity type - {'FromStateLogs', 'ToStateLogs'}. This message can be disregarded if explicit configuration has been specified in 'OnModelCreating'.
+2025-09-29 03:53:46.850 +07:00 [DBG] No relationship from 'User' to 'ReviewerAssignment' has been configured by convention because there are multiple properties on one entity type - {'ReviewerAssignments'} that could be matched with the properties on the other entity type - {'AssignedByUser', 'Reviewer'}. This message can be disregarded if explicit configuration has been specified in 'OnModelCreating'.
+2025-09-29 03:53:46.851 +07:00 [DBG] No relationship from 'WorkflowState' to 'SubmissionWorkflowLog' has been configured by convention because there are multiple properties on one entity type - {'FromStateLogs', 'ToStateLogs'} that could be matched with the properties on the other entity type - {'FromState', 'ToState'}. This message can be disregarded if explicit configuration has been specified in 'OnModelCreating'.
+2025-09-29 03:53:46.852 +07:00 [DBG] No relationship from 'WorkflowState' to 'WorkflowTransition' has been configured by convention because there are multiple properties on one entity type - {'FromTransitions', 'ToTransitions'} that could be matched with the properties on the other entity type - {'FromState', 'ToState'}. This message can be disregarded if explicit configuration has been specified in 'OnModelCreating'.
+2025-09-29 03:53:46.852 +07:00 [DBG] No relationship from 'WorkflowTransition' to 'WorkflowState' has been configured by convention because there are multiple properties on one entity type - {'FromState', 'ToState'} that could be matched with the properties on the other entity type - {'FromTransitions', 'ToTransitions'}. This message can be disregarded if explicit configuration has been specified in 'OnModelCreating'.
+2025-09-29 03:53:46.992 +07:00 [DBG] No relationship from 'ReviewerAssignment' to 'User' has been configured by convention because there are multiple properties on one entity type - {'AssignedByUser', 'Reviewer'} that could be matched with the properties on the other entity type - {'ReviewerAssignments'}. This message can be disregarded if explicit configuration has been specified in 'OnModelCreating'.
+2025-09-29 03:53:46.993 +07:00 [DBG] No relationship from 'User' to 'ReviewerAssignment' has been configured by convention because there are multiple properties on one entity type - {'ReviewerAssignments'} that could be matched with the properties on the other entity type - {'AssignedByUser', 'Reviewer'}. This message can be disregarded if explicit configuration has been specified in 'OnModelCreating'.
+2025-09-29 03:53:47.005 +07:00 [DBG] No relationship from 'WorkflowTransition' to 'WorkflowState' has been configured by convention because there are multiple properties on one entity type - {'FromState', 'ToState'} that could be matched with the properties on the other entity type - {'FromTransitions', 'ToTransitions'}. This message can be disregarded if explicit configuration has been specified in 'OnModelCreating'.
+2025-09-29 03:53:47.005 +07:00 [DBG] No relationship from 'WorkflowState' to 'SubmissionWorkflowLog' has been configured by convention because there are multiple properties on one entity type - {'FromStateLogs', 'ToStateLogs'} that could be matched with the properties on the other entity type - {'FromState', 'ToState'}. This message can be disregarded if explicit configuration has been specified in 'OnModelCreating'.
+2025-09-29 03:53:47.005 +07:00 [DBG] No relationship from 'WorkflowState' to 'WorkflowTransition' has been configured by convention because there are multiple properties on one entity type - {'FromTransitions', 'ToTransitions'} that could be matched with the properties on the other entity type - {'FromState', 'ToState'}. This message can be disregarded if explicit configuration has been specified in 'OnModelCreating'.
+2025-09-29 03:53:47.008 +07:00 [DBG] No relationship from 'WorkflowState' to 'SubmissionWorkflowLog' has been configured by convention because there are multiple properties on one entity type - {'FromStateLogs', 'ToStateLogs'} that could be matched with the properties on the other entity type - {'FromState', 'ToState'}. This message can be disregarded if explicit configuration has been specified in 'OnModelCreating'.
+2025-09-29 03:53:47.011 +07:00 [DBG] No relationship from 'SubmissionWorkflowLog' to 'WorkflowState' has been configured by convention because there are multiple properties on one entity type - {'FromState', 'ToState'} that could be matched with the properties on the other entity type - {'FromStateLogs', 'ToStateLogs'}. This message can be disregarded if explicit configuration has been specified in 'OnModelCreating'.
+2025-09-29 03:53:47.011 +07:00 [DBG] No relationship from 'WorkflowState' to 'SubmissionWorkflowLog' has been configured by convention because there are multiple properties on one entity type - {'FromStateLogs', 'ToStateLogs'} that could be matched with the properties on the other entity type - {'FromState', 'ToState'}. This message can be disregarded if explicit configuration has been specified in 'OnModelCreating'.
+2025-09-29 03:53:47.045 +07:00 [DBG] The index {'LecturerId'} was not created on entity type 'LecturerSkill' as the properties are already covered by the index {'LecturerId', 'SkillTag'}.
+2025-09-29 03:53:47.046 +07:00 [DBG] The index {'SemesterId'} was not created on entity type 'Phase' as the properties are already covered by the index {'SemesterId', 'PhaseTypeId'}.
+2025-09-29 03:53:47.046 +07:00 [DBG] The index {'AssignmentId'} was not created on entity type 'Review' as the properties are already covered by the index {'AssignmentId', 'Status'}.
+2025-09-29 03:53:47.046 +07:00 [DBG] The index {'ReviewId'} was not created on entity type 'ReviewComment' as the properties are already covered by the index {'ReviewId', 'SectionName'}.
+2025-09-29 03:53:47.046 +07:00 [DBG] The index {'ReviewId'} was not created on entity type 'ReviewCriteriaScore' as the properties are already covered by the index {'ReviewId', 'CriteriaId'}.
+2025-09-29 03:53:47.046 +07:00 [DBG] The index {'ReviewerId'} was not created on entity type 'ReviewerAssignment' as the properties are already covered by the index {'ReviewerId', 'Status'}.
+2025-09-29 03:53:47.046 +07:00 [DBG] The index {'SubmissionId'} was not created on entity type 'ReviewerAssignment' as the properties are already covered by the index {'SubmissionId', 'ReviewerId'}.
+2025-09-29 03:53:47.046 +07:00 [DBG] The index {'ReviewerId'} was not created on entity type 'ReviewerPerformance' as the properties are already covered by the index {'ReviewerId', 'SemesterId'}.
+2025-09-29 03:53:47.046 +07:00 [DBG] The index {'PhaseId'} was not created on entity type 'Submission' as the properties are already covered by the index {'PhaseId', 'Status'}.
+2025-09-29 03:53:47.046 +07:00 [DBG] The index {'PhaseId'} was not created on entity type 'Submission' as the properties are already covered by the index {'PhaseId', 'Status', 'SubmittedAt'}.
+2025-09-29 03:53:47.046 +07:00 [DBG] The index {'TopicId'} was not created on entity type 'Submission' as the properties are already covered by the index {'TopicId', 'PhaseId', 'SubmissionRound'}.
+2025-09-29 03:53:47.046 +07:00 [DBG] The index {'SubmissionId'} was not created on entity type 'SubmissionWorkflowLog' as the properties are already covered by the index {'SubmissionId', 'CreatedAt'}.
+2025-09-29 03:53:47.046 +07:00 [DBG] The index {'UserId'} was not created on entity type 'SystemNotification' as the properties are already covered by the index {'UserId', 'IsRead', 'CreatedAt'}.
+2025-09-29 03:53:47.046 +07:00 [DBG] The index {'SemesterId'} was not created on entity type 'Topic' as the properties are already covered by the index {'SemesterId', 'IsApproved'}.
+2025-09-29 03:53:47.046 +07:00 [DBG] The index {'SupervisorId'} was not created on entity type 'Topic' as the properties are already covered by the index {'SupervisorId', 'SemesterId'}.
+2025-09-29 03:53:47.046 +07:00 [DBG] The index {'TopicId'} was not created on entity type 'TopicVersion' as the properties are already covered by the index {'TopicId', 'Status'}.
+2025-09-29 03:53:47.046 +07:00 [DBG] The index {'TopicId'} was not created on entity type 'TopicVersion' as the properties are already covered by the index {'TopicId', 'VersionNumber'}.
+2025-09-29 03:53:47.046 +07:00 [DBG] The index {'UserId'} was not created on entity type 'UserRole' as the properties are already covered by the index {'UserId', 'RoleId'}.
+2025-09-29 03:53:47.046 +07:00 [DBG] The index {'UserId'} was not created on entity type 'UserToken' as the properties are already covered by the index {'UserId', 'LoginProvider', 'Name'}.
+2025-09-29 03:53:47.144 +07:00 [WRN] The 'ProficiencyLevels' property 'ProficiencyLevel' on entity type 'LecturerSkill' is configured with a database-generated default, but has no configured sentinel value. The database-generated default will always be used for inserts when the property has the value '0', since this is the CLR default for the 'ProficiencyLevels' type. Consider using a nullable type, using a nullable backing field, or setting the sentinel value for the property to ensure the database default is used when, and only when, appropriate. See https://aka.ms/efcore-docs-default-values for more information.
+2025-09-29 03:53:47.145 +07:00 [WRN] The 'ReviewRecommendations' property 'Recommendation' on entity type 'Review' is configured with a database-generated default, but has no configured sentinel value. The database-generated default will always be used for inserts when the property has the value '0', since this is the CLR default for the 'ReviewRecommendations' type. Consider using a nullable type, using a nullable backing field, or setting the sentinel value for the property to ensure the database default is used when, and only when, appropriate. See https://aka.ms/efcore-docs-default-values for more information.
+2025-09-29 03:53:47.145 +07:00 [WRN] The 'ReviewStatus' property 'Status' on entity type 'Review' is configured with a database-generated default, but has no configured sentinel value. The database-generated default will always be used for inserts when the property has the value '0', since this is the CLR default for the 'ReviewStatus' type. Consider using a nullable type, using a nullable backing field, or setting the sentinel value for the property to ensure the database default is used when, and only when, appropriate. See https://aka.ms/efcore-docs-default-values for more information.
+2025-09-29 03:53:47.146 +07:00 [WRN] The 'CommentTypes' property 'CommentType' on entity type 'ReviewComment' is configured with a database-generated default, but has no configured sentinel value. The database-generated default will always be used for inserts when the property has the value '0', since this is the CLR default for the 'CommentTypes' type. Consider using a nullable type, using a nullable backing field, or setting the sentinel value for the property to ensure the database default is used when, and only when, appropriate. See https://aka.ms/efcore-docs-default-values for more information.
+2025-09-29 03:53:47.146 +07:00 [WRN] The 'PriorityLevels' property 'Priority' on entity type 'ReviewComment' is configured with a database-generated default, but has no configured sentinel value. The database-generated default will always be used for inserts when the property has the value '0', since this is the CLR default for the 'PriorityLevels' type. Consider using a nullable type, using a nullable backing field, or setting the sentinel value for the property to ensure the database default is used when, and only when, appropriate. See https://aka.ms/efcore-docs-default-values for more information.
+2025-09-29 03:53:47.146 +07:00 [WRN] The 'AssignmentTypes' property 'AssignmentType' on entity type 'ReviewerAssignment' is configured with a database-generated default, but has no configured sentinel value. The database-generated default will always be used for inserts when the property has the value '0', since this is the CLR default for the 'AssignmentTypes' type. Consider using a nullable type, using a nullable backing field, or setting the sentinel value for the property to ensure the database default is used when, and only when, appropriate. See https://aka.ms/efcore-docs-default-values for more information.
+2025-09-29 03:53:47.146 +07:00 [WRN] The 'AssignmentStatus' property 'Status' on entity type 'ReviewerAssignment' is configured with a database-generated default, but has no configured sentinel value. The database-generated default will always be used for inserts when the property has the value '0', since this is the CLR default for the 'AssignmentStatus' type. Consider using a nullable type, using a nullable backing field, or setting the sentinel value for the property to ensure the database default is used when, and only when, appropriate. See https://aka.ms/efcore-docs-default-values for more information.
+2025-09-29 03:53:47.146 +07:00 [WRN] The 'AiCheckStatus' property 'AiCheckStatus' on entity type 'Submission' is configured with a database-generated default, but has no configured sentinel value. The database-generated default will always be used for inserts when the property has the value '0', since this is the CLR default for the 'AiCheckStatus' type. Consider using a nullable type, using a nullable backing field, or setting the sentinel value for the property to ensure the database default is used when, and only when, appropriate. See https://aka.ms/efcore-docs-default-values for more information.
+2025-09-29 03:53:47.146 +07:00 [WRN] The 'SubmissionStatus' property 'Status' on entity type 'Submission' is configured with a database-generated default, but has no configured sentinel value. The database-generated default will always be used for inserts when the property has the value '0', since this is the CLR default for the 'SubmissionStatus' type. Consider using a nullable type, using a nullable backing field, or setting the sentinel value for the property to ensure the database default is used when, and only when, appropriate. See https://aka.ms/efcore-docs-default-values for more information.
+2025-09-29 03:53:47.147 +07:00 [WRN] The 'NotificationTypes' property 'Type' on entity type 'SystemNotification' is configured with a database-generated default, but has no configured sentinel value. The database-generated default will always be used for inserts when the property has the value '0', since this is the CLR default for the 'NotificationTypes' type. Consider using a nullable type, using a nullable backing field, or setting the sentinel value for the property to ensure the database default is used when, and only when, appropriate. See https://aka.ms/efcore-docs-default-values for more information.
+2025-09-29 03:53:47.147 +07:00 [WRN] The 'TopicStatus' property 'Status' on entity type 'TopicVersion' is configured with a database-generated default, but has no configured sentinel value. The database-generated default will always be used for inserts when the property has the value '0', since this is the CLR default for the 'TopicStatus' type. Consider using a nullable type, using a nullable backing field, or setting the sentinel value for the property to ensure the database default is used when, and only when, appropriate. See https://aka.ms/efcore-docs-default-values for more information.
+2025-09-29 03:53:47.248 +07:00 [DBG] Entity Framework Core 8.0.16 initialized 'MyDbContext' using provider 'Microsoft.EntityFrameworkCore.SqlServer:8.0.13' with options: MigrationsAssembly=App.DAL 
+2025-09-29 03:53:47.287 +07:00 [DBG] Compiling query expression: 
+'DbSet<Role>()
+    .FirstOrDefault(r => r.NormalizedName == __normalizedName_0)'
+2025-09-29 03:53:47.388 +07:00 [DBG] Generated query execution expression: 
+'queryContext => ShapedQueryCompilingExpressionVisitor.SingleOrDefaultAsync<Role>(
+    asyncEnumerable: new SingleQueryingEnumerable<Role>(
+        (RelationalQueryContext)queryContext, 
+        RelationalCommandCache.QueryExpression(
+            Projection Mapping:
+                EmptyProjectionMember -> Dictionary<IProperty, int> { [Property: Role.Id (int) Required PK AfterSave:Throw ValueGenerated.OnAdd, 0], [Property: Role.ConcurrencyStamp (string), 1], [Property: Role.IsAdmin (bool) Required, 2], [Property: Role.Name (string), 3], [Property: Role.NormalizedName (string), 4] }
+            SELECT TOP(1) r.Id, r.ConcurrencyStamp, r.IsAdmin, r.Name, r.NormalizedName
+            FROM roles AS r
+            WHERE r.NormalizedName == @__normalizedName_0), 
+        null, 
+        Func<QueryContext, DbDataReader, ResultContext, SingleQueryResultCoordinator, Role>, 
+        App.DAL.Context.MyDbContext, 
+        False, 
+        False, 
+        True
+    ), 
+    cancellationToken: queryContext.CancellationToken)'
+2025-09-29 03:53:47.409 +07:00 [DBG] Creating DbConnection.
+2025-09-29 03:53:47.420 +07:00 [DBG] Created DbConnection. (9ms).
+2025-09-29 03:53:47.422 +07:00 [DBG] Opening connection to database 'capbot_db' on server 'localhost'.
+2025-09-29 03:53:47.515 +07:00 [DBG] Opened connection to database 'capbot_db' on server 'localhost'.
+2025-09-29 03:53:47.517 +07:00 [DBG] Creating DbCommand for 'ExecuteReader'.
+2025-09-29 03:53:47.520 +07:00 [DBG] Created DbCommand for 'ExecuteReader' (1ms).
+2025-09-29 03:53:47.524 +07:00 [DBG] Initialized DbCommand for 'ExecuteReader' (7ms).
+2025-09-29 03:53:47.528 +07:00 [DBG] Executing DbCommand [Parameters=[@__normalizedName_0='?' (Size = 4000)], CommandType='"Text"', CommandTimeout='30']
+SELECT TOP(1) [r].[Id], [r].[ConcurrencyStamp], [r].[IsAdmin], [r].[Name], [r].[NormalizedName]
+FROM [roles] AS [r]
+WHERE [r].[NormalizedName] = @__normalizedName_0
+2025-09-29 03:53:47.570 +07:00 [INF] Executed DbCommand (41ms) [Parameters=[@__normalizedName_0='?' (Size = 4000)], CommandType='"Text"', CommandTimeout='30']
+SELECT TOP(1) [r].[Id], [r].[ConcurrencyStamp], [r].[IsAdmin], [r].[Name], [r].[NormalizedName]
+FROM [roles] AS [r]
+WHERE [r].[NormalizedName] = @__normalizedName_0
+2025-09-29 03:53:47.594 +07:00 [DBG] Context 'MyDbContext' started tracking 'Role' entity. Consider using 'DbContextOptionsBuilder.EnableSensitiveDataLogging' to see key values.
+2025-09-29 03:53:47.608 +07:00 [DBG] Closing data reader to 'capbot_db' on server 'localhost'.
+2025-09-29 03:53:47.613 +07:00 [DBG] A data reader for 'capbot_db' on server 'localhost' is being disposed after spending 40ms reading results.
+2025-09-29 03:53:47.614 +07:00 [DBG] Closing connection to database 'capbot_db' on server 'localhost'.
+2025-09-29 03:53:47.618 +07:00 [DBG] Closed connection to database 'capbot_db' on server 'localhost' (2ms).
+2025-09-29 03:53:47.620 +07:00 [DBG] Opening connection to database 'capbot_db' on server 'localhost'.
+2025-09-29 03:53:47.620 +07:00 [DBG] Opened connection to database 'capbot_db' on server 'localhost'.
+2025-09-29 03:53:47.620 +07:00 [DBG] Creating DbCommand for 'ExecuteReader'.
+2025-09-29 03:53:47.620 +07:00 [DBG] Created DbCommand for 'ExecuteReader' (0ms).
+2025-09-29 03:53:47.620 +07:00 [DBG] Initialized DbCommand for 'ExecuteReader' (0ms).
+2025-09-29 03:53:47.621 +07:00 [DBG] Executing DbCommand [Parameters=[@__normalizedName_0='?' (Size = 4000)], CommandType='"Text"', CommandTimeout='30']
+SELECT TOP(1) [r].[Id], [r].[ConcurrencyStamp], [r].[IsAdmin], [r].[Name], [r].[NormalizedName]
+FROM [roles] AS [r]
+WHERE [r].[NormalizedName] = @__normalizedName_0
+2025-09-29 03:53:47.623 +07:00 [INF] Executed DbCommand (2ms) [Parameters=[@__normalizedName_0='?' (Size = 4000)], CommandType='"Text"', CommandTimeout='30']
+SELECT TOP(1) [r].[Id], [r].[ConcurrencyStamp], [r].[IsAdmin], [r].[Name], [r].[NormalizedName]
+FROM [roles] AS [r]
+WHERE [r].[NormalizedName] = @__normalizedName_0
+2025-09-29 03:53:47.623 +07:00 [DBG] Context 'MyDbContext' started tracking 'Role' entity. Consider using 'DbContextOptionsBuilder.EnableSensitiveDataLogging' to see key values.
+2025-09-29 03:53:47.624 +07:00 [DBG] Closing data reader to 'capbot_db' on server 'localhost'.
+2025-09-29 03:53:47.624 +07:00 [DBG] A data reader for 'capbot_db' on server 'localhost' is being disposed after spending 1ms reading results.
+2025-09-29 03:53:47.625 +07:00 [DBG] Closing connection to database 'capbot_db' on server 'localhost'.
+2025-09-29 03:53:47.625 +07:00 [DBG] Closed connection to database 'capbot_db' on server 'localhost' (0ms).
+2025-09-29 03:53:47.626 +07:00 [DBG] Opening connection to database 'capbot_db' on server 'localhost'.
+2025-09-29 03:53:47.626 +07:00 [DBG] Opened connection to database 'capbot_db' on server 'localhost'.
+2025-09-29 03:53:47.626 +07:00 [DBG] Creating DbCommand for 'ExecuteReader'.
+2025-09-29 03:53:47.626 +07:00 [DBG] Created DbCommand for 'ExecuteReader' (0ms).
+2025-09-29 03:53:47.626 +07:00 [DBG] Initialized DbCommand for 'ExecuteReader' (0ms).
+2025-09-29 03:53:47.626 +07:00 [DBG] Executing DbCommand [Parameters=[@__normalizedName_0='?' (Size = 4000)], CommandType='"Text"', CommandTimeout='30']
+SELECT TOP(1) [r].[Id], [r].[ConcurrencyStamp], [r].[IsAdmin], [r].[Name], [r].[NormalizedName]
+FROM [roles] AS [r]
+WHERE [r].[NormalizedName] = @__normalizedName_0
+2025-09-29 03:53:47.627 +07:00 [INF] Executed DbCommand (1ms) [Parameters=[@__normalizedName_0='?' (Size = 4000)], CommandType='"Text"', CommandTimeout='30']
+SELECT TOP(1) [r].[Id], [r].[ConcurrencyStamp], [r].[IsAdmin], [r].[Name], [r].[NormalizedName]
+FROM [roles] AS [r]
+WHERE [r].[NormalizedName] = @__normalizedName_0
+2025-09-29 03:53:47.627 +07:00 [DBG] Context 'MyDbContext' started tracking 'Role' entity. Consider using 'DbContextOptionsBuilder.EnableSensitiveDataLogging' to see key values.
+2025-09-29 03:53:47.627 +07:00 [DBG] Closing data reader to 'capbot_db' on server 'localhost'.
+2025-09-29 03:53:47.627 +07:00 [DBG] A data reader for 'capbot_db' on server 'localhost' is being disposed after spending 0ms reading results.
+2025-09-29 03:53:47.627 +07:00 [DBG] Closing connection to database 'capbot_db' on server 'localhost'.
+2025-09-29 03:53:47.627 +07:00 [DBG] Closed connection to database 'capbot_db' on server 'localhost' (0ms).
+2025-09-29 03:53:47.627 +07:00 [DBG] Opening connection to database 'capbot_db' on server 'localhost'.
+2025-09-29 03:53:47.628 +07:00 [DBG] Opened connection to database 'capbot_db' on server 'localhost'.
+2025-09-29 03:53:47.628 +07:00 [DBG] Creating DbCommand for 'ExecuteReader'.
+2025-09-29 03:53:47.628 +07:00 [DBG] Created DbCommand for 'ExecuteReader' (0ms).
+2025-09-29 03:53:47.628 +07:00 [DBG] Initialized DbCommand for 'ExecuteReader' (0ms).
+2025-09-29 03:53:47.628 +07:00 [DBG] Executing DbCommand [Parameters=[@__normalizedName_0='?' (Size = 4000)], CommandType='"Text"', CommandTimeout='30']
+SELECT TOP(1) [r].[Id], [r].[ConcurrencyStamp], [r].[IsAdmin], [r].[Name], [r].[NormalizedName]
+FROM [roles] AS [r]
+WHERE [r].[NormalizedName] = @__normalizedName_0
+2025-09-29 03:53:47.628 +07:00 [INF] Executed DbCommand (0ms) [Parameters=[@__normalizedName_0='?' (Size = 4000)], CommandType='"Text"', CommandTimeout='30']
+SELECT TOP(1) [r].[Id], [r].[ConcurrencyStamp], [r].[IsAdmin], [r].[Name], [r].[NormalizedName]
+FROM [roles] AS [r]
+WHERE [r].[NormalizedName] = @__normalizedName_0
+2025-09-29 03:53:47.628 +07:00 [DBG] Context 'MyDbContext' started tracking 'Role' entity. Consider using 'DbContextOptionsBuilder.EnableSensitiveDataLogging' to see key values.
+2025-09-29 03:53:47.629 +07:00 [DBG] Closing data reader to 'capbot_db' on server 'localhost'.
+2025-09-29 03:53:47.629 +07:00 [DBG] A data reader for 'capbot_db' on server 'localhost' is being disposed after spending 0ms reading results.
+2025-09-29 03:53:47.629 +07:00 [DBG] Closing connection to database 'capbot_db' on server 'localhost'.
+2025-09-29 03:53:47.629 +07:00 [DBG] Closed connection to database 'capbot_db' on server 'localhost' (0ms).
+2025-09-29 03:53:47.634 +07:00 [DBG] Compiling query expression: 
+'DbSet<User>()
+    .SingleOrDefault(u => u.NormalizedEmail == __normalizedEmail_0)'
+2025-09-29 03:53:47.639 +07:00 [DBG] Generated query execution expression: 
+'queryContext => ShapedQueryCompilingExpressionVisitor.SingleOrDefaultAsync<User>(
+    asyncEnumerable: new SingleQueryingEnumerable<User>(
+        (RelationalQueryContext)queryContext, 
+        RelationalCommandCache.QueryExpression(
+            Projection Mapping:
+                EmptyProjectionMember -> Dictionary<IProperty, int> { [Property: User.Id (int) Required PK AfterSave:Throw ValueGenerated.OnAdd, 0], [Property: User.AccessFailedCount (int) Required, 1], [Property: User.ConcurrencyStamp (string), 2], [Property: User.CreatedAt (DateTime) Required, 3], [Property: User.DeletedAt (DateTime?), 4], [Property: User.Email (string), 5], [Property: User.EmailConfirmed (bool) Required, 6], [Property: User.LastModifiedAt (DateTime) Required, 7], [Property: User.LastModifiedBy (string), 8], [Property: User.LockoutEnabled (bool) Required, 9], [Property: User.LockoutEnd (DateTimeOffset?), 10], [Property: User.NormalizedEmail (string), 11], [Property: User.NormalizedUserName (string), 12], [Property: User.PasswordHash (string), 13], [Property: User.PhoneNumber (string), 14], [Property: User.PhoneNumberConfirmed (bool) Required, 15], [Property: User.SecurityStamp (string), 16], [Property: User.TwoFactorEnabled (bool) Required, 17], [Property: User.UserName (string), 18] }
+            SELECT TOP(2) u.Id, u.AccessFailedCount, u.ConcurrencyStamp, u.CreatedAt, u.DeletedAt, u.Email, u.EmailConfirmed, u.LastModifiedAt, u.LastModifiedBy, u.LockoutEnabled, u.LockoutEnd, u.NormalizedEmail, u.NormalizedUserName, u.PasswordHash, u.PhoneNumber, u.PhoneNumberConfirmed, u.SecurityStamp, u.TwoFactorEnabled, u.UserName
+            FROM users AS u
+            WHERE u.NormalizedEmail == @__normalizedEmail_0), 
+        null, 
+        Func<QueryContext, DbDataReader, ResultContext, SingleQueryResultCoordinator, User>, 
+        App.DAL.Context.MyDbContext, 
+        False, 
+        False, 
+        True
+    ), 
+    cancellationToken: queryContext.CancellationToken)'
+2025-09-29 03:53:47.640 +07:00 [DBG] Opening connection to database 'capbot_db' on server 'localhost'.
+2025-09-29 03:53:47.640 +07:00 [DBG] Opened connection to database 'capbot_db' on server 'localhost'.
+2025-09-29 03:53:47.640 +07:00 [DBG] Creating DbCommand for 'ExecuteReader'.
+2025-09-29 03:53:47.640 +07:00 [DBG] Created DbCommand for 'ExecuteReader' (0ms).
+2025-09-29 03:53:47.640 +07:00 [DBG] Initialized DbCommand for 'ExecuteReader' (0ms).
+2025-09-29 03:53:47.640 +07:00 [DBG] Executing DbCommand [Parameters=[@__normalizedEmail_0='?' (Size = 4000)], CommandType='"Text"', CommandTimeout='30']
+SELECT TOP(2) [u].[Id], [u].[AccessFailedCount], [u].[ConcurrencyStamp], [u].[CreatedAt], [u].[DeletedAt], [u].[Email], [u].[EmailConfirmed], [u].[LastModifiedAt], [u].[LastModifiedBy], [u].[LockoutEnabled], [u].[LockoutEnd], [u].[NormalizedEmail], [u].[NormalizedUserName], [u].[PasswordHash], [u].[PhoneNumber], [u].[PhoneNumberConfirmed], [u].[SecurityStamp], [u].[TwoFactorEnabled], [u].[UserName]
+FROM [users] AS [u]
+WHERE [u].[NormalizedEmail] = @__normalizedEmail_0
+2025-09-29 03:53:47.645 +07:00 [INF] Executed DbCommand (5ms) [Parameters=[@__normalizedEmail_0='?' (Size = 4000)], CommandType='"Text"', CommandTimeout='30']
+SELECT TOP(2) [u].[Id], [u].[AccessFailedCount], [u].[ConcurrencyStamp], [u].[CreatedAt], [u].[DeletedAt], [u].[Email], [u].[EmailConfirmed], [u].[LastModifiedAt], [u].[LastModifiedBy], [u].[LockoutEnabled], [u].[LockoutEnd], [u].[NormalizedEmail], [u].[NormalizedUserName], [u].[PasswordHash], [u].[PhoneNumber], [u].[PhoneNumberConfirmed], [u].[SecurityStamp], [u].[TwoFactorEnabled], [u].[UserName]
+FROM [users] AS [u]
+WHERE [u].[NormalizedEmail] = @__normalizedEmail_0
+2025-09-29 03:53:47.663 +07:00 [DBG] Context 'MyDbContext' started tracking 'User' entity. Consider using 'DbContextOptionsBuilder.EnableSensitiveDataLogging' to see key values.
+2025-09-29 03:53:47.684 +07:00 [DBG] Closing data reader to 'capbot_db' on server 'localhost'.
+2025-09-29 03:53:47.684 +07:00 [DBG] A data reader for 'capbot_db' on server 'localhost' is being disposed after spending 38ms reading results.
+2025-09-29 03:53:47.684 +07:00 [DBG] Closing connection to database 'capbot_db' on server 'localhost'.
+2025-09-29 03:53:47.684 +07:00 [DBG] Closed connection to database 'capbot_db' on server 'localhost' (0ms).
+2025-09-29 03:53:47.687 +07:00 [INF] Admin user 'fptslayer@gmail.com' already exists
+2025-09-29 03:53:47.690 +07:00 [DBG] Opening connection to database 'capbot_db' on server 'localhost'.
+2025-09-29 03:53:47.690 +07:00 [DBG] Opened connection to database 'capbot_db' on server 'localhost'.
+2025-09-29 03:53:47.690 +07:00 [DBG] Creating DbCommand for 'ExecuteReader'.
+2025-09-29 03:53:47.690 +07:00 [DBG] Created DbCommand for 'ExecuteReader' (0ms).
+2025-09-29 03:53:47.690 +07:00 [DBG] Initialized DbCommand for 'ExecuteReader' (0ms).
+2025-09-29 03:53:47.690 +07:00 [DBG] Executing DbCommand [Parameters=[@__normalizedEmail_0='?' (Size = 4000)], CommandType='"Text"', CommandTimeout='30']
+SELECT TOP(2) [u].[Id], [u].[AccessFailedCount], [u].[ConcurrencyStamp], [u].[CreatedAt], [u].[DeletedAt], [u].[Email], [u].[EmailConfirmed], [u].[LastModifiedAt], [u].[LastModifiedBy], [u].[LockoutEnabled], [u].[LockoutEnd], [u].[NormalizedEmail], [u].[NormalizedUserName], [u].[PasswordHash], [u].[PhoneNumber], [u].[PhoneNumberConfirmed], [u].[SecurityStamp], [u].[TwoFactorEnabled], [u].[UserName]
+FROM [users] AS [u]
+WHERE [u].[NormalizedEmail] = @__normalizedEmail_0
+2025-09-29 03:53:47.691 +07:00 [INF] Executed DbCommand (1ms) [Parameters=[@__normalizedEmail_0='?' (Size = 4000)], CommandType='"Text"', CommandTimeout='30']
+SELECT TOP(2) [u].[Id], [u].[AccessFailedCount], [u].[ConcurrencyStamp], [u].[CreatedAt], [u].[DeletedAt], [u].[Email], [u].[EmailConfirmed], [u].[LastModifiedAt], [u].[LastModifiedBy], [u].[LockoutEnabled], [u].[LockoutEnd], [u].[NormalizedEmail], [u].[NormalizedUserName], [u].[PasswordHash], [u].[PhoneNumber], [u].[PhoneNumberConfirmed], [u].[SecurityStamp], [u].[TwoFactorEnabled], [u].[UserName]
+FROM [users] AS [u]
+WHERE [u].[NormalizedEmail] = @__normalizedEmail_0
+2025-09-29 03:53:47.692 +07:00 [DBG] Context 'MyDbContext' started tracking 'User' entity. Consider using 'DbContextOptionsBuilder.EnableSensitiveDataLogging' to see key values.
+2025-09-29 03:53:47.692 +07:00 [DBG] Closing data reader to 'capbot_db' on server 'localhost'.
+2025-09-29 03:53:47.692 +07:00 [DBG] A data reader for 'capbot_db' on server 'localhost' is being disposed after spending 0ms reading results.
+2025-09-29 03:53:47.692 +07:00 [DBG] Closing connection to database 'capbot_db' on server 'localhost'.
+2025-09-29 03:53:47.692 +07:00 [DBG] Closed connection to database 'capbot_db' on server 'localhost' (0ms).
+2025-09-29 03:53:47.692 +07:00 [INF] Sample moderator 'moderator@example.com' already exists
+2025-09-29 03:53:47.692 +07:00 [DBG] Opening connection to database 'capbot_db' on server 'localhost'.
+2025-09-29 03:53:47.693 +07:00 [DBG] Opened connection to database 'capbot_db' on server 'localhost'.
+2025-09-29 03:53:47.693 +07:00 [DBG] Creating DbCommand for 'ExecuteReader'.
+2025-09-29 03:53:47.694 +07:00 [DBG] Created DbCommand for 'ExecuteReader' (0ms).
+2025-09-29 03:53:47.694 +07:00 [DBG] Initialized DbCommand for 'ExecuteReader' (1ms).
+2025-09-29 03:53:47.695 +07:00 [DBG] Executing DbCommand [Parameters=[@__normalizedEmail_0='?' (Size = 4000)], CommandType='"Text"', CommandTimeout='30']
+SELECT TOP(2) [u].[Id], [u].[AccessFailedCount], [u].[ConcurrencyStamp], [u].[CreatedAt], [u].[DeletedAt], [u].[Email], [u].[EmailConfirmed], [u].[LastModifiedAt], [u].[LastModifiedBy], [u].[LockoutEnabled], [u].[LockoutEnd], [u].[NormalizedEmail], [u].[NormalizedUserName], [u].[PasswordHash], [u].[PhoneNumber], [u].[PhoneNumberConfirmed], [u].[SecurityStamp], [u].[TwoFactorEnabled], [u].[UserName]
+FROM [users] AS [u]
+WHERE [u].[NormalizedEmail] = @__normalizedEmail_0
+2025-09-29 03:53:47.696 +07:00 [INF] Executed DbCommand (1ms) [Parameters=[@__normalizedEmail_0='?' (Size = 4000)], CommandType='"Text"', CommandTimeout='30']
+SELECT TOP(2) [u].[Id], [u].[AccessFailedCount], [u].[ConcurrencyStamp], [u].[CreatedAt], [u].[DeletedAt], [u].[Email], [u].[EmailConfirmed], [u].[LastModifiedAt], [u].[LastModifiedBy], [u].[LockoutEnabled], [u].[LockoutEnd], [u].[NormalizedEmail], [u].[NormalizedUserName], [u].[PasswordHash], [u].[PhoneNumber], [u].[PhoneNumberConfirmed], [u].[SecurityStamp], [u].[TwoFactorEnabled], [u].[UserName]
+FROM [users] AS [u]
+WHERE [u].[NormalizedEmail] = @__normalizedEmail_0
+2025-09-29 03:53:47.696 +07:00 [DBG] Context 'MyDbContext' started tracking 'User' entity. Consider using 'DbContextOptionsBuilder.EnableSensitiveDataLogging' to see key values.
+2025-09-29 03:53:47.696 +07:00 [DBG] Closing data reader to 'capbot_db' on server 'localhost'.
+2025-09-29 03:53:47.697 +07:00 [DBG] A data reader for 'capbot_db' on server 'localhost' is being disposed after spending 0ms reading results.
+2025-09-29 03:53:47.697 +07:00 [DBG] Closing connection to database 'capbot_db' on server 'localhost'.
+2025-09-29 03:53:47.697 +07:00 [DBG] Closed connection to database 'capbot_db' on server 'localhost' (0ms).
+2025-09-29 03:53:47.698 +07:00 [DBG] Opening connection to database 'capbot_db' on server 'localhost'.
+2025-09-29 03:53:47.698 +07:00 [DBG] Opened connection to database 'capbot_db' on server 'localhost'.
+2025-09-29 03:53:47.698 +07:00 [DBG] Creating DbCommand for 'ExecuteReader'.
+2025-09-29 03:53:47.698 +07:00 [DBG] Created DbCommand for 'ExecuteReader' (0ms).
+2025-09-29 03:53:47.698 +07:00 [DBG] Initialized DbCommand for 'ExecuteReader' (0ms).
+2025-09-29 03:53:47.698 +07:00 [DBG] Executing DbCommand [Parameters=[@__normalizedEmail_0='?' (Size = 4000)], CommandType='"Text"', CommandTimeout='30']
+SELECT TOP(2) [u].[Id], [u].[AccessFailedCount], [u].[ConcurrencyStamp], [u].[CreatedAt], [u].[DeletedAt], [u].[Email], [u].[EmailConfirmed], [u].[LastModifiedAt], [u].[LastModifiedBy], [u].[LockoutEnabled], [u].[LockoutEnd], [u].[NormalizedEmail], [u].[NormalizedUserName], [u].[PasswordHash], [u].[PhoneNumber], [u].[PhoneNumberConfirmed], [u].[SecurityStamp], [u].[TwoFactorEnabled], [u].[UserName]
+FROM [users] AS [u]
+WHERE [u].[NormalizedEmail] = @__normalizedEmail_0
+2025-09-29 03:53:47.699 +07:00 [INF] Executed DbCommand (1ms) [Parameters=[@__normalizedEmail_0='?' (Size = 4000)], CommandType='"Text"', CommandTimeout='30']
+SELECT TOP(2) [u].[Id], [u].[AccessFailedCount], [u].[ConcurrencyStamp], [u].[CreatedAt], [u].[DeletedAt], [u].[Email], [u].[EmailConfirmed], [u].[LastModifiedAt], [u].[LastModifiedBy], [u].[LockoutEnabled], [u].[LockoutEnd], [u].[NormalizedEmail], [u].[NormalizedUserName], [u].[PasswordHash], [u].[PhoneNumber], [u].[PhoneNumberConfirmed], [u].[SecurityStamp], [u].[TwoFactorEnabled], [u].[UserName]
+FROM [users] AS [u]
+WHERE [u].[NormalizedEmail] = @__normalizedEmail_0
+2025-09-29 03:53:47.699 +07:00 [DBG] Context 'MyDbContext' started tracking 'User' entity. Consider using 'DbContextOptionsBuilder.EnableSensitiveDataLogging' to see key values.
+2025-09-29 03:53:47.699 +07:00 [DBG] Closing data reader to 'capbot_db' on server 'localhost'.
+2025-09-29 03:53:47.700 +07:00 [DBG] A data reader for 'capbot_db' on server 'localhost' is being disposed after spending 0ms reading results.
+2025-09-29 03:53:47.700 +07:00 [DBG] Closing connection to database 'capbot_db' on server 'localhost'.
+2025-09-29 03:53:47.700 +07:00 [DBG] Closed connection to database 'capbot_db' on server 'localhost' (0ms).
+2025-09-29 03:53:47.700 +07:00 [INF] Data seeding completed successfully
+2025-09-29 03:53:47.703 +07:00 [DBG] 'MyDbContext' disposed.
+2025-09-29 03:53:47.704 +07:00 [DBG] Disposing connection to database 'capbot_db' on server 'localhost'.
+2025-09-29 03:53:47.704 +07:00 [DBG] Disposed connection to database '' on server '' (0ms).
+2025-09-29 03:53:47.715 +07:00 [DBG] Registered SignalR Protocol: json, implemented by Microsoft.AspNetCore.SignalR.Protocol.JsonHubProtocol.
+2025-09-29 03:53:47.823 +07:00 [DBG] Registered model binder providers, in the following order: ["Microsoft.AspNetCore.Mvc.ModelBinding.Binders.BinderTypeModelBinderProvider","Microsoft.AspNetCore.Mvc.ModelBinding.Binders.ServicesModelBinderProvider","Microsoft.AspNetCore.Mvc.ModelBinding.Binders.BodyModelBinderProvider","Microsoft.AspNetCore.Mvc.ModelBinding.Binders.HeaderModelBinderProvider","Microsoft.AspNetCore.Mvc.ModelBinding.Binders.FloatingPointTypeModelBinderProvider","Microsoft.AspNetCore.Mvc.ModelBinding.Binders.EnumTypeModelBinderProvider","Microsoft.AspNetCore.Mvc.ModelBinding.Binders.DateTimeModelBinderProvider","Microsoft.AspNetCore.Mvc.ModelBinding.Binders.SimpleTypeModelBinderProvider","Microsoft.AspNetCore.Mvc.ModelBinding.Binders.TryParseModelBinderProvider","Microsoft.AspNetCore.Mvc.ModelBinding.Binders.CancellationTokenModelBinderProvider"]
+2025-09-29 03:53:47.900 +07:00 [DBG] Hosting starting
+2025-09-29 03:53:47.907 +07:00 [DBG] Reading data from file 'C:\Users\Admin\AppData\Local\ASP.NET\DataProtection-Keys\key-1d6bcff1-a155-4167-8a22-de35a5f05047.xml'.
+2025-09-29 03:53:47.951 +07:00 [DBG] Reading data from file 'C:\Users\Admin\AppData\Local\ASP.NET\DataProtection-Keys\key-2459dd29-32d5-4c49-ac9d-33896047bb78.xml'.
+2025-09-29 03:53:47.985 +07:00 [DBG] Reading data from file 'C:\Users\Admin\AppData\Local\ASP.NET\DataProtection-Keys\key-374624f1-e856-4617-8ae6-fe6a81ce6346.xml'.
+2025-09-29 03:53:48.029 +07:00 [DBG] Found key {1d6bcff1-a155-4167-8a22-de35a5f05047}.
+2025-09-29 03:53:48.032 +07:00 [DBG] Found key {2459dd29-32d5-4c49-ac9d-33896047bb78}.
+2025-09-29 03:53:48.032 +07:00 [DBG] Found key {374624f1-e856-4617-8ae6-fe6a81ce6346}.
+2025-09-29 03:53:48.036 +07:00 [DBG] Considering key {2459dd29-32d5-4c49-ac9d-33896047bb78} with expiration date 2025-11-03 12:40:53Z as default key.
+2025-09-29 03:53:48.038 +07:00 [DBG] Forwarded activator type request from Microsoft.AspNetCore.DataProtection.XmlEncryption.DpapiXmlDecryptor, Microsoft.AspNetCore.DataProtection, Version=8.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60 to Microsoft.AspNetCore.DataProtection.XmlEncryption.DpapiXmlDecryptor, Microsoft.AspNetCore.DataProtection, Culture=neutral, PublicKeyToken=adb9793829ddae60
+2025-09-29 03:53:48.038 +07:00 [DBG] Decrypting secret element using Windows DPAPI.
+2025-09-29 03:53:48.039 +07:00 [DBG] Forwarded activator type request from Microsoft.AspNetCore.DataProtection.AuthenticatedEncryption.ConfigurationModel.AuthenticatedEncryptorDescriptorDeserializer, Microsoft.AspNetCore.DataProtection, Version=8.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60 to Microsoft.AspNetCore.DataProtection.AuthenticatedEncryption.ConfigurationModel.AuthenticatedEncryptorDescriptorDeserializer, Microsoft.AspNetCore.DataProtection, Culture=neutral, PublicKeyToken=adb9793829ddae60
+2025-09-29 03:53:48.040 +07:00 [DBG] Opening CNG algorithm 'AES' from provider 'null' with chaining mode CBC.
+2025-09-29 03:53:48.041 +07:00 [DBG] Opening CNG algorithm 'SHA256' from provider 'null' with HMAC.
+2025-09-29 03:53:48.042 +07:00 [DBG] Using key {2459dd29-32d5-4c49-ac9d-33896047bb78} as the default key.
+2025-09-29 03:53:48.042 +07:00 [DBG] Key ring with default key {2459dd29-32d5-4c49-ac9d-33896047bb78} was loaded during application startup.
+2025-09-29 03:53:48.045 +07:00 [DBG] Middleware loaded
+2025-09-29 03:53:48.046 +07:00 [DBG] Middleware loaded. Script /_framework/aspnetcore-browser-refresh.js (16481 B).
+2025-09-29 03:53:48.046 +07:00 [DBG] Middleware loaded. Script /_framework/blazor-hotreload.js (799 B).
+2025-09-29 03:53:48.070 +07:00 [DBG] Middleware loaded: DOTNET_MODIFIABLE_ASSEMBLIES=debug, __ASPNETCORE_BROWSER_TOOLS=true
+2025-09-29 03:53:48.077 +07:00 [INF] Now listening on: http://localhost:5207
+2025-09-29 03:53:48.077 +07:00 [DBG] Loaded hosting startup assembly CapBot.api
+2025-09-29 03:53:48.077 +07:00 [DBG] Loaded hosting startup assembly Microsoft.AspNetCore.Watch.BrowserRefresh
+2025-09-29 03:53:48.077 +07:00 [INF] Application started. Press Ctrl+C to shut down.
+2025-09-29 03:53:48.077 +07:00 [INF] Hosting environment: Development
+2025-09-29 03:53:48.077 +07:00 [INF] Content root path: C:\Users\Admin\Downloads\CBAI_API\capbot.api
+2025-09-29 03:53:48.078 +07:00 [DBG] Hosting started
+2025-09-29 03:53:48.166 +07:00 [DBG] Connection id "0HNFUQ4FJ9UMI" accepted.
+2025-09-29 03:53:48.167 +07:00 [DBG] Connection id "0HNFUQ4FJ9UMI" started.
+2025-09-29 03:53:48.191 +07:00 [INF] Request starting HTTP/1.1 GET http://localhost:5207/index.html - null null
+2025-09-29 03:53:48.197 +07:00 [DBG] Wildcard detected, all requests with hosts will be allowed.
+2025-09-29 03:53:48.206 +07:00 [DBG] Connection id "0HNFUQ4FJ9UMJ" accepted.
+2025-09-29 03:53:48.207 +07:00 [DBG] Connection id "0HNFUQ4FJ9UMJ" started.
+2025-09-29 03:53:48.276 +07:00 [DBG] Response markup is scheduled to include browser refresh script injection.
+2025-09-29 03:53:48.284 +07:00 [DBG] Response markup was updated to include browser refresh script injection.
+2025-09-29 03:53:48.285 +07:00 [DBG] Connection id "0HNFUQ4FJ9UMI" completed keep alive response.
+2025-09-29 03:53:48.286 +07:00 [INF] Request finished HTTP/1.1 GET http://localhost:5207/index.html - 200 null text/html;charset=utf-8 95.8154ms
+2025-09-29 03:53:48.288 +07:00 [INF] Request starting HTTP/1.1 GET http://localhost:5207/_framework/aspnetcore-browser-refresh.js - null null
+2025-09-29 03:53:48.290 +07:00 [DBG] Script injected: /_framework/aspnetcore-browser-refresh.js
+2025-09-29 03:53:48.290 +07:00 [DBG] Connection id "0HNFUQ4FJ9UMI" completed keep alive response.
+2025-09-29 03:53:48.291 +07:00 [INF] Request finished HTTP/1.1 GET http://localhost:5207/_framework/aspnetcore-browser-refresh.js - 200 16481 application/javascript; charset=utf-8 2.168ms
+2025-09-29 03:53:48.343 +07:00 [INF] Request starting HTTP/1.1 GET http://localhost:5207/swagger/v1/swagger.json - null null
+2025-09-29 03:53:48.607 +07:00 [DBG] Connection id "0HNFUQ4FJ9UMI" completed keep alive response.
+2025-09-29 03:53:48.608 +07:00 [INF] Request finished HTTP/1.1 GET http://localhost:5207/swagger/v1/swagger.json - 200 null application/json;charset=utf-8 264.7764ms
+2025-09-29 03:54:18.052 +07:00 [DBG] Connection id "0HNFUQ4FJ9UMK" accepted.
+2025-09-29 03:54:18.054 +07:00 [DBG] Connection id "0HNFUQ4FJ9UMK" started.
+2025-09-29 03:54:18.055 +07:00 [DBG] Connection id "0HNFUQ4FJ9UML" accepted.
+2025-09-29 03:54:18.055 +07:00 [DBG] Connection id "0HNFUQ4FJ9UML" started.
+2025-09-29 03:54:18.056 +07:00 [INF] Request starting HTTP/1.1 OPTIONS http://localhost:5207/api/submission/list?PageNumber=1&PageSize=10 - null null
+2025-09-29 03:54:18.056 +07:00 [INF] Request starting HTTP/1.1 OPTIONS http://localhost:5207/api/user-profiles/me - null null
+2025-09-29 03:54:18.064 +07:00 [DBG] OPTIONS requests are not supported
+2025-09-29 03:54:18.064 +07:00 [DBG] OPTIONS requests are not supported
+2025-09-29 03:54:18.066 +07:00 [WRN] Failed to determine the https port for redirect.
+2025-09-29 03:54:18.066 +07:00 [DBG] OPTIONS requests are not supported
+2025-09-29 03:54:18.066 +07:00 [DBG] OPTIONS requests are not supported
+2025-09-29 03:54:18.070 +07:00 [DBG] The request has an origin header: 'http://localhost:3000'.
+2025-09-29 03:54:18.070 +07:00 [INF] CORS policy execution successful.
+2025-09-29 03:54:18.071 +07:00 [DBG] The request has an origin header: 'http://localhost:3000'.
+2025-09-29 03:54:18.071 +07:00 [INF] CORS policy execution successful.
+2025-09-29 03:54:18.073 +07:00 [DBG] The request is a preflight request.
+2025-09-29 03:54:18.075 +07:00 [DBG] The request is a preflight request.
+2025-09-29 03:54:18.077 +07:00 [DBG] Connection id "0HNFUQ4FJ9UML" completed keep alive response.
+2025-09-29 03:54:18.077 +07:00 [DBG] Connection id "0HNFUQ4FJ9UMK" completed keep alive response.
+2025-09-29 03:54:18.078 +07:00 [INF] Request finished HTTP/1.1 OPTIONS http://localhost:5207/api/user-profiles/me - 204 null null 21.6846ms
+2025-09-29 03:54:18.078 +07:00 [INF] Request finished HTTP/1.1 OPTIONS http://localhost:5207/api/submission/list?PageNumber=1&PageSize=10 - 204 null null 21.5691ms
+2025-09-29 03:54:18.081 +07:00 [INF] Request starting HTTP/1.1 GET http://localhost:5207/api/submission/list?PageNumber=1&PageSize=10 - null null
+2025-09-29 03:54:18.082 +07:00 [DBG] The request path /api/submission/list does not match a supported file type
+2025-09-29 03:54:18.083 +07:00 [DBG] The request path /api/submission/list does not match a supported file type
+2025-09-29 03:54:18.083 +07:00 [INF] Request starting HTTP/1.1 GET http://localhost:5207/api/user-profiles/me - null null
+2025-09-29 03:54:18.083 +07:00 [DBG] The request path /api/user-profiles/me does not match a supported file type
+2025-09-29 03:54:18.083 +07:00 [DBG] The request path /api/user-profiles/me does not match a supported file type
+2025-09-29 03:54:18.084 +07:00 [DBG] The request has an origin header: 'http://localhost:3000'.
+2025-09-29 03:54:18.084 +07:00 [DBG] The request has an origin header: 'http://localhost:3000'.
+2025-09-29 03:54:18.084 +07:00 [INF] CORS policy execution successful.
+2025-09-29 03:54:18.084 +07:00 [INF] CORS policy execution successful.
+2025-09-29 03:54:18.146 +07:00 [DBG] 1 candidate(s) found for the request path '/api/submission/list'
+2025-09-29 03:54:18.146 +07:00 [DBG] 2 candidate(s) found for the request path '/api/user-profiles/me'
+2025-09-29 03:54:18.148 +07:00 [DBG] Endpoint 'CapBot.api.Controllers.UserProfileController.GetMyProfile (CapBot.api)' with route pattern 'api/user-profiles/me' is valid for the request path '/api/user-profiles/me'
+2025-09-29 03:54:18.148 +07:00 [DBG] Endpoint 'CapBot.api.Controllers.SubmissionController.List (CapBot.api)' with route pattern 'api/submission/list' is valid for the request path '/api/submission/list'
+2025-09-29 03:54:18.148 +07:00 [DBG] Endpoint 'CapBot.api.Controllers.UserProfileController.GetById (CapBot.api)' with route pattern 'api/user-profiles/{id}' is valid for the request path '/api/user-profiles/me'
+2025-09-29 03:54:18.149 +07:00 [DBG] Request matched endpoint 'CapBot.api.Controllers.UserProfileController.GetMyProfile (CapBot.api)'
+2025-09-29 03:54:18.149 +07:00 [DBG] Request matched endpoint 'CapBot.api.Controllers.SubmissionController.List (CapBot.api)'
+2025-09-29 03:54:18.272 +07:00 [DBG] Successfully validated the token.
+2025-09-29 03:54:18.272 +07:00 [DBG] Successfully validated the token.
+2025-09-29 03:54:18.275 +07:00 [DBG] AuthenticationScheme: Bearer was successfully authenticated.
+2025-09-29 03:54:18.275 +07:00 [DBG] AuthenticationScheme: Bearer was successfully authenticated.
+2025-09-29 03:54:18.285 +07:00 [DBG] Authorization was successful.
+2025-09-29 03:54:18.285 +07:00 [DBG] Authorization was successful.
+2025-09-29 03:54:18.297 +07:00 [INF] Executing endpoint 'CapBot.api.Controllers.SubmissionController.List (CapBot.api)'
+2025-09-29 03:54:18.297 +07:00 [INF] Executing endpoint 'CapBot.api.Controllers.UserProfileController.GetMyProfile (CapBot.api)'
+2025-09-29 03:54:18.317 +07:00 [INF] Route matched with {action = "GetMyProfile", controller = "UserProfile"}. Executing controller action with signature System.Threading.Tasks.Task`1[Microsoft.AspNetCore.Mvc.IActionResult] GetMyProfile() on controller CapBot.api.Controllers.UserProfileController (CapBot.api).
+2025-09-29 03:54:18.320 +07:00 [DBG] Execution plan of authorization filters (in the following order): ["None"]
+2025-09-29 03:54:18.320 +07:00 [DBG] Execution plan of resource filters (in the following order): ["None"]
+2025-09-29 03:54:18.321 +07:00 [DBG] Execution plan of action filters (in the following order): ["Microsoft.AspNetCore.Mvc.ModelBinding.UnsupportedContentTypeFilter (Order: -3000)"]
+2025-09-29 03:54:18.322 +07:00 [DBG] Execution plan of exception filters (in the following order): ["None"]
+2025-09-29 03:54:18.322 +07:00 [DBG] Execution plan of result filters (in the following order): ["Microsoft.AspNetCore.Mvc.Infrastructure.ClientErrorResultFilter (Order: -2000)"]
+2025-09-29 03:54:18.326 +07:00 [DBG] Executing controller factory for controller CapBot.api.Controllers.UserProfileController (CapBot.api)
+2025-09-29 03:54:18.327 +07:00 [INF] Route matched with {action = "List", controller = "Submission"}. Executing controller action with signature System.Threading.Tasks.Task`1[Microsoft.AspNetCore.Mvc.IActionResult] List(App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO) on controller CapBot.api.Controllers.SubmissionController (CapBot.api).
+2025-09-29 03:54:18.327 +07:00 [DBG] Execution plan of authorization filters (in the following order): ["None"]
+2025-09-29 03:54:18.327 +07:00 [DBG] Execution plan of resource filters (in the following order): ["None"]
+2025-09-29 03:54:18.327 +07:00 [DBG] Execution plan of action filters (in the following order): ["Microsoft.AspNetCore.Mvc.ModelBinding.UnsupportedContentTypeFilter (Order: -3000)"]
+2025-09-29 03:54:18.328 +07:00 [DBG] Execution plan of exception filters (in the following order): ["None"]
+2025-09-29 03:54:18.328 +07:00 [DBG] Execution plan of result filters (in the following order): ["Microsoft.AspNetCore.Mvc.Infrastructure.ClientErrorResultFilter (Order: -2000)","Microsoft.AspNetCore.Mvc.ProducesAttribute (Order: 0)"]
+2025-09-29 03:54:18.328 +07:00 [DBG] Executing controller factory for controller CapBot.api.Controllers.SubmissionController (CapBot.api)
+2025-09-29 03:54:18.335 +07:00 [DBG] Executed controller factory for controller CapBot.api.Controllers.UserProfileController (CapBot.api)
+2025-09-29 03:54:18.361 +07:00 [DBG] Executed controller factory for controller CapBot.api.Controllers.SubmissionController (CapBot.api)
+2025-09-29 03:54:18.371 +07:00 [DBG] Attempting to bind parameter 'query' of type 'App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO' ...
+2025-09-29 03:54:18.376 +07:00 [DBG] Attempting to bind parameter 'query' of type 'App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO' using the name '' in request data ...
+2025-09-29 03:54:18.382 +07:00 [DBG] Attempting to bind property 'App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO.TopicVersionId' of type 'System.Nullable`1[System.Int32]' using the name 'TopicVersionId' in request data ...
+2025-09-29 03:54:18.383 +07:00 [DBG] Could not find a value in the request with name 'TopicVersionId' for binding property 'App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO.TopicVersionId' of type 'System.Nullable`1[System.Int32]'.
+2025-09-29 03:54:18.384 +07:00 [DBG] Done attempting to bind property 'App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO.TopicVersionId' of type 'System.Nullable`1[System.Int32]'.
+2025-09-29 03:54:18.386 +07:00 [DBG] Attempting to bind property 'App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO.PhaseId' of type 'System.Nullable`1[System.Int32]' using the name 'PhaseId' in request data ...
+2025-09-29 03:54:18.388 +07:00 [DBG] Could not find a value in the request with name 'PhaseId' for binding property 'App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO.PhaseId' of type 'System.Nullable`1[System.Int32]'.
+2025-09-29 03:54:18.389 +07:00 [DBG] Done attempting to bind property 'App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO.PhaseId' of type 'System.Nullable`1[System.Int32]'.
+2025-09-29 03:54:18.389 +07:00 [DBG] Attempting to bind property 'App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO.SemesterId' of type 'System.Nullable`1[System.Int32]' using the name 'SemesterId' in request data ...
+2025-09-29 03:54:18.390 +07:00 [DBG] Could not find a value in the request with name 'SemesterId' for binding property 'App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO.SemesterId' of type 'System.Nullable`1[System.Int32]'.
+2025-09-29 03:54:18.390 +07:00 [DBG] Done attempting to bind property 'App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO.SemesterId' of type 'System.Nullable`1[System.Int32]'.
+2025-09-29 03:54:18.390 +07:00 [DBG] Attempting to bind property 'App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO.Status' of type 'System.Nullable`1[App.Entities.Enums.SubmissionStatus]' using the name 'Status' in request data ...
+2025-09-29 03:54:18.390 +07:00 [DBG] Could not find a value in the request with name 'Status' for binding property 'App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO.Status' of type 'System.Nullable`1[App.Entities.Enums.SubmissionStatus]'.
+2025-09-29 03:54:18.391 +07:00 [DBG] Done attempting to bind property 'App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO.Status' of type 'System.Nullable`1[App.Entities.Enums.SubmissionStatus]'.
+2025-09-29 03:54:18.391 +07:00 [DBG] Attempting to bind property 'App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO.PageNumber' of type 'System.Int32' using the name 'PageNumber' in request data ...
+2025-09-29 03:54:18.392 +07:00 [DBG] Done attempting to bind property 'App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO.PageNumber' of type 'System.Int32'.
+2025-09-29 03:54:18.392 +07:00 [DBG] Attempting to bind property 'App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO.PageSize' of type 'System.Int32' using the name 'PageSize' in request data ...
+2025-09-29 03:54:18.393 +07:00 [DBG] Done attempting to bind property 'App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO.PageSize' of type 'System.Int32'.
+2025-09-29 03:54:18.393 +07:00 [DBG] Attempting to bind property 'App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO.Keyword' of type 'System.String' using the name 'Keyword' in request data ...
+2025-09-29 03:54:18.394 +07:00 [DBG] Could not find a value in the request with name 'Keyword' for binding property 'App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO.Keyword' of type 'System.String'.
+2025-09-29 03:54:18.395 +07:00 [DBG] Done attempting to bind property 'App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO.Keyword' of type 'System.String'.
+2025-09-29 03:54:18.396 +07:00 [DBG] Attempting to bind property 'App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO.TotalRecord' of type 'System.Int32' using the name 'TotalRecord' in request data ...
+2025-09-29 03:54:18.396 +07:00 [DBG] Could not find a value in the request with name 'TotalRecord' for binding property 'App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO.TotalRecord' of type 'System.Int32'.
+2025-09-29 03:54:18.397 +07:00 [DBG] Done attempting to bind property 'App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO.TotalRecord' of type 'System.Int32'.
+2025-09-29 03:54:18.397 +07:00 [DBG] Done attempting to bind parameter 'query' of type 'App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO'.
+2025-09-29 03:54:18.398 +07:00 [DBG] Done attempting to bind parameter 'query' of type 'App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO'.
+2025-09-29 03:54:18.398 +07:00 [DBG] Attempting to validate the bound parameter 'query' of type 'App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO' ...
+2025-09-29 03:54:18.410 +07:00 [DBG] Done attempting to validate the bound parameter 'query' of type 'App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO'.
+2025-09-29 03:54:18.447 +07:00 [DBG] Entity Framework Core 8.0.16 initialized 'MyDbContext' using provider 'Microsoft.EntityFrameworkCore.SqlServer:8.0.13' with options: MigrationsAssembly=App.DAL 
+2025-09-29 03:54:18.447 +07:00 [DBG] Entity Framework Core 8.0.16 initialized 'MyDbContext' using provider 'Microsoft.EntityFrameworkCore.SqlServer:8.0.13' with options: MigrationsAssembly=App.DAL 
+2025-09-29 03:54:18.461 +07:00 [DBG] Compiling query expression: 
+'DbSet<UserProfile>()
+    .AsNoTracking()
+    .Where(x => x.UserId == __targetUserId_0 && x.IsActive && x.DeletedAt == null && x.DeletedAt == null)
+    .FirstOrDefault()'
+2025-09-29 03:54:18.461 +07:00 [DBG] Compiling query expression: 
+'DbSet<Submission>()
+    .AsNoTracking()
+    .Include(x => x.SubmittedByUser)
+    .Include(x => x.Topic)
+    .Where(x => True)
+    .Count()'
+2025-09-29 03:54:18.477 +07:00 [DBG] Generated query execution expression: 
+'queryContext => ShapedQueryCompilingExpressionVisitor.SingleOrDefaultAsync<UserProfile>(
+    asyncEnumerable: new SingleQueryingEnumerable<UserProfile>(
+        (RelationalQueryContext)queryContext, 
+        RelationalCommandCache.QueryExpression(
+            Projection Mapping:
+                EmptyProjectionMember -> Dictionary<IProperty, int> { [Property: UserProfile.Id (int) Required PK AfterSave:Throw ValueGenerated.OnAdd, 0], [Property: UserProfile.Address (string), 1], [Property: UserProfile.Avatar (string), 2], [Property: UserProfile.CoverImage (string), 3], [Property: UserProfile.CreatedAt (DateTime) Required, 4], [Property: UserProfile.CreatedBy (string), 5], [Property: UserProfile.DeletedAt (DateTime?), 6], [Property: UserProfile.FullName (string), 7], [Property: UserProfile.IsActive (bool) Required, 8], [Property: UserProfile.LastModifiedAt (DateTime?), 9], [Property: UserProfile.LastModifiedBy (string), 10], [Property: UserProfile.UserId (int) Required FK Index, 11] }
+            SELECT TOP(1) p.Id, p.Address, p.Avatar, p.CoverImage, p.CreatedAt, p.CreatedBy, p.DeletedAt, p.FullName, p.IsActive, p.LastModifiedAt, p.LastModifiedBy, p.UserId
+            FROM profiles AS p
+            WHERE (((p.UserId == @__targetUserId_0) && p.IsActive) && (p.DeletedAt == NULL)) && (p.DeletedAt == NULL)), 
+        null, 
+        Func<QueryContext, DbDataReader, ResultContext, SingleQueryResultCoordinator, UserProfile>, 
+        App.DAL.Context.MyDbContext, 
+        False, 
+        False, 
+        True
+    ), 
+    cancellationToken: queryContext.CancellationToken)'
+2025-09-29 03:54:18.488 +07:00 [DBG] Creating DbConnection.
+2025-09-29 03:54:18.489 +07:00 [DBG] Created DbConnection. (0ms).
+2025-09-29 03:54:18.489 +07:00 [DBG] Opening connection to database 'capbot_db' on server 'localhost'.
+2025-09-29 03:54:18.490 +07:00 [DBG] Opened connection to database 'capbot_db' on server 'localhost'.
+2025-09-29 03:54:18.491 +07:00 [DBG] Creating DbCommand for 'ExecuteReader'.
+2025-09-29 03:54:18.492 +07:00 [DBG] Created DbCommand for 'ExecuteReader' (0ms).
+2025-09-29 03:54:18.492 +07:00 [DBG] Initialized DbCommand for 'ExecuteReader' (1ms).
+2025-09-29 03:54:18.493 +07:00 [DBG] Executing DbCommand [Parameters=[@__targetUserId_0='?' (DbType = Int32)], CommandType='"Text"', CommandTimeout='30']
+SELECT TOP(1) [p].[Id], [p].[Address], [p].[Avatar], [p].[CoverImage], [p].[CreatedAt], [p].[CreatedBy], [p].[DeletedAt], [p].[FullName], [p].[IsActive], [p].[LastModifiedAt], [p].[LastModifiedBy], [p].[UserId]
+FROM [profiles] AS [p]
+WHERE [p].[UserId] = @__targetUserId_0 AND [p].[IsActive] = CAST(1 AS bit) AND [p].[DeletedAt] IS NULL AND [p].[DeletedAt] IS NULL
+2025-09-29 03:54:18.502 +07:00 [INF] Executed DbCommand (10ms) [Parameters=[@__targetUserId_0='?' (DbType = Int32)], CommandType='"Text"', CommandTimeout='30']
+SELECT TOP(1) [p].[Id], [p].[Address], [p].[Avatar], [p].[CoverImage], [p].[CreatedAt], [p].[CreatedBy], [p].[DeletedAt], [p].[FullName], [p].[IsActive], [p].[LastModifiedAt], [p].[LastModifiedBy], [p].[UserId]
+FROM [profiles] AS [p]
+WHERE [p].[UserId] = @__targetUserId_0 AND [p].[IsActive] = CAST(1 AS bit) AND [p].[DeletedAt] IS NULL AND [p].[DeletedAt] IS NULL
+2025-09-29 03:54:18.504 +07:00 [DBG] Closing data reader to 'capbot_db' on server 'localhost'.
+2025-09-29 03:54:18.507 +07:00 [DBG] A data reader for 'capbot_db' on server 'localhost' is being disposed after spending 4ms reading results.
+2025-09-29 03:54:18.507 +07:00 [DBG] Closing connection to database 'capbot_db' on server 'localhost'.
+2025-09-29 03:54:18.507 +07:00 [DBG] Closed connection to database 'capbot_db' on server 'localhost' (0ms).
+2025-09-29 03:54:18.518 +07:00 [DBG] List of registered output formatters, in the following order: ["Microsoft.AspNetCore.OData.Formatter.ODataOutputFormatter","Microsoft.AspNetCore.OData.Formatter.ODataOutputFormatter","Microsoft.AspNetCore.OData.Formatter.ODataOutputFormatter","Microsoft.AspNetCore.Mvc.Formatters.HttpNoContentOutputFormatter","Microsoft.AspNetCore.Mvc.Formatters.StringOutputFormatter","Microsoft.AspNetCore.Mvc.Formatters.StreamOutputFormatter","Microsoft.AspNetCore.Mvc.Formatters.SystemTextJsonOutputFormatter"]
+2025-09-29 03:54:18.521 +07:00 [DBG] No information found on request to perform content negotiation.
+2025-09-29 03:54:18.521 +07:00 [DBG] Attempting to select an output formatter without using a content type as no explicit content types were specified for the response.
+2025-09-29 03:54:18.521 +07:00 [DBG] Attempting to select the first formatter in the output formatters list which can write the result.
+2025-09-29 03:54:18.524 +07:00 [DBG] Selected output formatter 'Microsoft.AspNetCore.Mvc.Formatters.SystemTextJsonOutputFormatter' and content type 'application/json' to write the response.
+2025-09-29 03:54:18.524 +07:00 [INF] Executing ObjectResult, writing value of type 'FS.Commons.FSResponse'.
+2025-09-29 03:54:18.543 +07:00 [DBG] Generated query execution expression: 
+'queryContext => ShapedQueryCompilingExpressionVisitor.SingleAsync<int>(
+    asyncEnumerable: new SingleQueryingEnumerable<int>(
+        (RelationalQueryContext)queryContext, 
+        RelationalCommandCache.QueryExpression(
+            Projection Mapping:
+                EmptyProjectionMember -> 0
+            SELECT COUNT(*)
+            FROM submissions AS s), 
+        null, 
+        Func<QueryContext, DbDataReader, ResultContext, SingleQueryResultCoordinator, int>, 
+        App.DAL.Context.MyDbContext, 
+        False, 
+        False, 
+        True
+    ), 
+    cancellationToken: queryContext.CancellationToken)'
+2025-09-29 03:54:18.552 +07:00 [DBG] Creating DbConnection.
+2025-09-29 03:54:18.553 +07:00 [DBG] Created DbConnection. (0ms).
+2025-09-29 03:54:18.553 +07:00 [DBG] Opening connection to database 'capbot_db' on server 'localhost'.
+2025-09-29 03:54:18.556 +07:00 [DBG] Opened connection to database 'capbot_db' on server 'localhost'.
+2025-09-29 03:54:18.556 +07:00 [DBG] Creating DbCommand for 'ExecuteReader'.
+2025-09-29 03:54:18.557 +07:00 [DBG] Created DbCommand for 'ExecuteReader' (0ms).
+2025-09-29 03:54:18.557 +07:00 [DBG] Initialized DbCommand for 'ExecuteReader' (0ms).
+2025-09-29 03:54:18.557 +07:00 [DBG] Executing DbCommand [Parameters=[], CommandType='"Text"', CommandTimeout='30']
+SELECT COUNT(*)
+FROM [submissions] AS [s]
+2025-09-29 03:54:18.567 +07:00 [INF] Executed DbCommand (10ms) [Parameters=[], CommandType='"Text"', CommandTimeout='30']
+SELECT COUNT(*)
+FROM [submissions] AS [s]
+2025-09-29 03:54:18.571 +07:00 [DBG] Closing data reader to 'capbot_db' on server 'localhost'.
+2025-09-29 03:54:18.571 +07:00 [DBG] A data reader for 'capbot_db' on server 'localhost' is being disposed after spending 3ms reading results.
+2025-09-29 03:54:18.572 +07:00 [DBG] Closing connection to database 'capbot_db' on server 'localhost'.
+2025-09-29 03:54:18.572 +07:00 [DBG] Closed connection to database 'capbot_db' on server 'localhost' (0ms).
+2025-09-29 03:54:18.580 +07:00 [DBG] Compiling query expression: 
+'DbSet<Submission>()
+    .AsNoTracking()
+    .Include(x => x.SubmittedByUser)
+    .Include(x => x.Topic)
+    .Where(x => True)
+    .OrderByDescending(x => x.SubmittedAt)
+    .Skip(__p_0)
+    .Take(__p_1)'
+2025-09-29 03:54:18.596 +07:00 [DBG] Including navigation: 'Submission.SubmittedByUser'.
+2025-09-29 03:54:18.599 +07:00 [INF] Executed action CapBot.api.Controllers.UserProfileController.GetMyProfile (CapBot.api) in 269.9766ms
+2025-09-29 03:54:18.600 +07:00 [INF] Executed endpoint 'CapBot.api.Controllers.UserProfileController.GetMyProfile (CapBot.api)'
+2025-09-29 03:54:18.600 +07:00 [DBG] Including navigation: 'Submission.Topic'.
+2025-09-29 03:54:18.604 +07:00 [DBG] Connection id "0HNFUQ4FJ9UML" completed keep alive response.
+2025-09-29 03:54:18.605 +07:00 [DBG] 'MyDbContext' disposed.
+2025-09-29 03:54:18.605 +07:00 [DBG] Disposing connection to database 'capbot_db' on server 'localhost'.
+2025-09-29 03:54:18.605 +07:00 [DBG] Disposed connection to database '' on server '' (0ms).
+2025-09-29 03:54:18.606 +07:00 [INF] Request finished HTTP/1.1 GET http://localhost:5207/api/user-profiles/me - 200 null application/json; charset=utf-8 523.6561ms
+2025-09-29 03:54:18.618 +07:00 [INF] Request starting HTTP/1.1 GET http://localhost:5207/images/entities/11111111.png - null null
+2025-09-29 03:54:18.619 +07:00 [DBG] The request path /images/entities/11111111.png does not match an existing file
+2025-09-29 03:54:18.620 +07:00 [DBG] The request path /images/entities/11111111.png does not match an existing file
+2025-09-29 03:54:18.621 +07:00 [DBG] No candidates found for the request path '/images/entities/11111111.png'
+2025-09-29 03:54:18.621 +07:00 [DBG] Request did not match any endpoints
+2025-09-29 03:54:18.627 +07:00 [DBG] AuthenticationScheme: Bearer was not authenticated.
+2025-09-29 03:54:18.629 +07:00 [DBG] Connection id "0HNFUQ4FJ9UMI" completed keep alive response.
+2025-09-29 03:54:18.629 +07:00 [INF] Request finished HTTP/1.1 GET http://localhost:5207/images/entities/11111111.png - 404 0 null 11.8255ms
+2025-09-29 03:54:18.630 +07:00 [INF] Request reached the end of the middleware pipeline without being handled by application code. Request path: GET http://localhost:5207/images/entities/11111111.png, Response status code: 404
+2025-09-29 03:54:18.690 +07:00 [DBG] Generated query execution expression: 
+'queryContext => new SingleQueryingEnumerable<Submission>(
+    (RelationalQueryContext)queryContext, 
+    RelationalCommandCache.QueryExpression(
+        Client Projections:
+            0 -> Dictionary<IProperty, int> { [Property: Submission.Id (int) Required PK AfterSave:Throw ValueGenerated.OnAdd, 0], [Property: Submission.AdditionalNotes (string), 1], [Property: Submission.AiCheckDetails (string), 2], [Property: Submission.AiCheckScore (decimal?), 3], [Property: Submission.AiCheckStatus (AiCheckStatus) Required ValueGenerated.OnAdd, 4], [Property: Submission.CreatedAt (DateTime) Required, 5], [Property: Submission.CreatedBy (string), 6], [Property: Submission.DeletedAt (DateTime?), 7], [Property: Submission.DocumentUrl (string) MaxLength(500), 8], [Property: Submission.IsActive (bool) Required, 9], [Property: Submission.LastModifiedAt (DateTime?), 10], [Property: Submission.LastModifiedBy (string), 11], [Property: Submission.PhaseId (int) Required FK Index, 12], [Property: Submission.Status (SubmissionStatus) Required Index ValueGenerated.OnAdd, 13], [Property: Submission.SubmissionRound (int) Required Index ValueGenerated.OnAdd, 14], [Property: Submission.SubmittedAt (DateTime?) Index ValueGenerated.OnAdd, 15], [Property: Submission.SubmittedBy (int) Required FK Index, 16], [Property: Submission.TopicId (int) Required FK Index, 17], [Property: Submission.TopicVersionId (int?) FK Index, 18] }
+            1 -> Dictionary<IProperty, int> { [Property: User.Id (int) Required PK AfterSave:Throw ValueGenerated.OnAdd, 19], [Property: User.AccessFailedCount (int) Required, 20], [Property: User.ConcurrencyStamp (string), 21], [Property: User.CreatedAt (DateTime) Required, 22], [Property: User.DeletedAt (DateTime?), 23], [Property: User.Email (string), 24], [Property: User.EmailConfirmed (bool) Required, 25], [Property: User.LastModifiedAt (DateTime) Required, 26], [Property: User.LastModifiedBy (string), 27], [Property: User.LockoutEnabled (bool) Required, 28], [Property: User.LockoutEnd (DateTimeOffset?), 29], [Property: User.NormalizedEmail (string), 30], [Property: User.NormalizedUserName (string), 31], [Property: User.PasswordHash (string), 32], [Property: User.PhoneNumber (string), 33], [Property: User.PhoneNumberConfirmed (bool) Required, 34], [Property: User.SecurityStamp (string), 35], [Property: User.TwoFactorEnabled (bool) Required, 36], [Property: User.UserName (string), 37] }
+            2 -> Dictionary<IProperty, int> { [Property: Topic.Id (int) Required PK AfterSave:Throw ValueGenerated.OnAdd, 38], [Property: Topic.Abbreviation (string), 39], [Property: Topic.CategoryId (int?) FK Index, 40], [Property: Topic.Content (string), 41], [Property: Topic.Context (string), 42], [Property: Topic.CreatedAt (DateTime) Required ValueGenerated.OnAdd, 43], [Property: Topic.CreatedBy (string), 44], [Property: Topic.DeletedAt (DateTime?), 45], [Property: Topic.Description (string), 46], [Property: Topic.EN_Title (string) Required MaxLength(500), 47], [Property: Topic.IsActive (bool) Required, 48], [Property: Topic.IsApproved (bool) Required Index Sentinel:True ValueGenerated.OnAdd, 49], [Property: Topic.IsLegacy (bool) Required Index ValueGenerated.OnAdd, 50], [Property: Topic.LastModifiedAt (DateTime?), 51], [Property: Topic.LastModifiedBy (string), 52], [Property: Topic.MaxStudents (int) Required ValueGenerated.OnAdd, 53], [Property: Topic.Objectives (string), 54], [Property: Topic.PotentialDuplicate (string), 55], [Property: Topic.Problem (string), 56], [Property: Topic.SemesterId (int) Required FK Index, 57], [Property: Topic.SupervisorId (int) Required FK Index, 58], [Property: Topic.VN_title (string), 59] }
+        SELECT t.Id, t.AdditionalNotes, t.AiCheckDetails, t.AiCheckScore, t.AiCheckStatus, t.CreatedAt, t.CreatedBy, t.DeletedAt, t.DocumentUrl, t.IsActive, t.LastModifiedAt, t.LastModifiedBy, t.PhaseId, t.Status, t.SubmissionRound, t.SubmittedAt, t.SubmittedBy, t.TopicId, t.TopicVersionId, u.Id, u.AccessFailedCount, u.ConcurrencyStamp, u.CreatedAt, u.DeletedAt, u.Email, u.EmailConfirmed, u.LastModifiedAt, u.LastModifiedBy, u.LockoutEnabled, u.LockoutEnd, u.NormalizedEmail, u.NormalizedUserName, u.PasswordHash, u.PhoneNumber, u.PhoneNumberConfirmed, u.SecurityStamp, u.TwoFactorEnabled, u.UserName, t0.Id, t0.Abbreviation, t0.CategoryId, t0.Content, t0.Context, t0.CreatedAt, t0.CreatedBy, t0.DeletedAt, t0.Description, t0.EN_Title, t0.IsActive, t0.IsApproved, t0.IsLegacy, t0.LastModifiedAt, t0.LastModifiedBy, t0.MaxStudents, t0.Objectives, t0.PotentialDuplicate, t0.Problem, t0.SemesterId, t0.SupervisorId, t0.VN_title
+        FROM 
+        (
+            SELECT s.Id, s.AdditionalNotes, s.AiCheckDetails, s.AiCheckScore, s.AiCheckStatus, s.CreatedAt, s.CreatedBy, s.DeletedAt, s.DocumentUrl, s.IsActive, s.LastModifiedAt, s.LastModifiedBy, s.PhaseId, s.Status, s.SubmissionRound, s.SubmittedAt, s.SubmittedBy, s.TopicId, s.TopicVersionId
+            FROM submissions AS s
+            ORDER BY s.SubmittedAt DESC
+            OFFSET @__p_0 ROWS FETCH NEXT @__p_1 ROWS ONLY
+        ) AS t
+        INNER JOIN users AS u ON t.SubmittedBy == u.Id
+        LEFT JOIN topics AS t0 ON t.TopicId == t0.Id
+        ORDER BY t.SubmittedAt DESC), 
+    null, 
+    Func<QueryContext, DbDataReader, ResultContext, SingleQueryResultCoordinator, Submission>, 
+    App.DAL.Context.MyDbContext, 
+    False, 
+    False, 
+    True
+)'
+2025-09-29 03:54:18.701 +07:00 [DBG] Opening connection to database 'capbot_db' on server 'localhost'.
+2025-09-29 03:54:18.702 +07:00 [DBG] Opened connection to database 'capbot_db' on server 'localhost'.
+2025-09-29 03:54:18.702 +07:00 [DBG] Creating DbCommand for 'ExecuteReader'.
+2025-09-29 03:54:18.702 +07:00 [DBG] Created DbCommand for 'ExecuteReader' (0ms).
+2025-09-29 03:54:18.703 +07:00 [DBG] Initialized DbCommand for 'ExecuteReader' (0ms).
+2025-09-29 03:54:18.704 +07:00 [DBG] Executing DbCommand [Parameters=[@__p_0='?' (DbType = Int32), @__p_1='?' (DbType = Int32)], CommandType='"Text"', CommandTimeout='30']
+SELECT [t].[Id], [t].[AdditionalNotes], [t].[AiCheckDetails], [t].[AiCheckScore], [t].[AiCheckStatus], [t].[CreatedAt], [t].[CreatedBy], [t].[DeletedAt], [t].[DocumentUrl], [t].[IsActive], [t].[LastModifiedAt], [t].[LastModifiedBy], [t].[PhaseId], [t].[Status], [t].[SubmissionRound], [t].[SubmittedAt], [t].[SubmittedBy], [t].[TopicId], [t].[TopicVersionId], [u].[Id], [u].[AccessFailedCount], [u].[ConcurrencyStamp], [u].[CreatedAt], [u].[DeletedAt], [u].[Email], [u].[EmailConfirmed], [u].[LastModifiedAt], [u].[LastModifiedBy], [u].[LockoutEnabled], [u].[LockoutEnd], [u].[NormalizedEmail], [u].[NormalizedUserName], [u].[PasswordHash], [u].[PhoneNumber], [u].[PhoneNumberConfirmed], [u].[SecurityStamp], [u].[TwoFactorEnabled], [u].[UserName], [t0].[Id], [t0].[Abbreviation], [t0].[CategoryId], [t0].[Content], [t0].[Context], [t0].[CreatedAt], [t0].[CreatedBy], [t0].[DeletedAt], [t0].[Description], [t0].[EN_Title], [t0].[IsActive], [t0].[IsApproved], [t0].[IsLegacy], [t0].[LastModifiedAt], [t0].[LastModifiedBy], [t0].[MaxStudents], [t0].[Objectives], [t0].[PotentialDuplicate], [t0].[Problem], [t0].[SemesterId], [t0].[SupervisorId], [t0].[VN_title]
+FROM (
+    SELECT [s].[Id], [s].[AdditionalNotes], [s].[AiCheckDetails], [s].[AiCheckScore], [s].[AiCheckStatus], [s].[CreatedAt], [s].[CreatedBy], [s].[DeletedAt], [s].[DocumentUrl], [s].[IsActive], [s].[LastModifiedAt], [s].[LastModifiedBy], [s].[PhaseId], [s].[Status], [s].[SubmissionRound], [s].[SubmittedAt], [s].[SubmittedBy], [s].[TopicId], [s].[TopicVersionId]
+    FROM [submissions] AS [s]
+    ORDER BY [s].[SubmittedAt] DESC
+    OFFSET @__p_0 ROWS FETCH NEXT @__p_1 ROWS ONLY
+) AS [t]
+INNER JOIN [users] AS [u] ON [t].[SubmittedBy] = [u].[Id]
+LEFT JOIN [topics] AS [t0] ON [t].[TopicId] = [t0].[Id]
+ORDER BY [t].[SubmittedAt] DESC
+2025-09-29 03:54:18.725 +07:00 [INF] Executed DbCommand (21ms) [Parameters=[@__p_0='?' (DbType = Int32), @__p_1='?' (DbType = Int32)], CommandType='"Text"', CommandTimeout='30']
+SELECT [t].[Id], [t].[AdditionalNotes], [t].[AiCheckDetails], [t].[AiCheckScore], [t].[AiCheckStatus], [t].[CreatedAt], [t].[CreatedBy], [t].[DeletedAt], [t].[DocumentUrl], [t].[IsActive], [t].[LastModifiedAt], [t].[LastModifiedBy], [t].[PhaseId], [t].[Status], [t].[SubmissionRound], [t].[SubmittedAt], [t].[SubmittedBy], [t].[TopicId], [t].[TopicVersionId], [u].[Id], [u].[AccessFailedCount], [u].[ConcurrencyStamp], [u].[CreatedAt], [u].[DeletedAt], [u].[Email], [u].[EmailConfirmed], [u].[LastModifiedAt], [u].[LastModifiedBy], [u].[LockoutEnabled], [u].[LockoutEnd], [u].[NormalizedEmail], [u].[NormalizedUserName], [u].[PasswordHash], [u].[PhoneNumber], [u].[PhoneNumberConfirmed], [u].[SecurityStamp], [u].[TwoFactorEnabled], [u].[UserName], [t0].[Id], [t0].[Abbreviation], [t0].[CategoryId], [t0].[Content], [t0].[Context], [t0].[CreatedAt], [t0].[CreatedBy], [t0].[DeletedAt], [t0].[Description], [t0].[EN_Title], [t0].[IsActive], [t0].[IsApproved], [t0].[IsLegacy], [t0].[LastModifiedAt], [t0].[LastModifiedBy], [t0].[MaxStudents], [t0].[Objectives], [t0].[PotentialDuplicate], [t0].[Problem], [t0].[SemesterId], [t0].[SupervisorId], [t0].[VN_title]
+FROM (
+    SELECT [s].[Id], [s].[AdditionalNotes], [s].[AiCheckDetails], [s].[AiCheckScore], [s].[AiCheckStatus], [s].[CreatedAt], [s].[CreatedBy], [s].[DeletedAt], [s].[DocumentUrl], [s].[IsActive], [s].[LastModifiedAt], [s].[LastModifiedBy], [s].[PhaseId], [s].[Status], [s].[SubmissionRound], [s].[SubmittedAt], [s].[SubmittedBy], [s].[TopicId], [s].[TopicVersionId]
+    FROM [submissions] AS [s]
+    ORDER BY [s].[SubmittedAt] DESC
+    OFFSET @__p_0 ROWS FETCH NEXT @__p_1 ROWS ONLY
+) AS [t]
+INNER JOIN [users] AS [u] ON [t].[SubmittedBy] = [u].[Id]
+LEFT JOIN [topics] AS [t0] ON [t].[TopicId] = [t0].[Id]
+ORDER BY [t].[SubmittedAt] DESC
+2025-09-29 03:54:18.739 +07:00 [DBG] Closing data reader to 'capbot_db' on server 'localhost'.
+2025-09-29 03:54:18.740 +07:00 [DBG] A data reader for 'capbot_db' on server 'localhost' is being disposed after spending 14ms reading results.
+2025-09-29 03:54:18.740 +07:00 [DBG] Closing connection to database 'capbot_db' on server 'localhost'.
+2025-09-29 03:54:18.741 +07:00 [DBG] Closed connection to database 'capbot_db' on server 'localhost' (0ms).
+2025-09-29 03:54:18.746 +07:00 [DBG] List of registered output formatters, in the following order: ["Microsoft.AspNetCore.OData.Formatter.ODataOutputFormatter","Microsoft.AspNetCore.OData.Formatter.ODataOutputFormatter","Microsoft.AspNetCore.OData.Formatter.ODataOutputFormatter","Microsoft.AspNetCore.Mvc.Formatters.HttpNoContentOutputFormatter","Microsoft.AspNetCore.Mvc.Formatters.StringOutputFormatter","Microsoft.AspNetCore.Mvc.Formatters.StreamOutputFormatter","Microsoft.AspNetCore.Mvc.Formatters.SystemTextJsonOutputFormatter"]
+2025-09-29 03:54:18.746 +07:00 [DBG] No information found on request to perform content negotiation.
+2025-09-29 03:54:18.748 +07:00 [DBG] Attempting to select the first output formatter in the output formatters list which supports a content type from the explicitly specified content types '["application/json"]'.
+2025-09-29 03:54:18.749 +07:00 [DBG] Selected output formatter 'Microsoft.AspNetCore.Mvc.Formatters.SystemTextJsonOutputFormatter' and content type 'application/json' to write the response.
+2025-09-29 03:54:18.749 +07:00 [INF] Executing ObjectResult, writing value of type 'FS.Commons.FSResponse'.
+2025-09-29 03:54:18.772 +07:00 [INF] Executed action CapBot.api.Controllers.SubmissionController.List (CapBot.api) in 444.1031ms
+2025-09-29 03:54:18.773 +07:00 [INF] Executed endpoint 'CapBot.api.Controllers.SubmissionController.List (CapBot.api)'
+2025-09-29 03:54:18.775 +07:00 [DBG] Connection id "0HNFUQ4FJ9UMK" completed keep alive response.
+2025-09-29 03:54:18.776 +07:00 [DBG] 'MyDbContext' disposed.
+2025-09-29 03:54:18.777 +07:00 [DBG] Disposing connection to database 'capbot_db' on server 'localhost'.
+2025-09-29 03:54:18.777 +07:00 [DBG] Disposed connection to database '' on server '' (0ms).
+2025-09-29 03:54:18.777 +07:00 [INF] Request finished HTTP/1.1 GET http://localhost:5207/api/submission/list?PageNumber=1&PageSize=10 - 200 null application/json; charset=utf-8 696.3788ms
+2025-09-29 03:54:23.130 +07:00 [INF] Request starting HTTP/1.1 OPTIONS http://localhost:5207/api/user-profiles/me - null null
+2025-09-29 03:54:23.130 +07:00 [DBG] OPTIONS requests are not supported
+2025-09-29 03:54:23.130 +07:00 [DBG] OPTIONS requests are not supported
+2025-09-29 03:54:23.130 +07:00 [DBG] The request has an origin header: 'http://localhost:3000'.
+2025-09-29 03:54:23.130 +07:00 [INF] CORS policy execution successful.
+2025-09-29 03:54:23.131 +07:00 [DBG] The request is a preflight request.
+2025-09-29 03:54:23.131 +07:00 [DBG] Connection id "0HNFUQ4FJ9UMK" completed keep alive response.
+2025-09-29 03:54:23.131 +07:00 [INF] Request finished HTTP/1.1 OPTIONS http://localhost:5207/api/user-profiles/me - 204 null null 0.8184ms
+2025-09-29 03:54:23.135 +07:00 [INF] Request starting HTTP/1.1 OPTIONS http://localhost:5207/api/submission/list?PageNumber=1&PageSize=10 - null null
+2025-09-29 03:54:23.135 +07:00 [DBG] OPTIONS requests are not supported
+2025-09-29 03:54:23.135 +07:00 [INF] Request starting HTTP/1.1 GET http://localhost:5207/api/user-profiles/me - null null
+2025-09-29 03:54:23.135 +07:00 [DBG] OPTIONS requests are not supported
+2025-09-29 03:54:23.135 +07:00 [DBG] The request has an origin header: 'http://localhost:3000'.
+2025-09-29 03:54:23.135 +07:00 [INF] CORS policy execution successful.
+2025-09-29 03:54:23.135 +07:00 [DBG] The request path /api/user-profiles/me does not match a supported file type
+2025-09-29 03:54:23.135 +07:00 [DBG] The request is a preflight request.
+2025-09-29 03:54:23.135 +07:00 [DBG] The request path /api/user-profiles/me does not match a supported file type
+2025-09-29 03:54:23.136 +07:00 [DBG] Connection id "0HNFUQ4FJ9UML" completed keep alive response.
+2025-09-29 03:54:23.136 +07:00 [DBG] The request has an origin header: 'http://localhost:3000'.
+2025-09-29 03:54:23.136 +07:00 [INF] CORS policy execution successful.
+2025-09-29 03:54:23.136 +07:00 [INF] Request finished HTTP/1.1 OPTIONS http://localhost:5207/api/submission/list?PageNumber=1&PageSize=10 - 204 null null 5.3702ms
+2025-09-29 03:54:23.139 +07:00 [INF] Request starting HTTP/1.1 GET http://localhost:5207/api/submission/list?PageNumber=1&PageSize=10 - null null
+2025-09-29 03:54:23.140 +07:00 [DBG] The request path /api/submission/list does not match a supported file type
+2025-09-29 03:54:23.140 +07:00 [DBG] The request path /api/submission/list does not match a supported file type
+2025-09-29 03:54:23.140 +07:00 [DBG] The request has an origin header: 'http://localhost:3000'.
+2025-09-29 03:54:23.140 +07:00 [INF] CORS policy execution successful.
+2025-09-29 03:54:23.144 +07:00 [DBG] 2 candidate(s) found for the request path '/api/user-profiles/me'
+2025-09-29 03:54:23.144 +07:00 [DBG] Endpoint 'CapBot.api.Controllers.UserProfileController.GetMyProfile (CapBot.api)' with route pattern 'api/user-profiles/me' is valid for the request path '/api/user-profiles/me'
+2025-09-29 03:54:23.144 +07:00 [DBG] Endpoint 'CapBot.api.Controllers.UserProfileController.GetById (CapBot.api)' with route pattern 'api/user-profiles/{id}' is valid for the request path '/api/user-profiles/me'
+2025-09-29 03:54:23.145 +07:00 [DBG] Request matched endpoint 'CapBot.api.Controllers.UserProfileController.GetMyProfile (CapBot.api)'
+2025-09-29 03:54:23.146 +07:00 [DBG] 1 candidate(s) found for the request path '/api/submission/list'
+2025-09-29 03:54:23.146 +07:00 [DBG] Endpoint 'CapBot.api.Controllers.SubmissionController.List (CapBot.api)' with route pattern 'api/submission/list' is valid for the request path '/api/submission/list'
+2025-09-29 03:54:23.146 +07:00 [DBG] Request matched endpoint 'CapBot.api.Controllers.SubmissionController.List (CapBot.api)'
+2025-09-29 03:54:23.147 +07:00 [DBG] Successfully validated the token.
+2025-09-29 03:54:23.148 +07:00 [DBG] AuthenticationScheme: Bearer was successfully authenticated.
+2025-09-29 03:54:23.148 +07:00 [DBG] Successfully validated the token.
+2025-09-29 03:54:23.148 +07:00 [DBG] AuthenticationScheme: Bearer was successfully authenticated.
+2025-09-29 03:54:23.150 +07:00 [DBG] Authorization was successful.
+2025-09-29 03:54:23.150 +07:00 [DBG] Authorization was successful.
+2025-09-29 03:54:23.151 +07:00 [INF] Executing endpoint 'CapBot.api.Controllers.UserProfileController.GetMyProfile (CapBot.api)'
+2025-09-29 03:54:23.151 +07:00 [INF] Executing endpoint 'CapBot.api.Controllers.SubmissionController.List (CapBot.api)'
+2025-09-29 03:54:23.152 +07:00 [INF] Route matched with {action = "List", controller = "Submission"}. Executing controller action with signature System.Threading.Tasks.Task`1[Microsoft.AspNetCore.Mvc.IActionResult] List(App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO) on controller CapBot.api.Controllers.SubmissionController (CapBot.api).
+2025-09-29 03:54:23.152 +07:00 [INF] Route matched with {action = "GetMyProfile", controller = "UserProfile"}. Executing controller action with signature System.Threading.Tasks.Task`1[Microsoft.AspNetCore.Mvc.IActionResult] GetMyProfile() on controller CapBot.api.Controllers.UserProfileController (CapBot.api).
+2025-09-29 03:54:23.153 +07:00 [DBG] Execution plan of authorization filters (in the following order): ["None"]
+2025-09-29 03:54:23.153 +07:00 [DBG] Execution plan of resource filters (in the following order): ["None"]
+2025-09-29 03:54:23.154 +07:00 [DBG] Execution plan of authorization filters (in the following order): ["None"]
+2025-09-29 03:54:23.154 +07:00 [DBG] Execution plan of resource filters (in the following order): ["None"]
+2025-09-29 03:54:23.154 +07:00 [DBG] Execution plan of action filters (in the following order): ["Microsoft.AspNetCore.Mvc.ModelBinding.UnsupportedContentTypeFilter (Order: -3000)"]
+2025-09-29 03:54:23.154 +07:00 [DBG] Execution plan of exception filters (in the following order): ["None"]
+2025-09-29 03:54:23.155 +07:00 [DBG] Execution plan of result filters (in the following order): ["Microsoft.AspNetCore.Mvc.Infrastructure.ClientErrorResultFilter (Order: -2000)","Microsoft.AspNetCore.Mvc.ProducesAttribute (Order: 0)"]
+2025-09-29 03:54:23.155 +07:00 [DBG] Execution plan of action filters (in the following order): ["Microsoft.AspNetCore.Mvc.ModelBinding.UnsupportedContentTypeFilter (Order: -3000)"]
+2025-09-29 03:54:23.155 +07:00 [DBG] Executing controller factory for controller CapBot.api.Controllers.SubmissionController (CapBot.api)
+2025-09-29 03:54:23.155 +07:00 [DBG] Execution plan of exception filters (in the following order): ["None"]
+2025-09-29 03:54:23.155 +07:00 [DBG] Execution plan of result filters (in the following order): ["Microsoft.AspNetCore.Mvc.Infrastructure.ClientErrorResultFilter (Order: -2000)"]
+2025-09-29 03:54:23.155 +07:00 [DBG] Executing controller factory for controller CapBot.api.Controllers.UserProfileController (CapBot.api)
+2025-09-29 03:54:23.157 +07:00 [DBG] Executed controller factory for controller CapBot.api.Controllers.UserProfileController (CapBot.api)
+2025-09-29 03:54:23.162 +07:00 [DBG] Entity Framework Core 8.0.16 initialized 'MyDbContext' using provider 'Microsoft.EntityFrameworkCore.SqlServer:8.0.13' with options: MigrationsAssembly=App.DAL 
+2025-09-29 03:54:23.162 +07:00 [DBG] Executed controller factory for controller CapBot.api.Controllers.SubmissionController (CapBot.api)
+2025-09-29 03:54:23.163 +07:00 [DBG] Attempting to bind parameter 'query' of type 'App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO' ...
+2025-09-29 03:54:23.163 +07:00 [DBG] Attempting to bind parameter 'query' of type 'App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO' using the name '' in request data ...
+2025-09-29 03:54:23.164 +07:00 [DBG] Attempting to bind property 'App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO.TopicVersionId' of type 'System.Nullable`1[System.Int32]' using the name 'TopicVersionId' in request data ...
+2025-09-29 03:54:23.164 +07:00 [DBG] Could not find a value in the request with name 'TopicVersionId' for binding property 'App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO.TopicVersionId' of type 'System.Nullable`1[System.Int32]'.
+2025-09-29 03:54:23.164 +07:00 [DBG] Done attempting to bind property 'App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO.TopicVersionId' of type 'System.Nullable`1[System.Int32]'.
+2025-09-29 03:54:23.164 +07:00 [DBG] Attempting to bind property 'App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO.PhaseId' of type 'System.Nullable`1[System.Int32]' using the name 'PhaseId' in request data ...
+2025-09-29 03:54:23.164 +07:00 [DBG] Creating DbConnection.
+2025-09-29 03:54:23.165 +07:00 [DBG] Could not find a value in the request with name 'PhaseId' for binding property 'App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO.PhaseId' of type 'System.Nullable`1[System.Int32]'.
+2025-09-29 03:54:23.165 +07:00 [DBG] Created DbConnection. (0ms).
+2025-09-29 03:54:23.165 +07:00 [DBG] Opening connection to database 'capbot_db' on server 'localhost'.
+2025-09-29 03:54:23.165 +07:00 [DBG] Done attempting to bind property 'App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO.PhaseId' of type 'System.Nullable`1[System.Int32]'.
+2025-09-29 03:54:23.165 +07:00 [DBG] Attempting to bind property 'App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO.SemesterId' of type 'System.Nullable`1[System.Int32]' using the name 'SemesterId' in request data ...
+2025-09-29 03:54:23.165 +07:00 [DBG] Could not find a value in the request with name 'SemesterId' for binding property 'App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO.SemesterId' of type 'System.Nullable`1[System.Int32]'.
+2025-09-29 03:54:23.166 +07:00 [DBG] Done attempting to bind property 'App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO.SemesterId' of type 'System.Nullable`1[System.Int32]'.
+2025-09-29 03:54:23.165 +07:00 [DBG] Opened connection to database 'capbot_db' on server 'localhost'.
+2025-09-29 03:54:23.166 +07:00 [DBG] Attempting to bind property 'App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO.Status' of type 'System.Nullable`1[App.Entities.Enums.SubmissionStatus]' using the name 'Status' in request data ...
+2025-09-29 03:54:23.166 +07:00 [DBG] Creating DbCommand for 'ExecuteReader'.
+2025-09-29 03:54:23.167 +07:00 [DBG] Could not find a value in the request with name 'Status' for binding property 'App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO.Status' of type 'System.Nullable`1[App.Entities.Enums.SubmissionStatus]'.
+2025-09-29 03:54:23.167 +07:00 [DBG] Created DbCommand for 'ExecuteReader' (0ms).
+2025-09-29 03:54:23.167 +07:00 [DBG] Done attempting to bind property 'App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO.Status' of type 'System.Nullable`1[App.Entities.Enums.SubmissionStatus]'.
+2025-09-29 03:54:23.167 +07:00 [DBG] Initialized DbCommand for 'ExecuteReader' (0ms).
+2025-09-29 03:54:23.167 +07:00 [DBG] Attempting to bind property 'App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO.PageNumber' of type 'System.Int32' using the name 'PageNumber' in request data ...
+2025-09-29 03:54:23.167 +07:00 [DBG] Done attempting to bind property 'App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO.PageNumber' of type 'System.Int32'.
+2025-09-29 03:54:23.169 +07:00 [DBG] Attempting to bind property 'App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO.PageSize' of type 'System.Int32' using the name 'PageSize' in request data ...
+2025-09-29 03:54:23.169 +07:00 [DBG] Done attempting to bind property 'App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO.PageSize' of type 'System.Int32'.
+2025-09-29 03:54:23.169 +07:00 [DBG] Attempting to bind property 'App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO.Keyword' of type 'System.String' using the name 'Keyword' in request data ...
+2025-09-29 03:54:23.170 +07:00 [DBG] Could not find a value in the request with name 'Keyword' for binding property 'App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO.Keyword' of type 'System.String'.
+2025-09-29 03:54:23.170 +07:00 [DBG] Done attempting to bind property 'App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO.Keyword' of type 'System.String'.
+2025-09-29 03:54:23.170 +07:00 [DBG] Attempting to bind property 'App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO.TotalRecord' of type 'System.Int32' using the name 'TotalRecord' in request data ...
+2025-09-29 03:54:23.170 +07:00 [DBG] Could not find a value in the request with name 'TotalRecord' for binding property 'App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO.TotalRecord' of type 'System.Int32'.
+2025-09-29 03:54:23.170 +07:00 [DBG] Executing DbCommand [Parameters=[@__targetUserId_0='?' (DbType = Int32)], CommandType='"Text"', CommandTimeout='30']
+SELECT TOP(1) [p].[Id], [p].[Address], [p].[Avatar], [p].[CoverImage], [p].[CreatedAt], [p].[CreatedBy], [p].[DeletedAt], [p].[FullName], [p].[IsActive], [p].[LastModifiedAt], [p].[LastModifiedBy], [p].[UserId]
+FROM [profiles] AS [p]
+WHERE [p].[UserId] = @__targetUserId_0 AND [p].[IsActive] = CAST(1 AS bit) AND [p].[DeletedAt] IS NULL AND [p].[DeletedAt] IS NULL
+2025-09-29 03:54:23.170 +07:00 [DBG] Done attempting to bind property 'App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO.TotalRecord' of type 'System.Int32'.
+2025-09-29 03:54:23.171 +07:00 [DBG] Done attempting to bind parameter 'query' of type 'App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO'.
+2025-09-29 03:54:23.171 +07:00 [DBG] Done attempting to bind parameter 'query' of type 'App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO'.
+2025-09-29 03:54:23.171 +07:00 [DBG] Attempting to validate the bound parameter 'query' of type 'App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO' ...
+2025-09-29 03:54:23.172 +07:00 [DBG] Done attempting to validate the bound parameter 'query' of type 'App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO'.
+2025-09-29 03:54:23.173 +07:00 [INF] Executed DbCommand (5ms) [Parameters=[@__targetUserId_0='?' (DbType = Int32)], CommandType='"Text"', CommandTimeout='30']
+SELECT TOP(1) [p].[Id], [p].[Address], [p].[Avatar], [p].[CoverImage], [p].[CreatedAt], [p].[CreatedBy], [p].[DeletedAt], [p].[FullName], [p].[IsActive], [p].[LastModifiedAt], [p].[LastModifiedBy], [p].[UserId]
+FROM [profiles] AS [p]
+WHERE [p].[UserId] = @__targetUserId_0 AND [p].[IsActive] = CAST(1 AS bit) AND [p].[DeletedAt] IS NULL AND [p].[DeletedAt] IS NULL
+2025-09-29 03:54:23.173 +07:00 [DBG] Closing data reader to 'capbot_db' on server 'localhost'.
+2025-09-29 03:54:23.174 +07:00 [DBG] A data reader for 'capbot_db' on server 'localhost' is being disposed after spending 0ms reading results.
+2025-09-29 03:54:23.174 +07:00 [DBG] Closing connection to database 'capbot_db' on server 'localhost'.
+2025-09-29 03:54:23.174 +07:00 [DBG] Closed connection to database 'capbot_db' on server 'localhost' (0ms).
+2025-09-29 03:54:23.175 +07:00 [DBG] Entity Framework Core 8.0.16 initialized 'MyDbContext' using provider 'Microsoft.EntityFrameworkCore.SqlServer:8.0.13' with options: MigrationsAssembly=App.DAL 
+2025-09-29 03:54:23.175 +07:00 [DBG] List of registered output formatters, in the following order: ["Microsoft.AspNetCore.OData.Formatter.ODataOutputFormatter","Microsoft.AspNetCore.OData.Formatter.ODataOutputFormatter","Microsoft.AspNetCore.OData.Formatter.ODataOutputFormatter","Microsoft.AspNetCore.Mvc.Formatters.HttpNoContentOutputFormatter","Microsoft.AspNetCore.Mvc.Formatters.StringOutputFormatter","Microsoft.AspNetCore.Mvc.Formatters.StreamOutputFormatter","Microsoft.AspNetCore.Mvc.Formatters.SystemTextJsonOutputFormatter"]
+2025-09-29 03:54:23.176 +07:00 [DBG] No information found on request to perform content negotiation.
+2025-09-29 03:54:23.176 +07:00 [DBG] Creating DbConnection.
+2025-09-29 03:54:23.176 +07:00 [DBG] Attempting to select an output formatter without using a content type as no explicit content types were specified for the response.
+2025-09-29 03:54:23.176 +07:00 [DBG] Attempting to select the first formatter in the output formatters list which can write the result.
+2025-09-29 03:54:23.176 +07:00 [DBG] Created DbConnection. (0ms).
+2025-09-29 03:54:23.176 +07:00 [DBG] Selected output formatter 'Microsoft.AspNetCore.Mvc.Formatters.SystemTextJsonOutputFormatter' and content type 'application/json' to write the response.
+2025-09-29 03:54:23.176 +07:00 [DBG] Opening connection to database 'capbot_db' on server 'localhost'.
+2025-09-29 03:54:23.177 +07:00 [INF] Executing ObjectResult, writing value of type 'FS.Commons.FSResponse'.
+2025-09-29 03:54:23.177 +07:00 [DBG] Opened connection to database 'capbot_db' on server 'localhost'.
+2025-09-29 03:54:23.177 +07:00 [INF] Executed action CapBot.api.Controllers.UserProfileController.GetMyProfile (CapBot.api) in 21.7475ms
+2025-09-29 03:54:23.177 +07:00 [DBG] Creating DbCommand for 'ExecuteReader'.
+2025-09-29 03:54:23.177 +07:00 [INF] Executed endpoint 'CapBot.api.Controllers.UserProfileController.GetMyProfile (CapBot.api)'
+2025-09-29 03:54:23.177 +07:00 [DBG] Created DbCommand for 'ExecuteReader' (0ms).
+2025-09-29 03:54:23.177 +07:00 [DBG] Connection id "0HNFUQ4FJ9UMK" completed keep alive response.
+2025-09-29 03:54:23.178 +07:00 [DBG] Initialized DbCommand for 'ExecuteReader' (0ms).
+2025-09-29 03:54:23.178 +07:00 [DBG] 'MyDbContext' disposed.
+2025-09-29 03:54:23.178 +07:00 [DBG] Executing DbCommand [Parameters=[], CommandType='"Text"', CommandTimeout='30']
+SELECT COUNT(*)
+FROM [submissions] AS [s]
+2025-09-29 03:54:23.178 +07:00 [DBG] Disposing connection to database 'capbot_db' on server 'localhost'.
+2025-09-29 03:54:23.178 +07:00 [DBG] Disposed connection to database '' on server '' (0ms).
+2025-09-29 03:54:23.178 +07:00 [INF] Request finished HTTP/1.1 GET http://localhost:5207/api/user-profiles/me - 200 null application/json; charset=utf-8 43.3294ms
+2025-09-29 03:54:23.180 +07:00 [INF] Executed DbCommand (2ms) [Parameters=[], CommandType='"Text"', CommandTimeout='30']
+SELECT COUNT(*)
+FROM [submissions] AS [s]
+2025-09-29 03:54:23.180 +07:00 [DBG] Closing data reader to 'capbot_db' on server 'localhost'.
+2025-09-29 03:54:23.180 +07:00 [DBG] A data reader for 'capbot_db' on server 'localhost' is being disposed after spending 0ms reading results.
+2025-09-29 03:54:23.181 +07:00 [DBG] Closing connection to database 'capbot_db' on server 'localhost'.
+2025-09-29 03:54:23.182 +07:00 [DBG] Closed connection to database 'capbot_db' on server 'localhost' (0ms).
+2025-09-29 03:54:23.184 +07:00 [DBG] Opening connection to database 'capbot_db' on server 'localhost'.
+2025-09-29 03:54:23.184 +07:00 [DBG] Opened connection to database 'capbot_db' on server 'localhost'.
+2025-09-29 03:54:23.185 +07:00 [DBG] Creating DbCommand for 'ExecuteReader'.
+2025-09-29 03:54:23.185 +07:00 [DBG] Created DbCommand for 'ExecuteReader' (0ms).
+2025-09-29 03:54:23.185 +07:00 [DBG] Initialized DbCommand for 'ExecuteReader' (0ms).
+2025-09-29 03:54:23.186 +07:00 [DBG] Executing DbCommand [Parameters=[@__p_0='?' (DbType = Int32), @__p_1='?' (DbType = Int32)], CommandType='"Text"', CommandTimeout='30']
+SELECT [t].[Id], [t].[AdditionalNotes], [t].[AiCheckDetails], [t].[AiCheckScore], [t].[AiCheckStatus], [t].[CreatedAt], [t].[CreatedBy], [t].[DeletedAt], [t].[DocumentUrl], [t].[IsActive], [t].[LastModifiedAt], [t].[LastModifiedBy], [t].[PhaseId], [t].[Status], [t].[SubmissionRound], [t].[SubmittedAt], [t].[SubmittedBy], [t].[TopicId], [t].[TopicVersionId], [u].[Id], [u].[AccessFailedCount], [u].[ConcurrencyStamp], [u].[CreatedAt], [u].[DeletedAt], [u].[Email], [u].[EmailConfirmed], [u].[LastModifiedAt], [u].[LastModifiedBy], [u].[LockoutEnabled], [u].[LockoutEnd], [u].[NormalizedEmail], [u].[NormalizedUserName], [u].[PasswordHash], [u].[PhoneNumber], [u].[PhoneNumberConfirmed], [u].[SecurityStamp], [u].[TwoFactorEnabled], [u].[UserName], [t0].[Id], [t0].[Abbreviation], [t0].[CategoryId], [t0].[Content], [t0].[Context], [t0].[CreatedAt], [t0].[CreatedBy], [t0].[DeletedAt], [t0].[Description], [t0].[EN_Title], [t0].[IsActive], [t0].[IsApproved], [t0].[IsLegacy], [t0].[LastModifiedAt], [t0].[LastModifiedBy], [t0].[MaxStudents], [t0].[Objectives], [t0].[PotentialDuplicate], [t0].[Problem], [t0].[SemesterId], [t0].[SupervisorId], [t0].[VN_title]
+FROM (
+    SELECT [s].[Id], [s].[AdditionalNotes], [s].[AiCheckDetails], [s].[AiCheckScore], [s].[AiCheckStatus], [s].[CreatedAt], [s].[CreatedBy], [s].[DeletedAt], [s].[DocumentUrl], [s].[IsActive], [s].[LastModifiedAt], [s].[LastModifiedBy], [s].[PhaseId], [s].[Status], [s].[SubmissionRound], [s].[SubmittedAt], [s].[SubmittedBy], [s].[TopicId], [s].[TopicVersionId]
+    FROM [submissions] AS [s]
+    ORDER BY [s].[SubmittedAt] DESC
+    OFFSET @__p_0 ROWS FETCH NEXT @__p_1 ROWS ONLY
+) AS [t]
+INNER JOIN [users] AS [u] ON [t].[SubmittedBy] = [u].[Id]
+LEFT JOIN [topics] AS [t0] ON [t].[TopicId] = [t0].[Id]
+ORDER BY [t].[SubmittedAt] DESC
+2025-09-29 03:54:23.189 +07:00 [INF] Executed DbCommand (3ms) [Parameters=[@__p_0='?' (DbType = Int32), @__p_1='?' (DbType = Int32)], CommandType='"Text"', CommandTimeout='30']
+SELECT [t].[Id], [t].[AdditionalNotes], [t].[AiCheckDetails], [t].[AiCheckScore], [t].[AiCheckStatus], [t].[CreatedAt], [t].[CreatedBy], [t].[DeletedAt], [t].[DocumentUrl], [t].[IsActive], [t].[LastModifiedAt], [t].[LastModifiedBy], [t].[PhaseId], [t].[Status], [t].[SubmissionRound], [t].[SubmittedAt], [t].[SubmittedBy], [t].[TopicId], [t].[TopicVersionId], [u].[Id], [u].[AccessFailedCount], [u].[ConcurrencyStamp], [u].[CreatedAt], [u].[DeletedAt], [u].[Email], [u].[EmailConfirmed], [u].[LastModifiedAt], [u].[LastModifiedBy], [u].[LockoutEnabled], [u].[LockoutEnd], [u].[NormalizedEmail], [u].[NormalizedUserName], [u].[PasswordHash], [u].[PhoneNumber], [u].[PhoneNumberConfirmed], [u].[SecurityStamp], [u].[TwoFactorEnabled], [u].[UserName], [t0].[Id], [t0].[Abbreviation], [t0].[CategoryId], [t0].[Content], [t0].[Context], [t0].[CreatedAt], [t0].[CreatedBy], [t0].[DeletedAt], [t0].[Description], [t0].[EN_Title], [t0].[IsActive], [t0].[IsApproved], [t0].[IsLegacy], [t0].[LastModifiedAt], [t0].[LastModifiedBy], [t0].[MaxStudents], [t0].[Objectives], [t0].[PotentialDuplicate], [t0].[Problem], [t0].[SemesterId], [t0].[SupervisorId], [t0].[VN_title]
+FROM (
+    SELECT [s].[Id], [s].[AdditionalNotes], [s].[AiCheckDetails], [s].[AiCheckScore], [s].[AiCheckStatus], [s].[CreatedAt], [s].[CreatedBy], [s].[DeletedAt], [s].[DocumentUrl], [s].[IsActive], [s].[LastModifiedAt], [s].[LastModifiedBy], [s].[PhaseId], [s].[Status], [s].[SubmissionRound], [s].[SubmittedAt], [s].[SubmittedBy], [s].[TopicId], [s].[TopicVersionId]
+    FROM [submissions] AS [s]
+    ORDER BY [s].[SubmittedAt] DESC
+    OFFSET @__p_0 ROWS FETCH NEXT @__p_1 ROWS ONLY
+) AS [t]
+INNER JOIN [users] AS [u] ON [t].[SubmittedBy] = [u].[Id]
+LEFT JOIN [topics] AS [t0] ON [t].[TopicId] = [t0].[Id]
+ORDER BY [t].[SubmittedAt] DESC
+2025-09-29 03:54:23.190 +07:00 [DBG] Closing data reader to 'capbot_db' on server 'localhost'.
+2025-09-29 03:54:23.190 +07:00 [DBG] A data reader for 'capbot_db' on server 'localhost' is being disposed after spending 0ms reading results.
+2025-09-29 03:54:23.190 +07:00 [DBG] Closing connection to database 'capbot_db' on server 'localhost'.
+2025-09-29 03:54:23.191 +07:00 [DBG] Closed connection to database 'capbot_db' on server 'localhost' (0ms).
+2025-09-29 03:54:23.191 +07:00 [DBG] List of registered output formatters, in the following order: ["Microsoft.AspNetCore.OData.Formatter.ODataOutputFormatter","Microsoft.AspNetCore.OData.Formatter.ODataOutputFormatter","Microsoft.AspNetCore.OData.Formatter.ODataOutputFormatter","Microsoft.AspNetCore.Mvc.Formatters.HttpNoContentOutputFormatter","Microsoft.AspNetCore.Mvc.Formatters.StringOutputFormatter","Microsoft.AspNetCore.Mvc.Formatters.StreamOutputFormatter","Microsoft.AspNetCore.Mvc.Formatters.SystemTextJsonOutputFormatter"]
+2025-09-29 03:54:23.192 +07:00 [DBG] No information found on request to perform content negotiation.
+2025-09-29 03:54:23.192 +07:00 [DBG] Attempting to select the first output formatter in the output formatters list which supports a content type from the explicitly specified content types '["application/json"]'.
+2025-09-29 03:54:23.192 +07:00 [DBG] Selected output formatter 'Microsoft.AspNetCore.Mvc.Formatters.SystemTextJsonOutputFormatter' and content type 'application/json' to write the response.
+2025-09-29 03:54:23.192 +07:00 [INF] Executing ObjectResult, writing value of type 'FS.Commons.FSResponse'.
+2025-09-29 03:54:23.193 +07:00 [INF] Executed action CapBot.api.Controllers.SubmissionController.List (CapBot.api) in 37.8224ms
+2025-09-29 03:54:23.193 +07:00 [INF] Executed endpoint 'CapBot.api.Controllers.SubmissionController.List (CapBot.api)'
+2025-09-29 03:54:23.194 +07:00 [DBG] Connection id "0HNFUQ4FJ9UML" completed keep alive response.
+2025-09-29 03:54:23.194 +07:00 [DBG] 'MyDbContext' disposed.
+2025-09-29 03:54:23.194 +07:00 [DBG] Disposing connection to database 'capbot_db' on server 'localhost'.
+2025-09-29 03:54:23.194 +07:00 [DBG] Disposed connection to database '' on server '' (0ms).
+2025-09-29 03:54:23.195 +07:00 [INF] Request finished HTTP/1.1 GET http://localhost:5207/api/submission/list?PageNumber=1&PageSize=10 - 200 null application/json; charset=utf-8 55.3302ms
+2025-09-29 03:54:23.195 +07:00 [INF] Request starting HTTP/1.1 GET http://localhost:5207/images/entities/11111111.png - null null
+2025-09-29 03:54:23.195 +07:00 [DBG] The request path /images/entities/11111111.png does not match an existing file
+2025-09-29 03:54:23.195 +07:00 [DBG] The request path /images/entities/11111111.png does not match an existing file
+2025-09-29 03:54:23.196 +07:00 [DBG] No candidates found for the request path '/images/entities/11111111.png'
+2025-09-29 03:54:23.196 +07:00 [DBG] Request did not match any endpoints
+2025-09-29 03:54:23.196 +07:00 [DBG] AuthenticationScheme: Bearer was not authenticated.
+2025-09-29 03:54:23.196 +07:00 [DBG] Connection id "0HNFUQ4FJ9UMI" completed keep alive response.
+2025-09-29 03:54:23.197 +07:00 [INF] Request finished HTTP/1.1 GET http://localhost:5207/images/entities/11111111.png - 404 0 null 1.7417ms
+2025-09-29 03:54:23.197 +07:00 [INF] Request reached the end of the middleware pipeline without being handled by application code. Request path: GET http://localhost:5207/images/entities/11111111.png, Response status code: 404
+2025-09-29 03:54:24.279 +07:00 [INF] Request starting HTTP/1.1 GET http://localhost:5207/api/user-profiles/me - null null
+2025-09-29 03:54:24.279 +07:00 [DBG] The request path /api/user-profiles/me does not match a supported file type
+2025-09-29 03:54:24.279 +07:00 [DBG] The request path /api/user-profiles/me does not match a supported file type
+2025-09-29 03:54:24.279 +07:00 [DBG] The request has an origin header: 'http://localhost:3000'.
+2025-09-29 03:54:24.279 +07:00 [INF] CORS policy execution successful.
+2025-09-29 03:54:24.279 +07:00 [DBG] 2 candidate(s) found for the request path '/api/user-profiles/me'
+2025-09-29 03:54:24.279 +07:00 [DBG] Endpoint 'CapBot.api.Controllers.UserProfileController.GetMyProfile (CapBot.api)' with route pattern 'api/user-profiles/me' is valid for the request path '/api/user-profiles/me'
+2025-09-29 03:54:24.279 +07:00 [DBG] Endpoint 'CapBot.api.Controllers.UserProfileController.GetById (CapBot.api)' with route pattern 'api/user-profiles/{id}' is valid for the request path '/api/user-profiles/me'
+2025-09-29 03:54:24.279 +07:00 [DBG] Request matched endpoint 'CapBot.api.Controllers.UserProfileController.GetMyProfile (CapBot.api)'
+2025-09-29 03:54:24.280 +07:00 [INF] Request starting HTTP/1.1 GET http://localhost:5207/api/submission/list?PageNumber=1&PageSize=10 - null null
+2025-09-29 03:54:24.280 +07:00 [DBG] Successfully validated the token.
+2025-09-29 03:54:24.280 +07:00 [DBG] AuthenticationScheme: Bearer was successfully authenticated.
+2025-09-29 03:54:24.280 +07:00 [DBG] The request path /api/submission/list does not match a supported file type
+2025-09-29 03:54:24.280 +07:00 [DBG] The request path /api/submission/list does not match a supported file type
+2025-09-29 03:54:24.280 +07:00 [DBG] Authorization was successful.
+2025-09-29 03:54:24.280 +07:00 [DBG] The request has an origin header: 'http://localhost:3000'.
+2025-09-29 03:54:24.280 +07:00 [INF] CORS policy execution successful.
+2025-09-29 03:54:24.280 +07:00 [INF] Executing endpoint 'CapBot.api.Controllers.UserProfileController.GetMyProfile (CapBot.api)'
+2025-09-29 03:54:24.280 +07:00 [DBG] 1 candidate(s) found for the request path '/api/submission/list'
+2025-09-29 03:54:24.280 +07:00 [DBG] Endpoint 'CapBot.api.Controllers.SubmissionController.List (CapBot.api)' with route pattern 'api/submission/list' is valid for the request path '/api/submission/list'
+2025-09-29 03:54:24.280 +07:00 [DBG] Request matched endpoint 'CapBot.api.Controllers.SubmissionController.List (CapBot.api)'
+2025-09-29 03:54:24.280 +07:00 [INF] Route matched with {action = "GetMyProfile", controller = "UserProfile"}. Executing controller action with signature System.Threading.Tasks.Task`1[Microsoft.AspNetCore.Mvc.IActionResult] GetMyProfile() on controller CapBot.api.Controllers.UserProfileController (CapBot.api).
+2025-09-29 03:54:24.281 +07:00 [DBG] Execution plan of authorization filters (in the following order): ["None"]
+2025-09-29 03:54:24.281 +07:00 [DBG] Execution plan of resource filters (in the following order): ["None"]
+2025-09-29 03:54:24.281 +07:00 [DBG] Execution plan of action filters (in the following order): ["Microsoft.AspNetCore.Mvc.ModelBinding.UnsupportedContentTypeFilter (Order: -3000)"]
+2025-09-29 03:54:24.281 +07:00 [DBG] Execution plan of exception filters (in the following order): ["None"]
+2025-09-29 03:54:24.281 +07:00 [DBG] Successfully validated the token.
+2025-09-29 03:54:24.281 +07:00 [DBG] Execution plan of result filters (in the following order): ["Microsoft.AspNetCore.Mvc.Infrastructure.ClientErrorResultFilter (Order: -2000)"]
+2025-09-29 03:54:24.281 +07:00 [DBG] AuthenticationScheme: Bearer was successfully authenticated.
+2025-09-29 03:54:24.281 +07:00 [DBG] Executing controller factory for controller CapBot.api.Controllers.UserProfileController (CapBot.api)
+2025-09-29 03:54:24.281 +07:00 [DBG] Authorization was successful.
+2025-09-29 03:54:24.281 +07:00 [INF] Executing endpoint 'CapBot.api.Controllers.SubmissionController.List (CapBot.api)'
+2025-09-29 03:54:24.281 +07:00 [INF] Route matched with {action = "List", controller = "Submission"}. Executing controller action with signature System.Threading.Tasks.Task`1[Microsoft.AspNetCore.Mvc.IActionResult] List(App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO) on controller CapBot.api.Controllers.SubmissionController (CapBot.api).
+2025-09-29 03:54:24.282 +07:00 [DBG] Execution plan of authorization filters (in the following order): ["None"]
+2025-09-29 03:54:24.282 +07:00 [DBG] Execution plan of resource filters (in the following order): ["None"]
+2025-09-29 03:54:24.286 +07:00 [DBG] Execution plan of action filters (in the following order): ["Microsoft.AspNetCore.Mvc.ModelBinding.UnsupportedContentTypeFilter (Order: -3000)"]
+2025-09-29 03:54:24.287 +07:00 [DBG] Execution plan of exception filters (in the following order): ["None"]
+2025-09-29 03:54:24.287 +07:00 [DBG] Execution plan of result filters (in the following order): ["Microsoft.AspNetCore.Mvc.Infrastructure.ClientErrorResultFilter (Order: -2000)","Microsoft.AspNetCore.Mvc.ProducesAttribute (Order: 0)"]
+2025-09-29 03:54:24.287 +07:00 [DBG] Executing controller factory for controller CapBot.api.Controllers.SubmissionController (CapBot.api)
+2025-09-29 03:54:24.316 +07:00 [DBG] Executed controller factory for controller CapBot.api.Controllers.UserProfileController (CapBot.api)
+2025-09-29 03:54:24.320 +07:00 [DBG] Entity Framework Core 8.0.16 initialized 'MyDbContext' using provider 'Microsoft.EntityFrameworkCore.SqlServer:8.0.13' with options: MigrationsAssembly=App.DAL 
+2025-09-29 03:54:24.321 +07:00 [DBG] Creating DbConnection.
+2025-09-29 03:54:24.321 +07:00 [DBG] Created DbConnection. (0ms).
+2025-09-29 03:54:24.321 +07:00 [DBG] Opening connection to database 'capbot_db' on server 'localhost'.
+2025-09-29 03:54:24.321 +07:00 [DBG] Opened connection to database 'capbot_db' on server 'localhost'.
+2025-09-29 03:54:24.321 +07:00 [DBG] Creating DbCommand for 'ExecuteReader'.
+2025-09-29 03:54:24.321 +07:00 [DBG] Created DbCommand for 'ExecuteReader' (0ms).
+2025-09-29 03:54:24.321 +07:00 [DBG] Initialized DbCommand for 'ExecuteReader' (0ms).
+2025-09-29 03:54:24.322 +07:00 [DBG] Executing DbCommand [Parameters=[@__targetUserId_0='?' (DbType = Int32)], CommandType='"Text"', CommandTimeout='30']
+SELECT TOP(1) [p].[Id], [p].[Address], [p].[Avatar], [p].[CoverImage], [p].[CreatedAt], [p].[CreatedBy], [p].[DeletedAt], [p].[FullName], [p].[IsActive], [p].[LastModifiedAt], [p].[LastModifiedBy], [p].[UserId]
+FROM [profiles] AS [p]
+WHERE [p].[UserId] = @__targetUserId_0 AND [p].[IsActive] = CAST(1 AS bit) AND [p].[DeletedAt] IS NULL AND [p].[DeletedAt] IS NULL
+2025-09-29 03:54:24.323 +07:00 [INF] Executed DbCommand (2ms) [Parameters=[@__targetUserId_0='?' (DbType = Int32)], CommandType='"Text"', CommandTimeout='30']
+SELECT TOP(1) [p].[Id], [p].[Address], [p].[Avatar], [p].[CoverImage], [p].[CreatedAt], [p].[CreatedBy], [p].[DeletedAt], [p].[FullName], [p].[IsActive], [p].[LastModifiedAt], [p].[LastModifiedBy], [p].[UserId]
+FROM [profiles] AS [p]
+WHERE [p].[UserId] = @__targetUserId_0 AND [p].[IsActive] = CAST(1 AS bit) AND [p].[DeletedAt] IS NULL AND [p].[DeletedAt] IS NULL
+2025-09-29 03:54:24.324 +07:00 [DBG] Closing data reader to 'capbot_db' on server 'localhost'.
+2025-09-29 03:54:24.324 +07:00 [DBG] A data reader for 'capbot_db' on server 'localhost' is being disposed after spending 0ms reading results.
+2025-09-29 03:54:24.324 +07:00 [DBG] Closing connection to database 'capbot_db' on server 'localhost'.
+2025-09-29 03:54:24.324 +07:00 [DBG] Closed connection to database 'capbot_db' on server 'localhost' (0ms).
+2025-09-29 03:54:24.325 +07:00 [DBG] List of registered output formatters, in the following order: ["Microsoft.AspNetCore.OData.Formatter.ODataOutputFormatter","Microsoft.AspNetCore.OData.Formatter.ODataOutputFormatter","Microsoft.AspNetCore.OData.Formatter.ODataOutputFormatter","Microsoft.AspNetCore.Mvc.Formatters.HttpNoContentOutputFormatter","Microsoft.AspNetCore.Mvc.Formatters.StringOutputFormatter","Microsoft.AspNetCore.Mvc.Formatters.StreamOutputFormatter","Microsoft.AspNetCore.Mvc.Formatters.SystemTextJsonOutputFormatter"]
+2025-09-29 03:54:24.325 +07:00 [DBG] No information found on request to perform content negotiation.
+2025-09-29 03:54:24.326 +07:00 [DBG] Attempting to select an output formatter without using a content type as no explicit content types were specified for the response.
+2025-09-29 03:54:24.326 +07:00 [DBG] Attempting to select the first formatter in the output formatters list which can write the result.
+2025-09-29 03:54:24.326 +07:00 [DBG] Selected output formatter 'Microsoft.AspNetCore.Mvc.Formatters.SystemTextJsonOutputFormatter' and content type 'application/json' to write the response.
+2025-09-29 03:54:24.326 +07:00 [INF] Executing ObjectResult, writing value of type 'FS.Commons.FSResponse'.
+2025-09-29 03:54:24.327 +07:00 [DBG] Executed controller factory for controller CapBot.api.Controllers.SubmissionController (CapBot.api)
+2025-09-29 03:54:24.327 +07:00 [INF] Executed action CapBot.api.Controllers.UserProfileController.GetMyProfile (CapBot.api) in 45.5878ms
+2025-09-29 03:54:24.327 +07:00 [INF] Executed endpoint 'CapBot.api.Controllers.UserProfileController.GetMyProfile (CapBot.api)'
+2025-09-29 03:54:24.327 +07:00 [DBG] Attempting to bind parameter 'query' of type 'App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO' ...
+2025-09-29 03:54:24.327 +07:00 [DBG] Connection id "0HNFUQ4FJ9UML" completed keep alive response.
+2025-09-29 03:54:24.327 +07:00 [DBG] Attempting to bind parameter 'query' of type 'App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO' using the name '' in request data ...
+2025-09-29 03:54:24.327 +07:00 [DBG] 'MyDbContext' disposed.
+2025-09-29 03:54:24.327 +07:00 [DBG] Attempting to bind property 'App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO.TopicVersionId' of type 'System.Nullable`1[System.Int32]' using the name 'TopicVersionId' in request data ...
+2025-09-29 03:54:24.327 +07:00 [DBG] Disposing connection to database 'capbot_db' on server 'localhost'.
+2025-09-29 03:54:24.327 +07:00 [DBG] Could not find a value in the request with name 'TopicVersionId' for binding property 'App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO.TopicVersionId' of type 'System.Nullable`1[System.Int32]'.
+2025-09-29 03:54:24.327 +07:00 [DBG] Disposed connection to database '' on server '' (0ms).
+2025-09-29 03:54:24.327 +07:00 [DBG] Done attempting to bind property 'App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO.TopicVersionId' of type 'System.Nullable`1[System.Int32]'.
+2025-09-29 03:54:24.327 +07:00 [DBG] Attempting to bind property 'App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO.PhaseId' of type 'System.Nullable`1[System.Int32]' using the name 'PhaseId' in request data ...
+2025-09-29 03:54:24.327 +07:00 [INF] Request finished HTTP/1.1 GET http://localhost:5207/api/user-profiles/me - 200 null application/json; charset=utf-8 48.7364ms
+2025-09-29 03:54:24.328 +07:00 [DBG] Could not find a value in the request with name 'PhaseId' for binding property 'App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO.PhaseId' of type 'System.Nullable`1[System.Int32]'.
+2025-09-29 03:54:24.328 +07:00 [DBG] Done attempting to bind property 'App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO.PhaseId' of type 'System.Nullable`1[System.Int32]'.
+2025-09-29 03:54:24.328 +07:00 [DBG] Attempting to bind property 'App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO.SemesterId' of type 'System.Nullable`1[System.Int32]' using the name 'SemesterId' in request data ...
+2025-09-29 03:54:24.328 +07:00 [DBG] Could not find a value in the request with name 'SemesterId' for binding property 'App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO.SemesterId' of type 'System.Nullable`1[System.Int32]'.
+2025-09-29 03:54:24.328 +07:00 [DBG] Done attempting to bind property 'App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO.SemesterId' of type 'System.Nullable`1[System.Int32]'.
+2025-09-29 03:54:24.328 +07:00 [DBG] Attempting to bind property 'App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO.Status' of type 'System.Nullable`1[App.Entities.Enums.SubmissionStatus]' using the name 'Status' in request data ...
+2025-09-29 03:54:24.328 +07:00 [DBG] Could not find a value in the request with name 'Status' for binding property 'App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO.Status' of type 'System.Nullable`1[App.Entities.Enums.SubmissionStatus]'.
+2025-09-29 03:54:24.328 +07:00 [DBG] Done attempting to bind property 'App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO.Status' of type 'System.Nullable`1[App.Entities.Enums.SubmissionStatus]'.
+2025-09-29 03:54:24.329 +07:00 [DBG] Attempting to bind property 'App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO.PageNumber' of type 'System.Int32' using the name 'PageNumber' in request data ...
+2025-09-29 03:54:24.329 +07:00 [DBG] Done attempting to bind property 'App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO.PageNumber' of type 'System.Int32'.
+2025-09-29 03:54:24.329 +07:00 [DBG] Attempting to bind property 'App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO.PageSize' of type 'System.Int32' using the name 'PageSize' in request data ...
+2025-09-29 03:54:24.329 +07:00 [DBG] Done attempting to bind property 'App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO.PageSize' of type 'System.Int32'.
+2025-09-29 03:54:24.329 +07:00 [DBG] Attempting to bind property 'App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO.Keyword' of type 'System.String' using the name 'Keyword' in request data ...
+2025-09-29 03:54:24.330 +07:00 [DBG] Could not find a value in the request with name 'Keyword' for binding property 'App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO.Keyword' of type 'System.String'.
+2025-09-29 03:54:24.330 +07:00 [DBG] Done attempting to bind property 'App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO.Keyword' of type 'System.String'.
+2025-09-29 03:54:24.330 +07:00 [DBG] Attempting to bind property 'App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO.TotalRecord' of type 'System.Int32' using the name 'TotalRecord' in request data ...
+2025-09-29 03:54:24.330 +07:00 [DBG] Could not find a value in the request with name 'TotalRecord' for binding property 'App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO.TotalRecord' of type 'System.Int32'.
+2025-09-29 03:54:24.330 +07:00 [DBG] Done attempting to bind property 'App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO.TotalRecord' of type 'System.Int32'.
+2025-09-29 03:54:24.331 +07:00 [DBG] Done attempting to bind parameter 'query' of type 'App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO'.
+2025-09-29 03:54:24.331 +07:00 [DBG] Done attempting to bind parameter 'query' of type 'App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO'.
+2025-09-29 03:54:24.332 +07:00 [DBG] Attempting to validate the bound parameter 'query' of type 'App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO' ...
+2025-09-29 03:54:24.332 +07:00 [DBG] Done attempting to validate the bound parameter 'query' of type 'App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO'.
+2025-09-29 03:54:24.337 +07:00 [DBG] Entity Framework Core 8.0.16 initialized 'MyDbContext' using provider 'Microsoft.EntityFrameworkCore.SqlServer:8.0.13' with options: MigrationsAssembly=App.DAL 
+2025-09-29 03:54:24.338 +07:00 [DBG] Creating DbConnection.
+2025-09-29 03:54:24.338 +07:00 [DBG] Created DbConnection. (0ms).
+2025-09-29 03:54:24.339 +07:00 [DBG] Opening connection to database 'capbot_db' on server 'localhost'.
+2025-09-29 03:54:24.339 +07:00 [DBG] Opened connection to database 'capbot_db' on server 'localhost'.
+2025-09-29 03:54:24.340 +07:00 [DBG] Creating DbCommand for 'ExecuteReader'.
+2025-09-29 03:54:24.340 +07:00 [DBG] Created DbCommand for 'ExecuteReader' (0ms).
+2025-09-29 03:54:24.340 +07:00 [DBG] Initialized DbCommand for 'ExecuteReader' (0ms).
+2025-09-29 03:54:24.340 +07:00 [DBG] Executing DbCommand [Parameters=[], CommandType='"Text"', CommandTimeout='30']
+SELECT COUNT(*)
+FROM [submissions] AS [s]
+2025-09-29 03:54:24.342 +07:00 [INF] Executed DbCommand (2ms) [Parameters=[], CommandType='"Text"', CommandTimeout='30']
+SELECT COUNT(*)
+FROM [submissions] AS [s]
+2025-09-29 03:54:24.343 +07:00 [DBG] Closing data reader to 'capbot_db' on server 'localhost'.
+2025-09-29 03:54:24.343 +07:00 [DBG] A data reader for 'capbot_db' on server 'localhost' is being disposed after spending 0ms reading results.
+2025-09-29 03:54:24.343 +07:00 [DBG] Closing connection to database 'capbot_db' on server 'localhost'.
+2025-09-29 03:54:24.343 +07:00 [DBG] Closed connection to database 'capbot_db' on server 'localhost' (0ms).
+2025-09-29 03:54:24.345 +07:00 [DBG] Opening connection to database 'capbot_db' on server 'localhost'.
+2025-09-29 03:54:24.346 +07:00 [DBG] Opened connection to database 'capbot_db' on server 'localhost'.
+2025-09-29 03:54:24.346 +07:00 [DBG] Creating DbCommand for 'ExecuteReader'.
+2025-09-29 03:54:24.346 +07:00 [DBG] Created DbCommand for 'ExecuteReader' (0ms).
+2025-09-29 03:54:24.346 +07:00 [DBG] Initialized DbCommand for 'ExecuteReader' (0ms).
+2025-09-29 03:54:24.347 +07:00 [DBG] Executing DbCommand [Parameters=[@__p_0='?' (DbType = Int32), @__p_1='?' (DbType = Int32)], CommandType='"Text"', CommandTimeout='30']
+SELECT [t].[Id], [t].[AdditionalNotes], [t].[AiCheckDetails], [t].[AiCheckScore], [t].[AiCheckStatus], [t].[CreatedAt], [t].[CreatedBy], [t].[DeletedAt], [t].[DocumentUrl], [t].[IsActive], [t].[LastModifiedAt], [t].[LastModifiedBy], [t].[PhaseId], [t].[Status], [t].[SubmissionRound], [t].[SubmittedAt], [t].[SubmittedBy], [t].[TopicId], [t].[TopicVersionId], [u].[Id], [u].[AccessFailedCount], [u].[ConcurrencyStamp], [u].[CreatedAt], [u].[DeletedAt], [u].[Email], [u].[EmailConfirmed], [u].[LastModifiedAt], [u].[LastModifiedBy], [u].[LockoutEnabled], [u].[LockoutEnd], [u].[NormalizedEmail], [u].[NormalizedUserName], [u].[PasswordHash], [u].[PhoneNumber], [u].[PhoneNumberConfirmed], [u].[SecurityStamp], [u].[TwoFactorEnabled], [u].[UserName], [t0].[Id], [t0].[Abbreviation], [t0].[CategoryId], [t0].[Content], [t0].[Context], [t0].[CreatedAt], [t0].[CreatedBy], [t0].[DeletedAt], [t0].[Description], [t0].[EN_Title], [t0].[IsActive], [t0].[IsApproved], [t0].[IsLegacy], [t0].[LastModifiedAt], [t0].[LastModifiedBy], [t0].[MaxStudents], [t0].[Objectives], [t0].[PotentialDuplicate], [t0].[Problem], [t0].[SemesterId], [t0].[SupervisorId], [t0].[VN_title]
+FROM (
+    SELECT [s].[Id], [s].[AdditionalNotes], [s].[AiCheckDetails], [s].[AiCheckScore], [s].[AiCheckStatus], [s].[CreatedAt], [s].[CreatedBy], [s].[DeletedAt], [s].[DocumentUrl], [s].[IsActive], [s].[LastModifiedAt], [s].[LastModifiedBy], [s].[PhaseId], [s].[Status], [s].[SubmissionRound], [s].[SubmittedAt], [s].[SubmittedBy], [s].[TopicId], [s].[TopicVersionId]
+    FROM [submissions] AS [s]
+    ORDER BY [s].[SubmittedAt] DESC
+    OFFSET @__p_0 ROWS FETCH NEXT @__p_1 ROWS ONLY
+) AS [t]
+INNER JOIN [users] AS [u] ON [t].[SubmittedBy] = [u].[Id]
+LEFT JOIN [topics] AS [t0] ON [t].[TopicId] = [t0].[Id]
+ORDER BY [t].[SubmittedAt] DESC
+2025-09-29 03:54:24.348 +07:00 [INF] Request starting HTTP/1.1 GET http://localhost:5207/images/entities/11111111.png - null null
+2025-09-29 03:54:24.349 +07:00 [DBG] The request path /images/entities/11111111.png does not match an existing file
+2025-09-29 03:54:24.349 +07:00 [DBG] The request path /images/entities/11111111.png does not match an existing file
+2025-09-29 03:54:24.349 +07:00 [DBG] No candidates found for the request path '/images/entities/11111111.png'
+2025-09-29 03:54:24.349 +07:00 [DBG] Request did not match any endpoints
+2025-09-29 03:54:24.349 +07:00 [INF] Executed DbCommand (3ms) [Parameters=[@__p_0='?' (DbType = Int32), @__p_1='?' (DbType = Int32)], CommandType='"Text"', CommandTimeout='30']
+SELECT [t].[Id], [t].[AdditionalNotes], [t].[AiCheckDetails], [t].[AiCheckScore], [t].[AiCheckStatus], [t].[CreatedAt], [t].[CreatedBy], [t].[DeletedAt], [t].[DocumentUrl], [t].[IsActive], [t].[LastModifiedAt], [t].[LastModifiedBy], [t].[PhaseId], [t].[Status], [t].[SubmissionRound], [t].[SubmittedAt], [t].[SubmittedBy], [t].[TopicId], [t].[TopicVersionId], [u].[Id], [u].[AccessFailedCount], [u].[ConcurrencyStamp], [u].[CreatedAt], [u].[DeletedAt], [u].[Email], [u].[EmailConfirmed], [u].[LastModifiedAt], [u].[LastModifiedBy], [u].[LockoutEnabled], [u].[LockoutEnd], [u].[NormalizedEmail], [u].[NormalizedUserName], [u].[PasswordHash], [u].[PhoneNumber], [u].[PhoneNumberConfirmed], [u].[SecurityStamp], [u].[TwoFactorEnabled], [u].[UserName], [t0].[Id], [t0].[Abbreviation], [t0].[CategoryId], [t0].[Content], [t0].[Context], [t0].[CreatedAt], [t0].[CreatedBy], [t0].[DeletedAt], [t0].[Description], [t0].[EN_Title], [t0].[IsActive], [t0].[IsApproved], [t0].[IsLegacy], [t0].[LastModifiedAt], [t0].[LastModifiedBy], [t0].[MaxStudents], [t0].[Objectives], [t0].[PotentialDuplicate], [t0].[Problem], [t0].[SemesterId], [t0].[SupervisorId], [t0].[VN_title]
+FROM (
+    SELECT [s].[Id], [s].[AdditionalNotes], [s].[AiCheckDetails], [s].[AiCheckScore], [s].[AiCheckStatus], [s].[CreatedAt], [s].[CreatedBy], [s].[DeletedAt], [s].[DocumentUrl], [s].[IsActive], [s].[LastModifiedAt], [s].[LastModifiedBy], [s].[PhaseId], [s].[Status], [s].[SubmissionRound], [s].[SubmittedAt], [s].[SubmittedBy], [s].[TopicId], [s].[TopicVersionId]
+    FROM [submissions] AS [s]
+    ORDER BY [s].[SubmittedAt] DESC
+    OFFSET @__p_0 ROWS FETCH NEXT @__p_1 ROWS ONLY
+) AS [t]
+INNER JOIN [users] AS [u] ON [t].[SubmittedBy] = [u].[Id]
+LEFT JOIN [topics] AS [t0] ON [t].[TopicId] = [t0].[Id]
+ORDER BY [t].[SubmittedAt] DESC
+2025-09-29 03:54:24.350 +07:00 [DBG] AuthenticationScheme: Bearer was not authenticated.
+2025-09-29 03:54:24.352 +07:00 [DBG] Closing data reader to 'capbot_db' on server 'localhost'.
+2025-09-29 03:54:24.352 +07:00 [DBG] A data reader for 'capbot_db' on server 'localhost' is being disposed after spending 0ms reading results.
+2025-09-29 03:54:24.352 +07:00 [DBG] Closing connection to database 'capbot_db' on server 'localhost'.
+2025-09-29 03:54:24.352 +07:00 [DBG] Closed connection to database 'capbot_db' on server 'localhost' (0ms).
+2025-09-29 03:54:24.352 +07:00 [DBG] List of registered output formatters, in the following order: ["Microsoft.AspNetCore.OData.Formatter.ODataOutputFormatter","Microsoft.AspNetCore.OData.Formatter.ODataOutputFormatter","Microsoft.AspNetCore.OData.Formatter.ODataOutputFormatter","Microsoft.AspNetCore.Mvc.Formatters.HttpNoContentOutputFormatter","Microsoft.AspNetCore.Mvc.Formatters.StringOutputFormatter","Microsoft.AspNetCore.Mvc.Formatters.StreamOutputFormatter","Microsoft.AspNetCore.Mvc.Formatters.SystemTextJsonOutputFormatter"]
+2025-09-29 03:54:24.352 +07:00 [DBG] Connection id "0HNFUQ4FJ9UMI" completed keep alive response.
+2025-09-29 03:54:24.353 +07:00 [DBG] No information found on request to perform content negotiation.
+2025-09-29 03:54:24.353 +07:00 [INF] Request finished HTTP/1.1 GET http://localhost:5207/images/entities/11111111.png - 404 0 null 4.5796ms
+2025-09-29 03:54:24.353 +07:00 [DBG] Attempting to select the first output formatter in the output formatters list which supports a content type from the explicitly specified content types '["application/json"]'.
+2025-09-29 03:54:24.353 +07:00 [INF] Request reached the end of the middleware pipeline without being handled by application code. Request path: GET http://localhost:5207/images/entities/11111111.png, Response status code: 404
+2025-09-29 03:54:24.353 +07:00 [DBG] Selected output formatter 'Microsoft.AspNetCore.Mvc.Formatters.SystemTextJsonOutputFormatter' and content type 'application/json' to write the response.
+2025-09-29 03:54:24.355 +07:00 [INF] Executing ObjectResult, writing value of type 'FS.Commons.FSResponse'.
+2025-09-29 03:54:24.355 +07:00 [INF] Executed action CapBot.api.Controllers.SubmissionController.List (CapBot.api) in 68.1091ms
+2025-09-29 03:54:24.355 +07:00 [INF] Executed endpoint 'CapBot.api.Controllers.SubmissionController.List (CapBot.api)'
+2025-09-29 03:54:24.355 +07:00 [DBG] Connection id "0HNFUQ4FJ9UMK" completed keep alive response.
+2025-09-29 03:54:24.356 +07:00 [DBG] 'MyDbContext' disposed.
+2025-09-29 03:54:24.356 +07:00 [DBG] Disposing connection to database 'capbot_db' on server 'localhost'.
+2025-09-29 03:54:24.356 +07:00 [DBG] Disposed connection to database '' on server '' (0ms).
+2025-09-29 03:54:24.356 +07:00 [INF] Request finished HTTP/1.1 GET http://localhost:5207/api/submission/list?PageNumber=1&PageSize=10 - 200 null application/json; charset=utf-8 76.3972ms
+2025-09-29 03:54:25.232 +07:00 [INF] Request starting HTTP/1.1 GET http://localhost:5207/api/submission/list?PageNumber=1&PageSize=10 - null null
+2025-09-29 03:54:25.232 +07:00 [INF] Request starting HTTP/1.1 GET http://localhost:5207/api/user-profiles/me - null null
+2025-09-29 03:54:25.232 +07:00 [DBG] The request path /api/submission/list does not match a supported file type
+2025-09-29 03:54:25.232 +07:00 [DBG] The request path /api/user-profiles/me does not match a supported file type
+2025-09-29 03:54:25.232 +07:00 [DBG] The request path /api/submission/list does not match a supported file type
+2025-09-29 03:54:25.232 +07:00 [DBG] The request path /api/user-profiles/me does not match a supported file type
+2025-09-29 03:54:25.232 +07:00 [DBG] The request has an origin header: 'http://localhost:3000'.
+2025-09-29 03:54:25.232 +07:00 [DBG] The request has an origin header: 'http://localhost:3000'.
+2025-09-29 03:54:25.232 +07:00 [INF] CORS policy execution successful.
+2025-09-29 03:54:25.232 +07:00 [INF] CORS policy execution successful.
+2025-09-29 03:54:25.232 +07:00 [DBG] 1 candidate(s) found for the request path '/api/submission/list'
+2025-09-29 03:54:25.233 +07:00 [DBG] Endpoint 'CapBot.api.Controllers.SubmissionController.List (CapBot.api)' with route pattern 'api/submission/list' is valid for the request path '/api/submission/list'
+2025-09-29 03:54:25.233 +07:00 [DBG] Request matched endpoint 'CapBot.api.Controllers.SubmissionController.List (CapBot.api)'
+2025-09-29 03:54:25.233 +07:00 [DBG] 2 candidate(s) found for the request path '/api/user-profiles/me'
+2025-09-29 03:54:25.233 +07:00 [DBG] Endpoint 'CapBot.api.Controllers.UserProfileController.GetMyProfile (CapBot.api)' with route pattern 'api/user-profiles/me' is valid for the request path '/api/user-profiles/me'
+2025-09-29 03:54:25.233 +07:00 [DBG] Endpoint 'CapBot.api.Controllers.UserProfileController.GetById (CapBot.api)' with route pattern 'api/user-profiles/{id}' is valid for the request path '/api/user-profiles/me'
+2025-09-29 03:54:25.233 +07:00 [DBG] Request matched endpoint 'CapBot.api.Controllers.UserProfileController.GetMyProfile (CapBot.api)'
+2025-09-29 03:54:25.235 +07:00 [DBG] Successfully validated the token.
+2025-09-29 03:54:25.235 +07:00 [DBG] AuthenticationScheme: Bearer was successfully authenticated.
+2025-09-29 03:54:25.235 +07:00 [DBG] Successfully validated the token.
+2025-09-29 03:54:25.235 +07:00 [DBG] Authorization was successful.
+2025-09-29 03:54:25.235 +07:00 [DBG] AuthenticationScheme: Bearer was successfully authenticated.
+2025-09-29 03:54:25.236 +07:00 [DBG] Authorization was successful.
+2025-09-29 03:54:25.236 +07:00 [INF] Executing endpoint 'CapBot.api.Controllers.SubmissionController.List (CapBot.api)'
+2025-09-29 03:54:25.236 +07:00 [INF] Executing endpoint 'CapBot.api.Controllers.UserProfileController.GetMyProfile (CapBot.api)'
+2025-09-29 03:54:25.236 +07:00 [INF] Route matched with {action = "GetMyProfile", controller = "UserProfile"}. Executing controller action with signature System.Threading.Tasks.Task`1[Microsoft.AspNetCore.Mvc.IActionResult] GetMyProfile() on controller CapBot.api.Controllers.UserProfileController (CapBot.api).
+2025-09-29 03:54:25.236 +07:00 [INF] Route matched with {action = "List", controller = "Submission"}. Executing controller action with signature System.Threading.Tasks.Task`1[Microsoft.AspNetCore.Mvc.IActionResult] List(App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO) on controller CapBot.api.Controllers.SubmissionController (CapBot.api).
+2025-09-29 03:54:25.236 +07:00 [DBG] Execution plan of authorization filters (in the following order): ["None"]
+2025-09-29 03:54:25.236 +07:00 [DBG] Execution plan of authorization filters (in the following order): ["None"]
+2025-09-29 03:54:25.236 +07:00 [DBG] Execution plan of resource filters (in the following order): ["None"]
+2025-09-29 03:54:25.236 +07:00 [DBG] Execution plan of resource filters (in the following order): ["None"]
+2025-09-29 03:54:25.236 +07:00 [DBG] Execution plan of action filters (in the following order): ["Microsoft.AspNetCore.Mvc.ModelBinding.UnsupportedContentTypeFilter (Order: -3000)"]
+2025-09-29 03:54:25.237 +07:00 [DBG] Execution plan of action filters (in the following order): ["Microsoft.AspNetCore.Mvc.ModelBinding.UnsupportedContentTypeFilter (Order: -3000)"]
+2025-09-29 03:54:25.237 +07:00 [DBG] Execution plan of exception filters (in the following order): ["None"]
+2025-09-29 03:54:25.237 +07:00 [DBG] Execution plan of exception filters (in the following order): ["None"]
+2025-09-29 03:54:25.237 +07:00 [DBG] Execution plan of result filters (in the following order): ["Microsoft.AspNetCore.Mvc.Infrastructure.ClientErrorResultFilter (Order: -2000)"]
+2025-09-29 03:54:25.237 +07:00 [DBG] Execution plan of result filters (in the following order): ["Microsoft.AspNetCore.Mvc.Infrastructure.ClientErrorResultFilter (Order: -2000)","Microsoft.AspNetCore.Mvc.ProducesAttribute (Order: 0)"]
+2025-09-29 03:54:25.237 +07:00 [DBG] Executing controller factory for controller CapBot.api.Controllers.UserProfileController (CapBot.api)
+2025-09-29 03:54:25.237 +07:00 [DBG] Executing controller factory for controller CapBot.api.Controllers.SubmissionController (CapBot.api)
+2025-09-29 03:54:25.237 +07:00 [DBG] Executed controller factory for controller CapBot.api.Controllers.SubmissionController (CapBot.api)
+2025-09-29 03:54:25.237 +07:00 [DBG] Executed controller factory for controller CapBot.api.Controllers.UserProfileController (CapBot.api)
+2025-09-29 03:54:25.238 +07:00 [DBG] Attempting to bind parameter 'query' of type 'App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO' ...
+2025-09-29 03:54:25.238 +07:00 [DBG] Attempting to bind parameter 'query' of type 'App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO' using the name '' in request data ...
+2025-09-29 03:54:25.238 +07:00 [DBG] Attempting to bind property 'App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO.TopicVersionId' of type 'System.Nullable`1[System.Int32]' using the name 'TopicVersionId' in request data ...
+2025-09-29 03:54:25.242 +07:00 [DBG] Entity Framework Core 8.0.16 initialized 'MyDbContext' using provider 'Microsoft.EntityFrameworkCore.SqlServer:8.0.13' with options: MigrationsAssembly=App.DAL 
+2025-09-29 03:54:25.243 +07:00 [DBG] Could not find a value in the request with name 'TopicVersionId' for binding property 'App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO.TopicVersionId' of type 'System.Nullable`1[System.Int32]'.
+2025-09-29 03:54:25.243 +07:00 [DBG] Done attempting to bind property 'App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO.TopicVersionId' of type 'System.Nullable`1[System.Int32]'.
+2025-09-29 03:54:25.244 +07:00 [DBG] Attempting to bind property 'App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO.PhaseId' of type 'System.Nullable`1[System.Int32]' using the name 'PhaseId' in request data ...
+2025-09-29 03:54:25.244 +07:00 [DBG] Could not find a value in the request with name 'PhaseId' for binding property 'App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO.PhaseId' of type 'System.Nullable`1[System.Int32]'.
+2025-09-29 03:54:25.244 +07:00 [DBG] Creating DbConnection.
+2025-09-29 03:54:25.246 +07:00 [DBG] Done attempting to bind property 'App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO.PhaseId' of type 'System.Nullable`1[System.Int32]'.
+2025-09-29 03:54:25.246 +07:00 [DBG] Created DbConnection. (1ms).
+2025-09-29 03:54:25.246 +07:00 [DBG] Opening connection to database 'capbot_db' on server 'localhost'.
+2025-09-29 03:54:25.246 +07:00 [DBG] Attempting to bind property 'App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO.SemesterId' of type 'System.Nullable`1[System.Int32]' using the name 'SemesterId' in request data ...
+2025-09-29 03:54:25.246 +07:00 [DBG] Could not find a value in the request with name 'SemesterId' for binding property 'App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO.SemesterId' of type 'System.Nullable`1[System.Int32]'.
+2025-09-29 03:54:25.246 +07:00 [DBG] Opened connection to database 'capbot_db' on server 'localhost'.
+2025-09-29 03:54:25.246 +07:00 [DBG] Done attempting to bind property 'App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO.SemesterId' of type 'System.Nullable`1[System.Int32]'.
+2025-09-29 03:54:25.246 +07:00 [DBG] Creating DbCommand for 'ExecuteReader'.
+2025-09-29 03:54:25.246 +07:00 [DBG] Attempting to bind property 'App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO.Status' of type 'System.Nullable`1[App.Entities.Enums.SubmissionStatus]' using the name 'Status' in request data ...
+2025-09-29 03:54:25.251 +07:00 [DBG] Could not find a value in the request with name 'Status' for binding property 'App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO.Status' of type 'System.Nullable`1[App.Entities.Enums.SubmissionStatus]'.
+2025-09-29 03:54:25.251 +07:00 [DBG] Created DbCommand for 'ExecuteReader' (4ms).
+2025-09-29 03:54:25.251 +07:00 [DBG] Done attempting to bind property 'App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO.Status' of type 'System.Nullable`1[App.Entities.Enums.SubmissionStatus]'.
+2025-09-29 03:54:25.251 +07:00 [DBG] Initialized DbCommand for 'ExecuteReader' (4ms).
+2025-09-29 03:54:25.251 +07:00 [DBG] Attempting to bind property 'App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO.PageNumber' of type 'System.Int32' using the name 'PageNumber' in request data ...
+2025-09-29 03:54:25.251 +07:00 [DBG] Executing DbCommand [Parameters=[@__targetUserId_0='?' (DbType = Int32)], CommandType='"Text"', CommandTimeout='30']
+SELECT TOP(1) [p].[Id], [p].[Address], [p].[Avatar], [p].[CoverImage], [p].[CreatedAt], [p].[CreatedBy], [p].[DeletedAt], [p].[FullName], [p].[IsActive], [p].[LastModifiedAt], [p].[LastModifiedBy], [p].[UserId]
+FROM [profiles] AS [p]
+WHERE [p].[UserId] = @__targetUserId_0 AND [p].[IsActive] = CAST(1 AS bit) AND [p].[DeletedAt] IS NULL AND [p].[DeletedAt] IS NULL
+2025-09-29 03:54:25.251 +07:00 [DBG] Done attempting to bind property 'App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO.PageNumber' of type 'System.Int32'.
+2025-09-29 03:54:25.254 +07:00 [DBG] Attempting to bind property 'App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO.PageSize' of type 'System.Int32' using the name 'PageSize' in request data ...
+2025-09-29 03:54:25.254 +07:00 [DBG] Done attempting to bind property 'App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO.PageSize' of type 'System.Int32'.
+2025-09-29 03:54:25.255 +07:00 [DBG] Attempting to bind property 'App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO.Keyword' of type 'System.String' using the name 'Keyword' in request data ...
+2025-09-29 03:54:25.255 +07:00 [INF] Executed DbCommand (4ms) [Parameters=[@__targetUserId_0='?' (DbType = Int32)], CommandType='"Text"', CommandTimeout='30']
+SELECT TOP(1) [p].[Id], [p].[Address], [p].[Avatar], [p].[CoverImage], [p].[CreatedAt], [p].[CreatedBy], [p].[DeletedAt], [p].[FullName], [p].[IsActive], [p].[LastModifiedAt], [p].[LastModifiedBy], [p].[UserId]
+FROM [profiles] AS [p]
+WHERE [p].[UserId] = @__targetUserId_0 AND [p].[IsActive] = CAST(1 AS bit) AND [p].[DeletedAt] IS NULL AND [p].[DeletedAt] IS NULL
+2025-09-29 03:54:25.258 +07:00 [DBG] Could not find a value in the request with name 'Keyword' for binding property 'App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO.Keyword' of type 'System.String'.
+2025-09-29 03:54:25.259 +07:00 [DBG] Done attempting to bind property 'App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO.Keyword' of type 'System.String'.
+2025-09-29 03:54:25.259 +07:00 [DBG] Closing data reader to 'capbot_db' on server 'localhost'.
+2025-09-29 03:54:25.259 +07:00 [DBG] Attempting to bind property 'App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO.TotalRecord' of type 'System.Int32' using the name 'TotalRecord' in request data ...
+2025-09-29 03:54:25.259 +07:00 [DBG] A data reader for 'capbot_db' on server 'localhost' is being disposed after spending 0ms reading results.
+2025-09-29 03:54:25.259 +07:00 [DBG] Could not find a value in the request with name 'TotalRecord' for binding property 'App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO.TotalRecord' of type 'System.Int32'.
+2025-09-29 03:54:25.259 +07:00 [DBG] Closing connection to database 'capbot_db' on server 'localhost'.
+2025-09-29 03:54:25.259 +07:00 [DBG] Done attempting to bind property 'App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO.TotalRecord' of type 'System.Int32'.
+2025-09-29 03:54:25.260 +07:00 [DBG] Closed connection to database 'capbot_db' on server 'localhost' (0ms).
+2025-09-29 03:54:25.260 +07:00 [DBG] Done attempting to bind parameter 'query' of type 'App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO'.
+2025-09-29 03:54:25.260 +07:00 [DBG] Done attempting to bind parameter 'query' of type 'App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO'.
+2025-09-29 03:54:25.260 +07:00 [DBG] Attempting to validate the bound parameter 'query' of type 'App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO' ...
+2025-09-29 03:54:25.260 +07:00 [DBG] List of registered output formatters, in the following order: ["Microsoft.AspNetCore.OData.Formatter.ODataOutputFormatter","Microsoft.AspNetCore.OData.Formatter.ODataOutputFormatter","Microsoft.AspNetCore.OData.Formatter.ODataOutputFormatter","Microsoft.AspNetCore.Mvc.Formatters.HttpNoContentOutputFormatter","Microsoft.AspNetCore.Mvc.Formatters.StringOutputFormatter","Microsoft.AspNetCore.Mvc.Formatters.StreamOutputFormatter","Microsoft.AspNetCore.Mvc.Formatters.SystemTextJsonOutputFormatter"]
+2025-09-29 03:54:25.264 +07:00 [DBG] No information found on request to perform content negotiation.
+2025-09-29 03:54:25.264 +07:00 [DBG] Done attempting to validate the bound parameter 'query' of type 'App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO'.
+2025-09-29 03:54:25.264 +07:00 [DBG] Attempting to select an output formatter without using a content type as no explicit content types were specified for the response.
+2025-09-29 03:54:25.264 +07:00 [DBG] Attempting to select the first formatter in the output formatters list which can write the result.
+2025-09-29 03:54:25.265 +07:00 [DBG] Entity Framework Core 8.0.16 initialized 'MyDbContext' using provider 'Microsoft.EntityFrameworkCore.SqlServer:8.0.13' with options: MigrationsAssembly=App.DAL 
+2025-09-29 03:54:25.266 +07:00 [DBG] Selected output formatter 'Microsoft.AspNetCore.Mvc.Formatters.SystemTextJsonOutputFormatter' and content type 'application/json' to write the response.
+2025-09-29 03:54:25.266 +07:00 [INF] Executing ObjectResult, writing value of type 'FS.Commons.FSResponse'.
+2025-09-29 03:54:25.266 +07:00 [DBG] Creating DbConnection.
+2025-09-29 03:54:25.266 +07:00 [INF] Executed action CapBot.api.Controllers.UserProfileController.GetMyProfile (CapBot.api) in 29.2666ms
+2025-09-29 03:54:25.266 +07:00 [DBG] Created DbConnection. (0ms).
+2025-09-29 03:54:25.266 +07:00 [INF] Executed endpoint 'CapBot.api.Controllers.UserProfileController.GetMyProfile (CapBot.api)'
+2025-09-29 03:54:25.266 +07:00 [DBG] Opening connection to database 'capbot_db' on server 'localhost'.
+2025-09-29 03:54:25.266 +07:00 [DBG] Connection id "0HNFUQ4FJ9UMK" completed keep alive response.
+2025-09-29 03:54:25.266 +07:00 [DBG] Opened connection to database 'capbot_db' on server 'localhost'.
+2025-09-29 03:54:25.266 +07:00 [DBG] 'MyDbContext' disposed.
+2025-09-29 03:54:25.267 +07:00 [DBG] Disposing connection to database 'capbot_db' on server 'localhost'.
+2025-09-29 03:54:25.267 +07:00 [DBG] Creating DbCommand for 'ExecuteReader'.
+2025-09-29 03:54:25.267 +07:00 [DBG] Disposed connection to database '' on server '' (0ms).
+2025-09-29 03:54:25.267 +07:00 [DBG] Created DbCommand for 'ExecuteReader' (0ms).
+2025-09-29 03:54:25.267 +07:00 [DBG] Initialized DbCommand for 'ExecuteReader' (0ms).
+2025-09-29 03:54:25.267 +07:00 [INF] Request finished HTTP/1.1 GET http://localhost:5207/api/user-profiles/me - 200 null application/json; charset=utf-8 35.7357ms
+2025-09-29 03:54:25.267 +07:00 [DBG] Executing DbCommand [Parameters=[], CommandType='"Text"', CommandTimeout='30']
+SELECT COUNT(*)
+FROM [submissions] AS [s]
+2025-09-29 03:54:25.270 +07:00 [INF] Executed DbCommand (2ms) [Parameters=[], CommandType='"Text"', CommandTimeout='30']
+SELECT COUNT(*)
+FROM [submissions] AS [s]
+2025-09-29 03:54:25.270 +07:00 [DBG] Closing data reader to 'capbot_db' on server 'localhost'.
+2025-09-29 03:54:25.270 +07:00 [DBG] A data reader for 'capbot_db' on server 'localhost' is being disposed after spending 0ms reading results.
+2025-09-29 03:54:25.270 +07:00 [DBG] Closing connection to database 'capbot_db' on server 'localhost'.
+2025-09-29 03:54:25.271 +07:00 [DBG] Closed connection to database 'capbot_db' on server 'localhost' (0ms).
+2025-09-29 03:54:25.272 +07:00 [DBG] Opening connection to database 'capbot_db' on server 'localhost'.
+2025-09-29 03:54:25.272 +07:00 [DBG] Opened connection to database 'capbot_db' on server 'localhost'.
+2025-09-29 03:54:25.272 +07:00 [DBG] Creating DbCommand for 'ExecuteReader'.
+2025-09-29 03:54:25.273 +07:00 [DBG] Created DbCommand for 'ExecuteReader' (0ms).
+2025-09-29 03:54:25.273 +07:00 [DBG] Initialized DbCommand for 'ExecuteReader' (0ms).
+2025-09-29 03:54:25.273 +07:00 [DBG] Executing DbCommand [Parameters=[@__p_0='?' (DbType = Int32), @__p_1='?' (DbType = Int32)], CommandType='"Text"', CommandTimeout='30']
+SELECT [t].[Id], [t].[AdditionalNotes], [t].[AiCheckDetails], [t].[AiCheckScore], [t].[AiCheckStatus], [t].[CreatedAt], [t].[CreatedBy], [t].[DeletedAt], [t].[DocumentUrl], [t].[IsActive], [t].[LastModifiedAt], [t].[LastModifiedBy], [t].[PhaseId], [t].[Status], [t].[SubmissionRound], [t].[SubmittedAt], [t].[SubmittedBy], [t].[TopicId], [t].[TopicVersionId], [u].[Id], [u].[AccessFailedCount], [u].[ConcurrencyStamp], [u].[CreatedAt], [u].[DeletedAt], [u].[Email], [u].[EmailConfirmed], [u].[LastModifiedAt], [u].[LastModifiedBy], [u].[LockoutEnabled], [u].[LockoutEnd], [u].[NormalizedEmail], [u].[NormalizedUserName], [u].[PasswordHash], [u].[PhoneNumber], [u].[PhoneNumberConfirmed], [u].[SecurityStamp], [u].[TwoFactorEnabled], [u].[UserName], [t0].[Id], [t0].[Abbreviation], [t0].[CategoryId], [t0].[Content], [t0].[Context], [t0].[CreatedAt], [t0].[CreatedBy], [t0].[DeletedAt], [t0].[Description], [t0].[EN_Title], [t0].[IsActive], [t0].[IsApproved], [t0].[IsLegacy], [t0].[LastModifiedAt], [t0].[LastModifiedBy], [t0].[MaxStudents], [t0].[Objectives], [t0].[PotentialDuplicate], [t0].[Problem], [t0].[SemesterId], [t0].[SupervisorId], [t0].[VN_title]
+FROM (
+    SELECT [s].[Id], [s].[AdditionalNotes], [s].[AiCheckDetails], [s].[AiCheckScore], [s].[AiCheckStatus], [s].[CreatedAt], [s].[CreatedBy], [s].[DeletedAt], [s].[DocumentUrl], [s].[IsActive], [s].[LastModifiedAt], [s].[LastModifiedBy], [s].[PhaseId], [s].[Status], [s].[SubmissionRound], [s].[SubmittedAt], [s].[SubmittedBy], [s].[TopicId], [s].[TopicVersionId]
+    FROM [submissions] AS [s]
+    ORDER BY [s].[SubmittedAt] DESC
+    OFFSET @__p_0 ROWS FETCH NEXT @__p_1 ROWS ONLY
+) AS [t]
+INNER JOIN [users] AS [u] ON [t].[SubmittedBy] = [u].[Id]
+LEFT JOIN [topics] AS [t0] ON [t].[TopicId] = [t0].[Id]
+ORDER BY [t].[SubmittedAt] DESC
+2025-09-29 03:54:25.276 +07:00 [INF] Executed DbCommand (2ms) [Parameters=[@__p_0='?' (DbType = Int32), @__p_1='?' (DbType = Int32)], CommandType='"Text"', CommandTimeout='30']
+SELECT [t].[Id], [t].[AdditionalNotes], [t].[AiCheckDetails], [t].[AiCheckScore], [t].[AiCheckStatus], [t].[CreatedAt], [t].[CreatedBy], [t].[DeletedAt], [t].[DocumentUrl], [t].[IsActive], [t].[LastModifiedAt], [t].[LastModifiedBy], [t].[PhaseId], [t].[Status], [t].[SubmissionRound], [t].[SubmittedAt], [t].[SubmittedBy], [t].[TopicId], [t].[TopicVersionId], [u].[Id], [u].[AccessFailedCount], [u].[ConcurrencyStamp], [u].[CreatedAt], [u].[DeletedAt], [u].[Email], [u].[EmailConfirmed], [u].[LastModifiedAt], [u].[LastModifiedBy], [u].[LockoutEnabled], [u].[LockoutEnd], [u].[NormalizedEmail], [u].[NormalizedUserName], [u].[PasswordHash], [u].[PhoneNumber], [u].[PhoneNumberConfirmed], [u].[SecurityStamp], [u].[TwoFactorEnabled], [u].[UserName], [t0].[Id], [t0].[Abbreviation], [t0].[CategoryId], [t0].[Content], [t0].[Context], [t0].[CreatedAt], [t0].[CreatedBy], [t0].[DeletedAt], [t0].[Description], [t0].[EN_Title], [t0].[IsActive], [t0].[IsApproved], [t0].[IsLegacy], [t0].[LastModifiedAt], [t0].[LastModifiedBy], [t0].[MaxStudents], [t0].[Objectives], [t0].[PotentialDuplicate], [t0].[Problem], [t0].[SemesterId], [t0].[SupervisorId], [t0].[VN_title]
+FROM (
+    SELECT [s].[Id], [s].[AdditionalNotes], [s].[AiCheckDetails], [s].[AiCheckScore], [s].[AiCheckStatus], [s].[CreatedAt], [s].[CreatedBy], [s].[DeletedAt], [s].[DocumentUrl], [s].[IsActive], [s].[LastModifiedAt], [s].[LastModifiedBy], [s].[PhaseId], [s].[Status], [s].[SubmissionRound], [s].[SubmittedAt], [s].[SubmittedBy], [s].[TopicId], [s].[TopicVersionId]
+    FROM [submissions] AS [s]
+    ORDER BY [s].[SubmittedAt] DESC
+    OFFSET @__p_0 ROWS FETCH NEXT @__p_1 ROWS ONLY
+) AS [t]
+INNER JOIN [users] AS [u] ON [t].[SubmittedBy] = [u].[Id]
+LEFT JOIN [topics] AS [t0] ON [t].[TopicId] = [t0].[Id]
+ORDER BY [t].[SubmittedAt] DESC
+2025-09-29 03:54:25.280 +07:00 [DBG] Closing data reader to 'capbot_db' on server 'localhost'.
+2025-09-29 03:54:25.280 +07:00 [INF] Request starting HTTP/1.1 GET http://localhost:5207/images/entities/11111111.png - null null
+2025-09-29 03:54:25.280 +07:00 [DBG] A data reader for 'capbot_db' on server 'localhost' is being disposed after spending 1ms reading results.
+2025-09-29 03:54:25.281 +07:00 [DBG] Closing connection to database 'capbot_db' on server 'localhost'.
+2025-09-29 03:54:25.281 +07:00 [DBG] Closed connection to database 'capbot_db' on server 'localhost' (0ms).
+2025-09-29 03:54:25.281 +07:00 [DBG] List of registered output formatters, in the following order: ["Microsoft.AspNetCore.OData.Formatter.ODataOutputFormatter","Microsoft.AspNetCore.OData.Formatter.ODataOutputFormatter","Microsoft.AspNetCore.OData.Formatter.ODataOutputFormatter","Microsoft.AspNetCore.Mvc.Formatters.HttpNoContentOutputFormatter","Microsoft.AspNetCore.Mvc.Formatters.StringOutputFormatter","Microsoft.AspNetCore.Mvc.Formatters.StreamOutputFormatter","Microsoft.AspNetCore.Mvc.Formatters.SystemTextJsonOutputFormatter"]
+2025-09-29 03:54:25.281 +07:00 [DBG] The request path /images/entities/11111111.png does not match an existing file
+2025-09-29 03:54:25.283 +07:00 [DBG] No information found on request to perform content negotiation.
+2025-09-29 03:54:25.284 +07:00 [DBG] Attempting to select the first output formatter in the output formatters list which supports a content type from the explicitly specified content types '["application/json"]'.
+2025-09-29 03:54:25.284 +07:00 [DBG] The request path /images/entities/11111111.png does not match an existing file
+2025-09-29 03:54:25.284 +07:00 [DBG] Selected output formatter 'Microsoft.AspNetCore.Mvc.Formatters.SystemTextJsonOutputFormatter' and content type 'application/json' to write the response.
+2025-09-29 03:54:25.284 +07:00 [DBG] No candidates found for the request path '/images/entities/11111111.png'
+2025-09-29 03:54:25.284 +07:00 [INF] Executing ObjectResult, writing value of type 'FS.Commons.FSResponse'.
+2025-09-29 03:54:25.284 +07:00 [DBG] Request did not match any endpoints
+2025-09-29 03:54:25.285 +07:00 [DBG] AuthenticationScheme: Bearer was not authenticated.
+2025-09-29 03:54:25.285 +07:00 [INF] Executed action CapBot.api.Controllers.SubmissionController.List (CapBot.api) in 48.5019ms
+2025-09-29 03:54:25.285 +07:00 [INF] Executed endpoint 'CapBot.api.Controllers.SubmissionController.List (CapBot.api)'
+2025-09-29 03:54:25.285 +07:00 [DBG] Connection id "0HNFUQ4FJ9UMI" completed keep alive response.
+2025-09-29 03:54:25.286 +07:00 [DBG] Connection id "0HNFUQ4FJ9UML" completed keep alive response.
+2025-09-29 03:54:25.286 +07:00 [INF] Request finished HTTP/1.1 GET http://localhost:5207/images/entities/11111111.png - 404 0 null 5.3625ms
+2025-09-29 03:54:25.286 +07:00 [DBG] 'MyDbContext' disposed.
+2025-09-29 03:54:25.286 +07:00 [INF] Request reached the end of the middleware pipeline without being handled by application code. Request path: GET http://localhost:5207/images/entities/11111111.png, Response status code: 404
+2025-09-29 03:54:25.286 +07:00 [DBG] Disposing connection to database 'capbot_db' on server 'localhost'.
+2025-09-29 03:54:25.286 +07:00 [DBG] Disposed connection to database '' on server '' (0ms).
+2025-09-29 03:54:25.287 +07:00 [INF] Request finished HTTP/1.1 GET http://localhost:5207/api/submission/list?PageNumber=1&PageSize=10 - 200 null application/json; charset=utf-8 55.1433ms
+2025-09-29 03:54:26.366 +07:00 [INF] Request starting HTTP/1.1 GET http://localhost:5207/api/submission/list?PageNumber=1&PageSize=10 - null null
+2025-09-29 03:54:26.366 +07:00 [INF] Request starting HTTP/1.1 GET http://localhost:5207/api/user-profiles/me - null null
+2025-09-29 03:54:26.366 +07:00 [DBG] The request path /api/submission/list does not match a supported file type
+2025-09-29 03:54:26.366 +07:00 [DBG] The request path /api/user-profiles/me does not match a supported file type
+2025-09-29 03:54:26.366 +07:00 [DBG] The request path /api/submission/list does not match a supported file type
+2025-09-29 03:54:26.366 +07:00 [DBG] The request path /api/user-profiles/me does not match a supported file type
+2025-09-29 03:54:26.366 +07:00 [DBG] The request has an origin header: 'http://localhost:3000'.
+2025-09-29 03:54:26.366 +07:00 [DBG] The request has an origin header: 'http://localhost:3000'.
+2025-09-29 03:54:26.367 +07:00 [INF] CORS policy execution successful.
+2025-09-29 03:54:26.367 +07:00 [INF] CORS policy execution successful.
+2025-09-29 03:54:26.367 +07:00 [DBG] 1 candidate(s) found for the request path '/api/submission/list'
+2025-09-29 03:54:26.367 +07:00 [DBG] 2 candidate(s) found for the request path '/api/user-profiles/me'
+2025-09-29 03:54:26.367 +07:00 [DBG] Endpoint 'CapBot.api.Controllers.SubmissionController.List (CapBot.api)' with route pattern 'api/submission/list' is valid for the request path '/api/submission/list'
+2025-09-29 03:54:26.367 +07:00 [DBG] Endpoint 'CapBot.api.Controllers.UserProfileController.GetMyProfile (CapBot.api)' with route pattern 'api/user-profiles/me' is valid for the request path '/api/user-profiles/me'
+2025-09-29 03:54:26.367 +07:00 [DBG] Request matched endpoint 'CapBot.api.Controllers.SubmissionController.List (CapBot.api)'
+2025-09-29 03:54:26.367 +07:00 [DBG] Endpoint 'CapBot.api.Controllers.UserProfileController.GetById (CapBot.api)' with route pattern 'api/user-profiles/{id}' is valid for the request path '/api/user-profiles/me'
+2025-09-29 03:54:26.367 +07:00 [DBG] Request matched endpoint 'CapBot.api.Controllers.UserProfileController.GetMyProfile (CapBot.api)'
+2025-09-29 03:54:26.367 +07:00 [DBG] Successfully validated the token.
+2025-09-29 03:54:26.367 +07:00 [DBG] Successfully validated the token.
+2025-09-29 03:54:26.367 +07:00 [DBG] AuthenticationScheme: Bearer was successfully authenticated.
+2025-09-29 03:54:26.367 +07:00 [DBG] AuthenticationScheme: Bearer was successfully authenticated.
+2025-09-29 03:54:26.367 +07:00 [DBG] Authorization was successful.
+2025-09-29 03:54:26.367 +07:00 [DBG] Authorization was successful.
+2025-09-29 03:54:26.367 +07:00 [INF] Executing endpoint 'CapBot.api.Controllers.UserProfileController.GetMyProfile (CapBot.api)'
+2025-09-29 03:54:26.367 +07:00 [INF] Executing endpoint 'CapBot.api.Controllers.SubmissionController.List (CapBot.api)'
+2025-09-29 03:54:26.367 +07:00 [INF] Route matched with {action = "GetMyProfile", controller = "UserProfile"}. Executing controller action with signature System.Threading.Tasks.Task`1[Microsoft.AspNetCore.Mvc.IActionResult] GetMyProfile() on controller CapBot.api.Controllers.UserProfileController (CapBot.api).
+2025-09-29 03:54:26.367 +07:00 [INF] Route matched with {action = "List", controller = "Submission"}. Executing controller action with signature System.Threading.Tasks.Task`1[Microsoft.AspNetCore.Mvc.IActionResult] List(App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO) on controller CapBot.api.Controllers.SubmissionController (CapBot.api).
+2025-09-29 03:54:26.367 +07:00 [DBG] Execution plan of authorization filters (in the following order): ["None"]
+2025-09-29 03:54:26.367 +07:00 [DBG] Execution plan of authorization filters (in the following order): ["None"]
+2025-09-29 03:54:26.367 +07:00 [DBG] Execution plan of resource filters (in the following order): ["None"]
+2025-09-29 03:54:26.367 +07:00 [DBG] Execution plan of resource filters (in the following order): ["None"]
+2025-09-29 03:54:26.367 +07:00 [DBG] Execution plan of action filters (in the following order): ["Microsoft.AspNetCore.Mvc.ModelBinding.UnsupportedContentTypeFilter (Order: -3000)"]
+2025-09-29 03:54:26.367 +07:00 [DBG] Execution plan of action filters (in the following order): ["Microsoft.AspNetCore.Mvc.ModelBinding.UnsupportedContentTypeFilter (Order: -3000)"]
+2025-09-29 03:54:26.368 +07:00 [DBG] Execution plan of exception filters (in the following order): ["None"]
+2025-09-29 03:54:26.368 +07:00 [DBG] Execution plan of exception filters (in the following order): ["None"]
+2025-09-29 03:54:26.368 +07:00 [DBG] Execution plan of result filters (in the following order): ["Microsoft.AspNetCore.Mvc.Infrastructure.ClientErrorResultFilter (Order: -2000)"]
+2025-09-29 03:54:26.368 +07:00 [DBG] Execution plan of result filters (in the following order): ["Microsoft.AspNetCore.Mvc.Infrastructure.ClientErrorResultFilter (Order: -2000)","Microsoft.AspNetCore.Mvc.ProducesAttribute (Order: 0)"]
+2025-09-29 03:54:26.368 +07:00 [DBG] Executing controller factory for controller CapBot.api.Controllers.UserProfileController (CapBot.api)
+2025-09-29 03:54:26.368 +07:00 [DBG] Executing controller factory for controller CapBot.api.Controllers.SubmissionController (CapBot.api)
+2025-09-29 03:54:26.368 +07:00 [DBG] Executed controller factory for controller CapBot.api.Controllers.UserProfileController (CapBot.api)
+2025-09-29 03:54:26.368 +07:00 [DBG] Executed controller factory for controller CapBot.api.Controllers.SubmissionController (CapBot.api)
+2025-09-29 03:54:26.369 +07:00 [DBG] Attempting to bind parameter 'query' of type 'App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO' ...
+2025-09-29 03:54:26.369 +07:00 [DBG] Attempting to bind parameter 'query' of type 'App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO' using the name '' in request data ...
+2025-09-29 03:54:26.369 +07:00 [DBG] Attempting to bind property 'App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO.TopicVersionId' of type 'System.Nullable`1[System.Int32]' using the name 'TopicVersionId' in request data ...
+2025-09-29 03:54:26.369 +07:00 [DBG] Could not find a value in the request with name 'TopicVersionId' for binding property 'App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO.TopicVersionId' of type 'System.Nullable`1[System.Int32]'.
+2025-09-29 03:54:26.369 +07:00 [DBG] Entity Framework Core 8.0.16 initialized 'MyDbContext' using provider 'Microsoft.EntityFrameworkCore.SqlServer:8.0.13' with options: MigrationsAssembly=App.DAL 
+2025-09-29 03:54:26.370 +07:00 [DBG] Done attempting to bind property 'App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO.TopicVersionId' of type 'System.Nullable`1[System.Int32]'.
+2025-09-29 03:54:26.370 +07:00 [DBG] Attempting to bind property 'App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO.PhaseId' of type 'System.Nullable`1[System.Int32]' using the name 'PhaseId' in request data ...
+2025-09-29 03:54:26.370 +07:00 [DBG] Could not find a value in the request with name 'PhaseId' for binding property 'App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO.PhaseId' of type 'System.Nullable`1[System.Int32]'.
+2025-09-29 03:54:26.370 +07:00 [DBG] Done attempting to bind property 'App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO.PhaseId' of type 'System.Nullable`1[System.Int32]'.
+2025-09-29 03:54:26.370 +07:00 [DBG] Attempting to bind property 'App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO.SemesterId' of type 'System.Nullable`1[System.Int32]' using the name 'SemesterId' in request data ...
+2025-09-29 03:54:26.371 +07:00 [DBG] Creating DbConnection.
+2025-09-29 03:54:26.372 +07:00 [DBG] Could not find a value in the request with name 'SemesterId' for binding property 'App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO.SemesterId' of type 'System.Nullable`1[System.Int32]'.
+2025-09-29 03:54:26.372 +07:00 [DBG] Done attempting to bind property 'App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO.SemesterId' of type 'System.Nullable`1[System.Int32]'.
+2025-09-29 03:54:26.372 +07:00 [DBG] Created DbConnection. (0ms).
+2025-09-29 03:54:26.372 +07:00 [DBG] Opening connection to database 'capbot_db' on server 'localhost'.
+2025-09-29 03:54:26.372 +07:00 [DBG] Attempting to bind property 'App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO.Status' of type 'System.Nullable`1[App.Entities.Enums.SubmissionStatus]' using the name 'Status' in request data ...
+2025-09-29 03:54:26.372 +07:00 [DBG] Could not find a value in the request with name 'Status' for binding property 'App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO.Status' of type 'System.Nullable`1[App.Entities.Enums.SubmissionStatus]'.
+2025-09-29 03:54:26.372 +07:00 [DBG] Done attempting to bind property 'App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO.Status' of type 'System.Nullable`1[App.Entities.Enums.SubmissionStatus]'.
+2025-09-29 03:54:26.372 +07:00 [DBG] Opened connection to database 'capbot_db' on server 'localhost'.
+2025-09-29 03:54:26.373 +07:00 [DBG] Attempting to bind property 'App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO.PageNumber' of type 'System.Int32' using the name 'PageNumber' in request data ...
+2025-09-29 03:54:26.373 +07:00 [DBG] Creating DbCommand for 'ExecuteReader'.
+2025-09-29 03:54:26.373 +07:00 [DBG] Done attempting to bind property 'App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO.PageNumber' of type 'System.Int32'.
+2025-09-29 03:54:26.373 +07:00 [DBG] Created DbCommand for 'ExecuteReader' (0ms).
+2025-09-29 03:54:26.373 +07:00 [DBG] Attempting to bind property 'App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO.PageSize' of type 'System.Int32' using the name 'PageSize' in request data ...
+2025-09-29 03:54:26.373 +07:00 [DBG] Initialized DbCommand for 'ExecuteReader' (0ms).
+2025-09-29 03:54:26.373 +07:00 [DBG] Done attempting to bind property 'App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO.PageSize' of type 'System.Int32'.
+2025-09-29 03:54:26.375 +07:00 [DBG] Executing DbCommand [Parameters=[@__targetUserId_0='?' (DbType = Int32)], CommandType='"Text"', CommandTimeout='30']
+SELECT TOP(1) [p].[Id], [p].[Address], [p].[Avatar], [p].[CoverImage], [p].[CreatedAt], [p].[CreatedBy], [p].[DeletedAt], [p].[FullName], [p].[IsActive], [p].[LastModifiedAt], [p].[LastModifiedBy], [p].[UserId]
+FROM [profiles] AS [p]
+WHERE [p].[UserId] = @__targetUserId_0 AND [p].[IsActive] = CAST(1 AS bit) AND [p].[DeletedAt] IS NULL AND [p].[DeletedAt] IS NULL
+2025-09-29 03:54:26.375 +07:00 [DBG] Attempting to bind property 'App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO.Keyword' of type 'System.String' using the name 'Keyword' in request data ...
+2025-09-29 03:54:26.375 +07:00 [DBG] Could not find a value in the request with name 'Keyword' for binding property 'App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO.Keyword' of type 'System.String'.
+2025-09-29 03:54:26.375 +07:00 [DBG] Done attempting to bind property 'App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO.Keyword' of type 'System.String'.
+2025-09-29 03:54:26.375 +07:00 [DBG] Attempting to bind property 'App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO.TotalRecord' of type 'System.Int32' using the name 'TotalRecord' in request data ...
+2025-09-29 03:54:26.375 +07:00 [DBG] Could not find a value in the request with name 'TotalRecord' for binding property 'App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO.TotalRecord' of type 'System.Int32'.
+2025-09-29 03:54:26.375 +07:00 [DBG] Done attempting to bind property 'App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO.TotalRecord' of type 'System.Int32'.
+2025-09-29 03:54:26.376 +07:00 [DBG] Done attempting to bind parameter 'query' of type 'App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO'.
+2025-09-29 03:54:26.376 +07:00 [DBG] Done attempting to bind parameter 'query' of type 'App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO'.
+2025-09-29 03:54:26.376 +07:00 [DBG] Attempting to validate the bound parameter 'query' of type 'App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO' ...
+2025-09-29 03:54:26.376 +07:00 [INF] Executed DbCommand (1ms) [Parameters=[@__targetUserId_0='?' (DbType = Int32)], CommandType='"Text"', CommandTimeout='30']
+SELECT TOP(1) [p].[Id], [p].[Address], [p].[Avatar], [p].[CoverImage], [p].[CreatedAt], [p].[CreatedBy], [p].[DeletedAt], [p].[FullName], [p].[IsActive], [p].[LastModifiedAt], [p].[LastModifiedBy], [p].[UserId]
+FROM [profiles] AS [p]
+WHERE [p].[UserId] = @__targetUserId_0 AND [p].[IsActive] = CAST(1 AS bit) AND [p].[DeletedAt] IS NULL AND [p].[DeletedAt] IS NULL
+2025-09-29 03:54:26.376 +07:00 [DBG] Done attempting to validate the bound parameter 'query' of type 'App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO'.
+2025-09-29 03:54:26.376 +07:00 [DBG] Closing data reader to 'capbot_db' on server 'localhost'.
+2025-09-29 03:54:26.376 +07:00 [DBG] A data reader for 'capbot_db' on server 'localhost' is being disposed after spending 0ms reading results.
+2025-09-29 03:54:26.376 +07:00 [DBG] Closing connection to database 'capbot_db' on server 'localhost'.
+2025-09-29 03:54:26.376 +07:00 [DBG] Closed connection to database 'capbot_db' on server 'localhost' (0ms).
+2025-09-29 03:54:26.376 +07:00 [DBG] List of registered output formatters, in the following order: ["Microsoft.AspNetCore.OData.Formatter.ODataOutputFormatter","Microsoft.AspNetCore.OData.Formatter.ODataOutputFormatter","Microsoft.AspNetCore.OData.Formatter.ODataOutputFormatter","Microsoft.AspNetCore.Mvc.Formatters.HttpNoContentOutputFormatter","Microsoft.AspNetCore.Mvc.Formatters.StringOutputFormatter","Microsoft.AspNetCore.Mvc.Formatters.StreamOutputFormatter","Microsoft.AspNetCore.Mvc.Formatters.SystemTextJsonOutputFormatter"]
+2025-09-29 03:54:26.376 +07:00 [DBG] Entity Framework Core 8.0.16 initialized 'MyDbContext' using provider 'Microsoft.EntityFrameworkCore.SqlServer:8.0.13' with options: MigrationsAssembly=App.DAL 
+2025-09-29 03:54:26.377 +07:00 [DBG] No information found on request to perform content negotiation.
+2025-09-29 03:54:26.377 +07:00 [DBG] Attempting to select an output formatter without using a content type as no explicit content types were specified for the response.
+2025-09-29 03:54:26.377 +07:00 [DBG] Attempting to select the first formatter in the output formatters list which can write the result.
+2025-09-29 03:54:26.377 +07:00 [DBG] Selected output formatter 'Microsoft.AspNetCore.Mvc.Formatters.SystemTextJsonOutputFormatter' and content type 'application/json' to write the response.
+2025-09-29 03:54:26.377 +07:00 [DBG] Creating DbConnection.
+2025-09-29 03:54:26.379 +07:00 [INF] Executing ObjectResult, writing value of type 'FS.Commons.FSResponse'.
+2025-09-29 03:54:26.379 +07:00 [DBG] Created DbConnection. (2ms).
+2025-09-29 03:54:26.380 +07:00 [DBG] Opening connection to database 'capbot_db' on server 'localhost'.
+2025-09-29 03:54:26.380 +07:00 [DBG] Opened connection to database 'capbot_db' on server 'localhost'.
+2025-09-29 03:54:26.380 +07:00 [INF] Executed action CapBot.api.Controllers.UserProfileController.GetMyProfile (CapBot.api) in 12.0773ms
+2025-09-29 03:54:26.380 +07:00 [DBG] Creating DbCommand for 'ExecuteReader'.
+2025-09-29 03:54:26.380 +07:00 [INF] Executed endpoint 'CapBot.api.Controllers.UserProfileController.GetMyProfile (CapBot.api)'
+2025-09-29 03:54:26.380 +07:00 [DBG] Created DbCommand for 'ExecuteReader' (0ms).
+2025-09-29 03:54:26.380 +07:00 [DBG] Initialized DbCommand for 'ExecuteReader' (0ms).
+2025-09-29 03:54:26.380 +07:00 [DBG] Connection id "0HNFUQ4FJ9UML" completed keep alive response.
+2025-09-29 03:54:26.380 +07:00 [DBG] Executing DbCommand [Parameters=[], CommandType='"Text"', CommandTimeout='30']
+SELECT COUNT(*)
+FROM [submissions] AS [s]
+2025-09-29 03:54:26.380 +07:00 [DBG] 'MyDbContext' disposed.
+2025-09-29 03:54:26.381 +07:00 [DBG] Disposing connection to database 'capbot_db' on server 'localhost'.
+2025-09-29 03:54:26.381 +07:00 [DBG] Disposed connection to database '' on server '' (0ms).
+2025-09-29 03:54:26.381 +07:00 [INF] Request finished HTTP/1.1 GET http://localhost:5207/api/user-profiles/me - 200 null application/json; charset=utf-8 15.1034ms
+2025-09-29 03:54:26.382 +07:00 [INF] Executed DbCommand (2ms) [Parameters=[], CommandType='"Text"', CommandTimeout='30']
+SELECT COUNT(*)
+FROM [submissions] AS [s]
+2025-09-29 03:54:26.382 +07:00 [DBG] Closing data reader to 'capbot_db' on server 'localhost'.
+2025-09-29 03:54:26.382 +07:00 [DBG] A data reader for 'capbot_db' on server 'localhost' is being disposed after spending 0ms reading results.
+2025-09-29 03:54:26.382 +07:00 [DBG] Closing connection to database 'capbot_db' on server 'localhost'.
+2025-09-29 03:54:26.383 +07:00 [DBG] Closed connection to database 'capbot_db' on server 'localhost' (0ms).
+2025-09-29 03:54:26.383 +07:00 [DBG] Opening connection to database 'capbot_db' on server 'localhost'.
+2025-09-29 03:54:26.384 +07:00 [DBG] Opened connection to database 'capbot_db' on server 'localhost'.
+2025-09-29 03:54:26.384 +07:00 [DBG] Creating DbCommand for 'ExecuteReader'.
+2025-09-29 03:54:26.384 +07:00 [DBG] Created DbCommand for 'ExecuteReader' (0ms).
+2025-09-29 03:54:26.385 +07:00 [DBG] Initialized DbCommand for 'ExecuteReader' (0ms).
+2025-09-29 03:54:26.385 +07:00 [DBG] Executing DbCommand [Parameters=[@__p_0='?' (DbType = Int32), @__p_1='?' (DbType = Int32)], CommandType='"Text"', CommandTimeout='30']
+SELECT [t].[Id], [t].[AdditionalNotes], [t].[AiCheckDetails], [t].[AiCheckScore], [t].[AiCheckStatus], [t].[CreatedAt], [t].[CreatedBy], [t].[DeletedAt], [t].[DocumentUrl], [t].[IsActive], [t].[LastModifiedAt], [t].[LastModifiedBy], [t].[PhaseId], [t].[Status], [t].[SubmissionRound], [t].[SubmittedAt], [t].[SubmittedBy], [t].[TopicId], [t].[TopicVersionId], [u].[Id], [u].[AccessFailedCount], [u].[ConcurrencyStamp], [u].[CreatedAt], [u].[DeletedAt], [u].[Email], [u].[EmailConfirmed], [u].[LastModifiedAt], [u].[LastModifiedBy], [u].[LockoutEnabled], [u].[LockoutEnd], [u].[NormalizedEmail], [u].[NormalizedUserName], [u].[PasswordHash], [u].[PhoneNumber], [u].[PhoneNumberConfirmed], [u].[SecurityStamp], [u].[TwoFactorEnabled], [u].[UserName], [t0].[Id], [t0].[Abbreviation], [t0].[CategoryId], [t0].[Content], [t0].[Context], [t0].[CreatedAt], [t0].[CreatedBy], [t0].[DeletedAt], [t0].[Description], [t0].[EN_Title], [t0].[IsActive], [t0].[IsApproved], [t0].[IsLegacy], [t0].[LastModifiedAt], [t0].[LastModifiedBy], [t0].[MaxStudents], [t0].[Objectives], [t0].[PotentialDuplicate], [t0].[Problem], [t0].[SemesterId], [t0].[SupervisorId], [t0].[VN_title]
+FROM (
+    SELECT [s].[Id], [s].[AdditionalNotes], [s].[AiCheckDetails], [s].[AiCheckScore], [s].[AiCheckStatus], [s].[CreatedAt], [s].[CreatedBy], [s].[DeletedAt], [s].[DocumentUrl], [s].[IsActive], [s].[LastModifiedAt], [s].[LastModifiedBy], [s].[PhaseId], [s].[Status], [s].[SubmissionRound], [s].[SubmittedAt], [s].[SubmittedBy], [s].[TopicId], [s].[TopicVersionId]
+    FROM [submissions] AS [s]
+    ORDER BY [s].[SubmittedAt] DESC
+    OFFSET @__p_0 ROWS FETCH NEXT @__p_1 ROWS ONLY
+) AS [t]
+INNER JOIN [users] AS [u] ON [t].[SubmittedBy] = [u].[Id]
+LEFT JOIN [topics] AS [t0] ON [t].[TopicId] = [t0].[Id]
+ORDER BY [t].[SubmittedAt] DESC
+2025-09-29 03:54:26.388 +07:00 [INF] Executed DbCommand (3ms) [Parameters=[@__p_0='?' (DbType = Int32), @__p_1='?' (DbType = Int32)], CommandType='"Text"', CommandTimeout='30']
+SELECT [t].[Id], [t].[AdditionalNotes], [t].[AiCheckDetails], [t].[AiCheckScore], [t].[AiCheckStatus], [t].[CreatedAt], [t].[CreatedBy], [t].[DeletedAt], [t].[DocumentUrl], [t].[IsActive], [t].[LastModifiedAt], [t].[LastModifiedBy], [t].[PhaseId], [t].[Status], [t].[SubmissionRound], [t].[SubmittedAt], [t].[SubmittedBy], [t].[TopicId], [t].[TopicVersionId], [u].[Id], [u].[AccessFailedCount], [u].[ConcurrencyStamp], [u].[CreatedAt], [u].[DeletedAt], [u].[Email], [u].[EmailConfirmed], [u].[LastModifiedAt], [u].[LastModifiedBy], [u].[LockoutEnabled], [u].[LockoutEnd], [u].[NormalizedEmail], [u].[NormalizedUserName], [u].[PasswordHash], [u].[PhoneNumber], [u].[PhoneNumberConfirmed], [u].[SecurityStamp], [u].[TwoFactorEnabled], [u].[UserName], [t0].[Id], [t0].[Abbreviation], [t0].[CategoryId], [t0].[Content], [t0].[Context], [t0].[CreatedAt], [t0].[CreatedBy], [t0].[DeletedAt], [t0].[Description], [t0].[EN_Title], [t0].[IsActive], [t0].[IsApproved], [t0].[IsLegacy], [t0].[LastModifiedAt], [t0].[LastModifiedBy], [t0].[MaxStudents], [t0].[Objectives], [t0].[PotentialDuplicate], [t0].[Problem], [t0].[SemesterId], [t0].[SupervisorId], [t0].[VN_title]
+FROM (
+    SELECT [s].[Id], [s].[AdditionalNotes], [s].[AiCheckDetails], [s].[AiCheckScore], [s].[AiCheckStatus], [s].[CreatedAt], [s].[CreatedBy], [s].[DeletedAt], [s].[DocumentUrl], [s].[IsActive], [s].[LastModifiedAt], [s].[LastModifiedBy], [s].[PhaseId], [s].[Status], [s].[SubmissionRound], [s].[SubmittedAt], [s].[SubmittedBy], [s].[TopicId], [s].[TopicVersionId]
+    FROM [submissions] AS [s]
+    ORDER BY [s].[SubmittedAt] DESC
+    OFFSET @__p_0 ROWS FETCH NEXT @__p_1 ROWS ONLY
+) AS [t]
+INNER JOIN [users] AS [u] ON [t].[SubmittedBy] = [u].[Id]
+LEFT JOIN [topics] AS [t0] ON [t].[TopicId] = [t0].[Id]
+ORDER BY [t].[SubmittedAt] DESC
+2025-09-29 03:54:26.389 +07:00 [DBG] Closing data reader to 'capbot_db' on server 'localhost'.
+2025-09-29 03:54:26.389 +07:00 [DBG] A data reader for 'capbot_db' on server 'localhost' is being disposed after spending 0ms reading results.
+2025-09-29 03:54:26.389 +07:00 [DBG] Closing connection to database 'capbot_db' on server 'localhost'.
+2025-09-29 03:54:26.389 +07:00 [DBG] Closed connection to database 'capbot_db' on server 'localhost' (0ms).
+2025-09-29 03:54:26.390 +07:00 [DBG] List of registered output formatters, in the following order: ["Microsoft.AspNetCore.OData.Formatter.ODataOutputFormatter","Microsoft.AspNetCore.OData.Formatter.ODataOutputFormatter","Microsoft.AspNetCore.OData.Formatter.ODataOutputFormatter","Microsoft.AspNetCore.Mvc.Formatters.HttpNoContentOutputFormatter","Microsoft.AspNetCore.Mvc.Formatters.StringOutputFormatter","Microsoft.AspNetCore.Mvc.Formatters.StreamOutputFormatter","Microsoft.AspNetCore.Mvc.Formatters.SystemTextJsonOutputFormatter"]
+2025-09-29 03:54:26.390 +07:00 [DBG] No information found on request to perform content negotiation.
+2025-09-29 03:54:26.390 +07:00 [DBG] Attempting to select the first output formatter in the output formatters list which supports a content type from the explicitly specified content types '["application/json"]'.
+2025-09-29 03:54:26.390 +07:00 [DBG] Selected output formatter 'Microsoft.AspNetCore.Mvc.Formatters.SystemTextJsonOutputFormatter' and content type 'application/json' to write the response.
+2025-09-29 03:54:26.390 +07:00 [INF] Executing ObjectResult, writing value of type 'FS.Commons.FSResponse'.
+2025-09-29 03:54:26.390 +07:00 [INF] Executed action CapBot.api.Controllers.SubmissionController.List (CapBot.api) in 22.7174ms
+2025-09-29 03:54:26.390 +07:00 [INF] Executed endpoint 'CapBot.api.Controllers.SubmissionController.List (CapBot.api)'
+2025-09-29 03:54:26.391 +07:00 [DBG] Connection id "0HNFUQ4FJ9UMK" completed keep alive response.
+2025-09-29 03:54:26.391 +07:00 [DBG] 'MyDbContext' disposed.
+2025-09-29 03:54:26.391 +07:00 [DBG] Disposing connection to database 'capbot_db' on server 'localhost'.
+2025-09-29 03:54:26.391 +07:00 [DBG] Disposed connection to database '' on server '' (0ms).
+2025-09-29 03:54:26.391 +07:00 [INF] Request finished HTTP/1.1 GET http://localhost:5207/api/submission/list?PageNumber=1&PageSize=10 - 200 null application/json; charset=utf-8 24.8433ms
+2025-09-29 03:54:26.397 +07:00 [INF] Request starting HTTP/1.1 GET http://localhost:5207/images/entities/11111111.png - null null
+2025-09-29 03:54:26.397 +07:00 [DBG] The request path /images/entities/11111111.png does not match an existing file
+2025-09-29 03:54:26.397 +07:00 [DBG] The request path /images/entities/11111111.png does not match an existing file
+2025-09-29 03:54:26.397 +07:00 [DBG] No candidates found for the request path '/images/entities/11111111.png'
+2025-09-29 03:54:26.397 +07:00 [DBG] Request did not match any endpoints
+2025-09-29 03:54:26.398 +07:00 [DBG] AuthenticationScheme: Bearer was not authenticated.
+2025-09-29 03:54:26.399 +07:00 [DBG] Connection id "0HNFUQ4FJ9UMI" completed keep alive response.
+2025-09-29 03:54:26.399 +07:00 [INF] Request finished HTTP/1.1 GET http://localhost:5207/images/entities/11111111.png - 404 0 null 2.3055ms
+2025-09-29 03:54:26.399 +07:00 [INF] Request reached the end of the middleware pipeline without being handled by application code. Request path: GET http://localhost:5207/images/entities/11111111.png, Response status code: 404
+2025-09-29 03:54:27.371 +07:00 [INF] Request starting HTTP/1.1 GET http://localhost:5207/api/user-profiles/me - null null
+2025-09-29 03:54:27.371 +07:00 [INF] Request starting HTTP/1.1 GET http://localhost:5207/api/submission/list?PageNumber=1&PageSize=10 - null null
+2025-09-29 03:54:27.371 +07:00 [DBG] The request path /api/user-profiles/me does not match a supported file type
+2025-09-29 03:54:27.371 +07:00 [DBG] The request path /api/submission/list does not match a supported file type
+2025-09-29 03:54:27.371 +07:00 [DBG] The request path /api/user-profiles/me does not match a supported file type
+2025-09-29 03:54:27.371 +07:00 [DBG] The request path /api/submission/list does not match a supported file type
+2025-09-29 03:54:27.372 +07:00 [DBG] The request has an origin header: 'http://localhost:3000'.
+2025-09-29 03:54:27.372 +07:00 [DBG] The request has an origin header: 'http://localhost:3000'.
+2025-09-29 03:54:27.372 +07:00 [INF] CORS policy execution successful.
+2025-09-29 03:54:27.372 +07:00 [INF] CORS policy execution successful.
+2025-09-29 03:54:27.372 +07:00 [DBG] 2 candidate(s) found for the request path '/api/user-profiles/me'
+2025-09-29 03:54:27.372 +07:00 [DBG] 1 candidate(s) found for the request path '/api/submission/list'
+2025-09-29 03:54:27.372 +07:00 [DBG] Endpoint 'CapBot.api.Controllers.UserProfileController.GetMyProfile (CapBot.api)' with route pattern 'api/user-profiles/me' is valid for the request path '/api/user-profiles/me'
+2025-09-29 03:54:27.372 +07:00 [DBG] Endpoint 'CapBot.api.Controllers.SubmissionController.List (CapBot.api)' with route pattern 'api/submission/list' is valid for the request path '/api/submission/list'
+2025-09-29 03:54:27.372 +07:00 [DBG] Endpoint 'CapBot.api.Controllers.UserProfileController.GetById (CapBot.api)' with route pattern 'api/user-profiles/{id}' is valid for the request path '/api/user-profiles/me'
+2025-09-29 03:54:27.372 +07:00 [DBG] Request matched endpoint 'CapBot.api.Controllers.SubmissionController.List (CapBot.api)'
+2025-09-29 03:54:27.372 +07:00 [DBG] Request matched endpoint 'CapBot.api.Controllers.UserProfileController.GetMyProfile (CapBot.api)'
+2025-09-29 03:54:27.372 +07:00 [DBG] Successfully validated the token.
+2025-09-29 03:54:27.373 +07:00 [DBG] AuthenticationScheme: Bearer was successfully authenticated.
+2025-09-29 03:54:27.372 +07:00 [DBG] Successfully validated the token.
+2025-09-29 03:54:27.373 +07:00 [DBG] Authorization was successful.
+2025-09-29 03:54:27.373 +07:00 [DBG] AuthenticationScheme: Bearer was successfully authenticated.
+2025-09-29 03:54:27.373 +07:00 [DBG] Authorization was successful.
+2025-09-29 03:54:27.373 +07:00 [INF] Executing endpoint 'CapBot.api.Controllers.SubmissionController.List (CapBot.api)'
+2025-09-29 03:54:27.373 +07:00 [INF] Executing endpoint 'CapBot.api.Controllers.UserProfileController.GetMyProfile (CapBot.api)'
+2025-09-29 03:54:27.373 +07:00 [INF] Route matched with {action = "GetMyProfile", controller = "UserProfile"}. Executing controller action with signature System.Threading.Tasks.Task`1[Microsoft.AspNetCore.Mvc.IActionResult] GetMyProfile() on controller CapBot.api.Controllers.UserProfileController (CapBot.api).
+2025-09-29 03:54:27.373 +07:00 [INF] Route matched with {action = "List", controller = "Submission"}. Executing controller action with signature System.Threading.Tasks.Task`1[Microsoft.AspNetCore.Mvc.IActionResult] List(App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO) on controller CapBot.api.Controllers.SubmissionController (CapBot.api).
+2025-09-29 03:54:27.374 +07:00 [DBG] Execution plan of authorization filters (in the following order): ["None"]
+2025-09-29 03:54:27.374 +07:00 [DBG] Execution plan of authorization filters (in the following order): ["None"]
+2025-09-29 03:54:27.374 +07:00 [DBG] Execution plan of resource filters (in the following order): ["None"]
+2025-09-29 03:54:27.374 +07:00 [DBG] Execution plan of resource filters (in the following order): ["None"]
+2025-09-29 03:54:27.374 +07:00 [DBG] Execution plan of action filters (in the following order): ["Microsoft.AspNetCore.Mvc.ModelBinding.UnsupportedContentTypeFilter (Order: -3000)"]
+2025-09-29 03:54:27.374 +07:00 [DBG] Execution plan of action filters (in the following order): ["Microsoft.AspNetCore.Mvc.ModelBinding.UnsupportedContentTypeFilter (Order: -3000)"]
+2025-09-29 03:54:27.374 +07:00 [DBG] Execution plan of exception filters (in the following order): ["None"]
+2025-09-29 03:54:27.374 +07:00 [DBG] Execution plan of exception filters (in the following order): ["None"]
+2025-09-29 03:54:27.374 +07:00 [DBG] Execution plan of result filters (in the following order): ["Microsoft.AspNetCore.Mvc.Infrastructure.ClientErrorResultFilter (Order: -2000)"]
+2025-09-29 03:54:27.374 +07:00 [DBG] Execution plan of result filters (in the following order): ["Microsoft.AspNetCore.Mvc.Infrastructure.ClientErrorResultFilter (Order: -2000)","Microsoft.AspNetCore.Mvc.ProducesAttribute (Order: 0)"]
+2025-09-29 03:54:27.374 +07:00 [DBG] Executing controller factory for controller CapBot.api.Controllers.UserProfileController (CapBot.api)
+2025-09-29 03:54:27.374 +07:00 [DBG] Executing controller factory for controller CapBot.api.Controllers.SubmissionController (CapBot.api)
+2025-09-29 03:54:27.375 +07:00 [DBG] Executed controller factory for controller CapBot.api.Controllers.SubmissionController (CapBot.api)
+2025-09-29 03:54:27.375 +07:00 [DBG] Executed controller factory for controller CapBot.api.Controllers.UserProfileController (CapBot.api)
+2025-09-29 03:54:27.377 +07:00 [DBG] Attempting to bind parameter 'query' of type 'App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO' ...
+2025-09-29 03:54:27.378 +07:00 [DBG] Attempting to bind parameter 'query' of type 'App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO' using the name '' in request data ...
+2025-09-29 03:54:27.378 +07:00 [DBG] Entity Framework Core 8.0.16 initialized 'MyDbContext' using provider 'Microsoft.EntityFrameworkCore.SqlServer:8.0.13' with options: MigrationsAssembly=App.DAL 
+2025-09-29 03:54:27.378 +07:00 [DBG] Attempting to bind property 'App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO.TopicVersionId' of type 'System.Nullable`1[System.Int32]' using the name 'TopicVersionId' in request data ...
+2025-09-29 03:54:27.378 +07:00 [DBG] Could not find a value in the request with name 'TopicVersionId' for binding property 'App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO.TopicVersionId' of type 'System.Nullable`1[System.Int32]'.
+2025-09-29 03:54:27.401 +07:00 [DBG] Done attempting to bind property 'App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO.TopicVersionId' of type 'System.Nullable`1[System.Int32]'.
+2025-09-29 03:54:27.401 +07:00 [DBG] Attempting to bind property 'App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO.PhaseId' of type 'System.Nullable`1[System.Int32]' using the name 'PhaseId' in request data ...
+2025-09-29 03:54:27.401 +07:00 [DBG] Could not find a value in the request with name 'PhaseId' for binding property 'App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO.PhaseId' of type 'System.Nullable`1[System.Int32]'.
+2025-09-29 03:54:27.401 +07:00 [DBG] Creating DbConnection.
+2025-09-29 03:54:27.401 +07:00 [DBG] Done attempting to bind property 'App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO.PhaseId' of type 'System.Nullable`1[System.Int32]'.
+2025-09-29 03:54:27.401 +07:00 [DBG] Created DbConnection. (0ms).
+2025-09-29 03:54:27.401 +07:00 [DBG] Attempting to bind property 'App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO.SemesterId' of type 'System.Nullable`1[System.Int32]' using the name 'SemesterId' in request data ...
+2025-09-29 03:54:27.401 +07:00 [DBG] Opening connection to database 'capbot_db' on server 'localhost'.
+2025-09-29 03:54:27.402 +07:00 [DBG] Could not find a value in the request with name 'SemesterId' for binding property 'App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO.SemesterId' of type 'System.Nullable`1[System.Int32]'.
+2025-09-29 03:54:27.402 +07:00 [DBG] Done attempting to bind property 'App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO.SemesterId' of type 'System.Nullable`1[System.Int32]'.
+2025-09-29 03:54:27.402 +07:00 [DBG] Opened connection to database 'capbot_db' on server 'localhost'.
+2025-09-29 03:54:27.402 +07:00 [DBG] Attempting to bind property 'App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO.Status' of type 'System.Nullable`1[App.Entities.Enums.SubmissionStatus]' using the name 'Status' in request data ...
+2025-09-29 03:54:27.402 +07:00 [DBG] Creating DbCommand for 'ExecuteReader'.
+2025-09-29 03:54:27.402 +07:00 [DBG] Could not find a value in the request with name 'Status' for binding property 'App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO.Status' of type 'System.Nullable`1[App.Entities.Enums.SubmissionStatus]'.
+2025-09-29 03:54:27.402 +07:00 [DBG] Created DbCommand for 'ExecuteReader' (0ms).
+2025-09-29 03:54:27.403 +07:00 [DBG] Done attempting to bind property 'App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO.Status' of type 'System.Nullable`1[App.Entities.Enums.SubmissionStatus]'.
+2025-09-29 03:54:27.403 +07:00 [DBG] Initialized DbCommand for 'ExecuteReader' (0ms).
+2025-09-29 03:54:27.403 +07:00 [DBG] Attempting to bind property 'App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO.PageNumber' of type 'System.Int32' using the name 'PageNumber' in request data ...
+2025-09-29 03:54:27.403 +07:00 [DBG] Executing DbCommand [Parameters=[@__targetUserId_0='?' (DbType = Int32)], CommandType='"Text"', CommandTimeout='30']
+SELECT TOP(1) [p].[Id], [p].[Address], [p].[Avatar], [p].[CoverImage], [p].[CreatedAt], [p].[CreatedBy], [p].[DeletedAt], [p].[FullName], [p].[IsActive], [p].[LastModifiedAt], [p].[LastModifiedBy], [p].[UserId]
+FROM [profiles] AS [p]
+WHERE [p].[UserId] = @__targetUserId_0 AND [p].[IsActive] = CAST(1 AS bit) AND [p].[DeletedAt] IS NULL AND [p].[DeletedAt] IS NULL
+2025-09-29 03:54:27.403 +07:00 [DBG] Done attempting to bind property 'App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO.PageNumber' of type 'System.Int32'.
+2025-09-29 03:54:27.406 +07:00 [DBG] Attempting to bind property 'App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO.PageSize' of type 'System.Int32' using the name 'PageSize' in request data ...
+2025-09-29 03:54:27.406 +07:00 [DBG] Done attempting to bind property 'App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO.PageSize' of type 'System.Int32'.
+2025-09-29 03:54:27.406 +07:00 [DBG] Attempting to bind property 'App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO.Keyword' of type 'System.String' using the name 'Keyword' in request data ...
+2025-09-29 03:54:27.406 +07:00 [DBG] Could not find a value in the request with name 'Keyword' for binding property 'App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO.Keyword' of type 'System.String'.
+2025-09-29 03:54:27.407 +07:00 [DBG] Done attempting to bind property 'App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO.Keyword' of type 'System.String'.
+2025-09-29 03:54:27.408 +07:00 [INF] Executed DbCommand (4ms) [Parameters=[@__targetUserId_0='?' (DbType = Int32)], CommandType='"Text"', CommandTimeout='30']
+SELECT TOP(1) [p].[Id], [p].[Address], [p].[Avatar], [p].[CoverImage], [p].[CreatedAt], [p].[CreatedBy], [p].[DeletedAt], [p].[FullName], [p].[IsActive], [p].[LastModifiedAt], [p].[LastModifiedBy], [p].[UserId]
+FROM [profiles] AS [p]
+WHERE [p].[UserId] = @__targetUserId_0 AND [p].[IsActive] = CAST(1 AS bit) AND [p].[DeletedAt] IS NULL AND [p].[DeletedAt] IS NULL
+2025-09-29 03:54:27.409 +07:00 [DBG] Attempting to bind property 'App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO.TotalRecord' of type 'System.Int32' using the name 'TotalRecord' in request data ...
+2025-09-29 03:54:27.409 +07:00 [DBG] Could not find a value in the request with name 'TotalRecord' for binding property 'App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO.TotalRecord' of type 'System.Int32'.
+2025-09-29 03:54:27.409 +07:00 [DBG] Done attempting to bind property 'App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO.TotalRecord' of type 'System.Int32'.
+2025-09-29 03:54:27.409 +07:00 [DBG] Closing data reader to 'capbot_db' on server 'localhost'.
+2025-09-29 03:54:27.410 +07:00 [DBG] Done attempting to bind parameter 'query' of type 'App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO'.
+2025-09-29 03:54:27.410 +07:00 [DBG] Done attempting to bind parameter 'query' of type 'App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO'.
+2025-09-29 03:54:27.410 +07:00 [DBG] A data reader for 'capbot_db' on server 'localhost' is being disposed after spending 0ms reading results.
+2025-09-29 03:54:27.410 +07:00 [DBG] Attempting to validate the bound parameter 'query' of type 'App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO' ...
+2025-09-29 03:54:27.410 +07:00 [DBG] Closing connection to database 'capbot_db' on server 'localhost'.
+2025-09-29 03:54:27.410 +07:00 [DBG] Closed connection to database 'capbot_db' on server 'localhost' (0ms).
+2025-09-29 03:54:27.410 +07:00 [DBG] Done attempting to validate the bound parameter 'query' of type 'App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO'.
+2025-09-29 03:54:27.410 +07:00 [DBG] List of registered output formatters, in the following order: ["Microsoft.AspNetCore.OData.Formatter.ODataOutputFormatter","Microsoft.AspNetCore.OData.Formatter.ODataOutputFormatter","Microsoft.AspNetCore.OData.Formatter.ODataOutputFormatter","Microsoft.AspNetCore.Mvc.Formatters.HttpNoContentOutputFormatter","Microsoft.AspNetCore.Mvc.Formatters.StringOutputFormatter","Microsoft.AspNetCore.Mvc.Formatters.StreamOutputFormatter","Microsoft.AspNetCore.Mvc.Formatters.SystemTextJsonOutputFormatter"]
+2025-09-29 03:54:27.411 +07:00 [DBG] Entity Framework Core 8.0.16 initialized 'MyDbContext' using provider 'Microsoft.EntityFrameworkCore.SqlServer:8.0.13' with options: MigrationsAssembly=App.DAL 
+2025-09-29 03:54:27.415 +07:00 [DBG] No information found on request to perform content negotiation.
+2025-09-29 03:54:27.415 +07:00 [DBG] Attempting to select an output formatter without using a content type as no explicit content types were specified for the response.
+2025-09-29 03:54:27.415 +07:00 [DBG] Attempting to select the first formatter in the output formatters list which can write the result.
+2025-09-29 03:54:27.415 +07:00 [DBG] Selected output formatter 'Microsoft.AspNetCore.Mvc.Formatters.SystemTextJsonOutputFormatter' and content type 'application/json' to write the response.
+2025-09-29 03:54:27.415 +07:00 [DBG] Creating DbConnection.
+2025-09-29 03:54:27.415 +07:00 [INF] Executing ObjectResult, writing value of type 'FS.Commons.FSResponse'.
+2025-09-29 03:54:27.415 +07:00 [DBG] Created DbConnection. (0ms).
+2025-09-29 03:54:27.415 +07:00 [DBG] Opening connection to database 'capbot_db' on server 'localhost'.
+2025-09-29 03:54:27.416 +07:00 [DBG] Opened connection to database 'capbot_db' on server 'localhost'.
+2025-09-29 03:54:27.416 +07:00 [INF] Executed action CapBot.api.Controllers.UserProfileController.GetMyProfile (CapBot.api) in 41.5457ms
+2025-09-29 03:54:27.416 +07:00 [DBG] Creating DbCommand for 'ExecuteReader'.
+2025-09-29 03:54:27.416 +07:00 [INF] Executed endpoint 'CapBot.api.Controllers.UserProfileController.GetMyProfile (CapBot.api)'
+2025-09-29 03:54:27.416 +07:00 [DBG] Connection id "0HNFUQ4FJ9UMK" completed keep alive response.
+2025-09-29 03:54:27.416 +07:00 [DBG] Created DbCommand for 'ExecuteReader' (0ms).
+2025-09-29 03:54:27.416 +07:00 [DBG] 'MyDbContext' disposed.
+2025-09-29 03:54:27.416 +07:00 [DBG] Initialized DbCommand for 'ExecuteReader' (0ms).
+2025-09-29 03:54:27.416 +07:00 [DBG] Disposing connection to database 'capbot_db' on server 'localhost'.
+2025-09-29 03:54:27.416 +07:00 [DBG] Disposed connection to database '' on server '' (0ms).
+2025-09-29 03:54:27.416 +07:00 [DBG] Executing DbCommand [Parameters=[], CommandType='"Text"', CommandTimeout='30']
+SELECT COUNT(*)
+FROM [submissions] AS [s]
+2025-09-29 03:54:27.417 +07:00 [INF] Request finished HTTP/1.1 GET http://localhost:5207/api/user-profiles/me - 200 null application/json; charset=utf-8 45.5784ms
+2025-09-29 03:54:27.418 +07:00 [INF] Executed DbCommand (2ms) [Parameters=[], CommandType='"Text"', CommandTimeout='30']
+SELECT COUNT(*)
+FROM [submissions] AS [s]
+2025-09-29 03:54:27.418 +07:00 [DBG] Closing data reader to 'capbot_db' on server 'localhost'.
+2025-09-29 03:54:27.419 +07:00 [DBG] A data reader for 'capbot_db' on server 'localhost' is being disposed after spending 0ms reading results.
+2025-09-29 03:54:27.419 +07:00 [DBG] Closing connection to database 'capbot_db' on server 'localhost'.
+2025-09-29 03:54:27.419 +07:00 [DBG] Closed connection to database 'capbot_db' on server 'localhost' (0ms).
+2025-09-29 03:54:27.421 +07:00 [DBG] Opening connection to database 'capbot_db' on server 'localhost'.
+2025-09-29 03:54:27.421 +07:00 [DBG] Opened connection to database 'capbot_db' on server 'localhost'.
+2025-09-29 03:54:27.421 +07:00 [DBG] Creating DbCommand for 'ExecuteReader'.
+2025-09-29 03:54:27.422 +07:00 [DBG] Created DbCommand for 'ExecuteReader' (0ms).
+2025-09-29 03:54:27.422 +07:00 [DBG] Initialized DbCommand for 'ExecuteReader' (0ms).
+2025-09-29 03:54:27.422 +07:00 [DBG] Executing DbCommand [Parameters=[@__p_0='?' (DbType = Int32), @__p_1='?' (DbType = Int32)], CommandType='"Text"', CommandTimeout='30']
+SELECT [t].[Id], [t].[AdditionalNotes], [t].[AiCheckDetails], [t].[AiCheckScore], [t].[AiCheckStatus], [t].[CreatedAt], [t].[CreatedBy], [t].[DeletedAt], [t].[DocumentUrl], [t].[IsActive], [t].[LastModifiedAt], [t].[LastModifiedBy], [t].[PhaseId], [t].[Status], [t].[SubmissionRound], [t].[SubmittedAt], [t].[SubmittedBy], [t].[TopicId], [t].[TopicVersionId], [u].[Id], [u].[AccessFailedCount], [u].[ConcurrencyStamp], [u].[CreatedAt], [u].[DeletedAt], [u].[Email], [u].[EmailConfirmed], [u].[LastModifiedAt], [u].[LastModifiedBy], [u].[LockoutEnabled], [u].[LockoutEnd], [u].[NormalizedEmail], [u].[NormalizedUserName], [u].[PasswordHash], [u].[PhoneNumber], [u].[PhoneNumberConfirmed], [u].[SecurityStamp], [u].[TwoFactorEnabled], [u].[UserName], [t0].[Id], [t0].[Abbreviation], [t0].[CategoryId], [t0].[Content], [t0].[Context], [t0].[CreatedAt], [t0].[CreatedBy], [t0].[DeletedAt], [t0].[Description], [t0].[EN_Title], [t0].[IsActive], [t0].[IsApproved], [t0].[IsLegacy], [t0].[LastModifiedAt], [t0].[LastModifiedBy], [t0].[MaxStudents], [t0].[Objectives], [t0].[PotentialDuplicate], [t0].[Problem], [t0].[SemesterId], [t0].[SupervisorId], [t0].[VN_title]
+FROM (
+    SELECT [s].[Id], [s].[AdditionalNotes], [s].[AiCheckDetails], [s].[AiCheckScore], [s].[AiCheckStatus], [s].[CreatedAt], [s].[CreatedBy], [s].[DeletedAt], [s].[DocumentUrl], [s].[IsActive], [s].[LastModifiedAt], [s].[LastModifiedBy], [s].[PhaseId], [s].[Status], [s].[SubmissionRound], [s].[SubmittedAt], [s].[SubmittedBy], [s].[TopicId], [s].[TopicVersionId]
+    FROM [submissions] AS [s]
+    ORDER BY [s].[SubmittedAt] DESC
+    OFFSET @__p_0 ROWS FETCH NEXT @__p_1 ROWS ONLY
+) AS [t]
+INNER JOIN [users] AS [u] ON [t].[SubmittedBy] = [u].[Id]
+LEFT JOIN [topics] AS [t0] ON [t].[TopicId] = [t0].[Id]
+ORDER BY [t].[SubmittedAt] DESC
+2025-09-29 03:54:27.424 +07:00 [INF] Executed DbCommand (2ms) [Parameters=[@__p_0='?' (DbType = Int32), @__p_1='?' (DbType = Int32)], CommandType='"Text"', CommandTimeout='30']
+SELECT [t].[Id], [t].[AdditionalNotes], [t].[AiCheckDetails], [t].[AiCheckScore], [t].[AiCheckStatus], [t].[CreatedAt], [t].[CreatedBy], [t].[DeletedAt], [t].[DocumentUrl], [t].[IsActive], [t].[LastModifiedAt], [t].[LastModifiedBy], [t].[PhaseId], [t].[Status], [t].[SubmissionRound], [t].[SubmittedAt], [t].[SubmittedBy], [t].[TopicId], [t].[TopicVersionId], [u].[Id], [u].[AccessFailedCount], [u].[ConcurrencyStamp], [u].[CreatedAt], [u].[DeletedAt], [u].[Email], [u].[EmailConfirmed], [u].[LastModifiedAt], [u].[LastModifiedBy], [u].[LockoutEnabled], [u].[LockoutEnd], [u].[NormalizedEmail], [u].[NormalizedUserName], [u].[PasswordHash], [u].[PhoneNumber], [u].[PhoneNumberConfirmed], [u].[SecurityStamp], [u].[TwoFactorEnabled], [u].[UserName], [t0].[Id], [t0].[Abbreviation], [t0].[CategoryId], [t0].[Content], [t0].[Context], [t0].[CreatedAt], [t0].[CreatedBy], [t0].[DeletedAt], [t0].[Description], [t0].[EN_Title], [t0].[IsActive], [t0].[IsApproved], [t0].[IsLegacy], [t0].[LastModifiedAt], [t0].[LastModifiedBy], [t0].[MaxStudents], [t0].[Objectives], [t0].[PotentialDuplicate], [t0].[Problem], [t0].[SemesterId], [t0].[SupervisorId], [t0].[VN_title]
+FROM (
+    SELECT [s].[Id], [s].[AdditionalNotes], [s].[AiCheckDetails], [s].[AiCheckScore], [s].[AiCheckStatus], [s].[CreatedAt], [s].[CreatedBy], [s].[DeletedAt], [s].[DocumentUrl], [s].[IsActive], [s].[LastModifiedAt], [s].[LastModifiedBy], [s].[PhaseId], [s].[Status], [s].[SubmissionRound], [s].[SubmittedAt], [s].[SubmittedBy], [s].[TopicId], [s].[TopicVersionId]
+    FROM [submissions] AS [s]
+    ORDER BY [s].[SubmittedAt] DESC
+    OFFSET @__p_0 ROWS FETCH NEXT @__p_1 ROWS ONLY
+) AS [t]
+INNER JOIN [users] AS [u] ON [t].[SubmittedBy] = [u].[Id]
+LEFT JOIN [topics] AS [t0] ON [t].[TopicId] = [t0].[Id]
+ORDER BY [t].[SubmittedAt] DESC
+2025-09-29 03:54:27.425 +07:00 [DBG] Closing data reader to 'capbot_db' on server 'localhost'.
+2025-09-29 03:54:27.428 +07:00 [DBG] A data reader for 'capbot_db' on server 'localhost' is being disposed after spending 3ms reading results.
+2025-09-29 03:54:27.428 +07:00 [DBG] Closing connection to database 'capbot_db' on server 'localhost'.
+2025-09-29 03:54:27.428 +07:00 [DBG] Closed connection to database 'capbot_db' on server 'localhost' (0ms).
+2025-09-29 03:54:27.428 +07:00 [DBG] List of registered output formatters, in the following order: ["Microsoft.AspNetCore.OData.Formatter.ODataOutputFormatter","Microsoft.AspNetCore.OData.Formatter.ODataOutputFormatter","Microsoft.AspNetCore.OData.Formatter.ODataOutputFormatter","Microsoft.AspNetCore.Mvc.Formatters.HttpNoContentOutputFormatter","Microsoft.AspNetCore.Mvc.Formatters.StringOutputFormatter","Microsoft.AspNetCore.Mvc.Formatters.StreamOutputFormatter","Microsoft.AspNetCore.Mvc.Formatters.SystemTextJsonOutputFormatter"]
+2025-09-29 03:54:27.429 +07:00 [DBG] No information found on request to perform content negotiation.
+2025-09-29 03:54:27.429 +07:00 [DBG] Attempting to select the first output formatter in the output formatters list which supports a content type from the explicitly specified content types '["application/json"]'.
+2025-09-29 03:54:27.429 +07:00 [DBG] Selected output formatter 'Microsoft.AspNetCore.Mvc.Formatters.SystemTextJsonOutputFormatter' and content type 'application/json' to write the response.
+2025-09-29 03:54:27.429 +07:00 [INF] Executing ObjectResult, writing value of type 'FS.Commons.FSResponse'.
+2025-09-29 03:54:27.429 +07:00 [INF] Executed action CapBot.api.Controllers.SubmissionController.List (CapBot.api) in 55.1067ms
+2025-09-29 03:54:27.429 +07:00 [INF] Executed endpoint 'CapBot.api.Controllers.SubmissionController.List (CapBot.api)'
+2025-09-29 03:54:27.429 +07:00 [DBG] Connection id "0HNFUQ4FJ9UML" completed keep alive response.
+2025-09-29 03:54:27.430 +07:00 [DBG] 'MyDbContext' disposed.
+2025-09-29 03:54:27.430 +07:00 [DBG] Disposing connection to database 'capbot_db' on server 'localhost'.
+2025-09-29 03:54:27.430 +07:00 [DBG] Disposed connection to database '' on server '' (0ms).
+2025-09-29 03:54:27.430 +07:00 [INF] Request finished HTTP/1.1 GET http://localhost:5207/api/submission/list?PageNumber=1&PageSize=10 - 200 null application/json; charset=utf-8 58.8486ms
+2025-09-29 03:54:27.438 +07:00 [INF] Request starting HTTP/1.1 GET http://localhost:5207/images/entities/11111111.png - null null
+2025-09-29 03:54:27.438 +07:00 [DBG] The request path /images/entities/11111111.png does not match an existing file
+2025-09-29 03:54:27.440 +07:00 [DBG] The request path /images/entities/11111111.png does not match an existing file
+2025-09-29 03:54:27.441 +07:00 [DBG] No candidates found for the request path '/images/entities/11111111.png'
+2025-09-29 03:54:27.441 +07:00 [DBG] Request did not match any endpoints
+2025-09-29 03:54:27.441 +07:00 [DBG] AuthenticationScheme: Bearer was not authenticated.
+2025-09-29 03:54:27.442 +07:00 [DBG] Connection id "0HNFUQ4FJ9UMI" completed keep alive response.
+2025-09-29 03:54:27.442 +07:00 [INF] Request finished HTTP/1.1 GET http://localhost:5207/images/entities/11111111.png - 404 0 null 4.5742ms
+2025-09-29 03:54:27.442 +07:00 [INF] Request reached the end of the middleware pipeline without being handled by application code. Request path: GET http://localhost:5207/images/entities/11111111.png, Response status code: 404
+2025-09-29 03:54:29.448 +07:00 [INF] Request starting HTTP/1.1 OPTIONS http://localhost:5207/api/user-profiles/me - null null
+2025-09-29 03:54:29.448 +07:00 [DBG] OPTIONS requests are not supported
+2025-09-29 03:54:29.448 +07:00 [DBG] OPTIONS requests are not supported
+2025-09-29 03:54:29.448 +07:00 [DBG] The request has an origin header: 'http://localhost:3000'.
+2025-09-29 03:54:29.448 +07:00 [INF] CORS policy execution successful.
+2025-09-29 03:54:29.448 +07:00 [DBG] The request is a preflight request.
+2025-09-29 03:54:29.448 +07:00 [DBG] Connection id "0HNFUQ4FJ9UML" completed keep alive response.
+2025-09-29 03:54:29.448 +07:00 [INF] Request finished HTTP/1.1 OPTIONS http://localhost:5207/api/user-profiles/me - 204 null null 0.4783ms
+2025-09-29 03:54:29.448 +07:00 [INF] Request starting HTTP/1.1 OPTIONS http://localhost:5207/api/submission/list?PageNumber=1&PageSize=10 - null null
+2025-09-29 03:54:29.448 +07:00 [DBG] OPTIONS requests are not supported
+2025-09-29 03:54:29.449 +07:00 [DBG] OPTIONS requests are not supported
+2025-09-29 03:54:29.449 +07:00 [DBG] The request has an origin header: 'http://localhost:3000'.
+2025-09-29 03:54:29.449 +07:00 [INF] CORS policy execution successful.
+2025-09-29 03:54:29.449 +07:00 [DBG] The request is a preflight request.
+2025-09-29 03:54:29.449 +07:00 [DBG] Connection id "0HNFUQ4FJ9UMK" completed keep alive response.
+2025-09-29 03:54:29.449 +07:00 [INF] Request finished HTTP/1.1 OPTIONS http://localhost:5207/api/submission/list?PageNumber=1&PageSize=10 - 204 null null 0.2599ms
+2025-09-29 03:54:29.452 +07:00 [INF] Request starting HTTP/1.1 GET http://localhost:5207/api/user-profiles/me - null null
+2025-09-29 03:54:29.452 +07:00 [INF] Request starting HTTP/1.1 GET http://localhost:5207/api/submission/list?PageNumber=1&PageSize=10 - null null
+2025-09-29 03:54:29.452 +07:00 [DBG] The request path /api/user-profiles/me does not match a supported file type
+2025-09-29 03:54:29.453 +07:00 [DBG] The request path /api/user-profiles/me does not match a supported file type
+2025-09-29 03:54:29.453 +07:00 [DBG] The request path /api/submission/list does not match a supported file type
+2025-09-29 03:54:29.453 +07:00 [DBG] The request has an origin header: 'http://localhost:3000'.
+2025-09-29 03:54:29.453 +07:00 [DBG] The request path /api/submission/list does not match a supported file type
+2025-09-29 03:54:29.453 +07:00 [DBG] The request has an origin header: 'http://localhost:3000'.
+2025-09-29 03:54:29.453 +07:00 [INF] CORS policy execution successful.
+2025-09-29 03:54:29.453 +07:00 [INF] CORS policy execution successful.
+2025-09-29 03:54:29.453 +07:00 [DBG] 2 candidate(s) found for the request path '/api/user-profiles/me'
+2025-09-29 03:54:29.453 +07:00 [DBG] 1 candidate(s) found for the request path '/api/submission/list'
+2025-09-29 03:54:29.453 +07:00 [DBG] Endpoint 'CapBot.api.Controllers.SubmissionController.List (CapBot.api)' with route pattern 'api/submission/list' is valid for the request path '/api/submission/list'
+2025-09-29 03:54:29.453 +07:00 [DBG] Endpoint 'CapBot.api.Controllers.UserProfileController.GetMyProfile (CapBot.api)' with route pattern 'api/user-profiles/me' is valid for the request path '/api/user-profiles/me'
+2025-09-29 03:54:29.453 +07:00 [DBG] Request matched endpoint 'CapBot.api.Controllers.SubmissionController.List (CapBot.api)'
+2025-09-29 03:54:29.453 +07:00 [DBG] Endpoint 'CapBot.api.Controllers.UserProfileController.GetById (CapBot.api)' with route pattern 'api/user-profiles/{id}' is valid for the request path '/api/user-profiles/me'
+2025-09-29 03:54:29.453 +07:00 [DBG] Request matched endpoint 'CapBot.api.Controllers.UserProfileController.GetMyProfile (CapBot.api)'
+2025-09-29 03:54:29.454 +07:00 [DBG] Successfully validated the token.
+2025-09-29 03:54:29.454 +07:00 [DBG] AuthenticationScheme: Bearer was successfully authenticated.
+2025-09-29 03:54:29.454 +07:00 [DBG] Authorization was successful.
+2025-09-29 03:54:29.455 +07:00 [INF] Executing endpoint 'CapBot.api.Controllers.UserProfileController.GetMyProfile (CapBot.api)'
+2025-09-29 03:54:29.455 +07:00 [INF] Route matched with {action = "GetMyProfile", controller = "UserProfile"}. Executing controller action with signature System.Threading.Tasks.Task`1[Microsoft.AspNetCore.Mvc.IActionResult] GetMyProfile() on controller CapBot.api.Controllers.UserProfileController (CapBot.api).
+2025-09-29 03:54:29.455 +07:00 [DBG] Successfully validated the token.
+2025-09-29 03:54:29.455 +07:00 [DBG] AuthenticationScheme: Bearer was successfully authenticated.
+2025-09-29 03:54:29.456 +07:00 [DBG] Authorization was successful.
+2025-09-29 03:54:29.456 +07:00 [INF] Executing endpoint 'CapBot.api.Controllers.SubmissionController.List (CapBot.api)'
+2025-09-29 03:54:29.455 +07:00 [DBG] Execution plan of authorization filters (in the following order): ["None"]
+2025-09-29 03:54:29.456 +07:00 [INF] Route matched with {action = "List", controller = "Submission"}. Executing controller action with signature System.Threading.Tasks.Task`1[Microsoft.AspNetCore.Mvc.IActionResult] List(App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO) on controller CapBot.api.Controllers.SubmissionController (CapBot.api).
+2025-09-29 03:54:29.456 +07:00 [DBG] Execution plan of resource filters (in the following order): ["None"]
+2025-09-29 03:54:29.456 +07:00 [DBG] Execution plan of authorization filters (in the following order): ["None"]
+2025-09-29 03:54:29.456 +07:00 [DBG] Execution plan of action filters (in the following order): ["Microsoft.AspNetCore.Mvc.ModelBinding.UnsupportedContentTypeFilter (Order: -3000)"]
+2025-09-29 03:54:29.456 +07:00 [DBG] Execution plan of resource filters (in the following order): ["None"]
+2025-09-29 03:54:29.456 +07:00 [DBG] Execution plan of exception filters (in the following order): ["None"]
+2025-09-29 03:54:29.456 +07:00 [DBG] Execution plan of action filters (in the following order): ["Microsoft.AspNetCore.Mvc.ModelBinding.UnsupportedContentTypeFilter (Order: -3000)"]
+2025-09-29 03:54:29.456 +07:00 [DBG] Execution plan of result filters (in the following order): ["Microsoft.AspNetCore.Mvc.Infrastructure.ClientErrorResultFilter (Order: -2000)"]
+2025-09-29 03:54:29.457 +07:00 [DBG] Executing controller factory for controller CapBot.api.Controllers.UserProfileController (CapBot.api)
+2025-09-29 03:54:29.458 +07:00 [DBG] Executed controller factory for controller CapBot.api.Controllers.UserProfileController (CapBot.api)
+2025-09-29 03:54:29.458 +07:00 [DBG] Execution plan of exception filters (in the following order): ["None"]
+2025-09-29 03:54:29.465 +07:00 [DBG] Execution plan of result filters (in the following order): ["Microsoft.AspNetCore.Mvc.Infrastructure.ClientErrorResultFilter (Order: -2000)","Microsoft.AspNetCore.Mvc.ProducesAttribute (Order: 0)"]
+2025-09-29 03:54:29.465 +07:00 [DBG] Executing controller factory for controller CapBot.api.Controllers.SubmissionController (CapBot.api)
+2025-09-29 03:54:29.466 +07:00 [DBG] Executed controller factory for controller CapBot.api.Controllers.SubmissionController (CapBot.api)
+2025-09-29 03:54:29.466 +07:00 [DBG] Attempting to bind parameter 'query' of type 'App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO' ...
+2025-09-29 03:54:29.466 +07:00 [DBG] Attempting to bind parameter 'query' of type 'App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO' using the name '' in request data ...
+2025-09-29 03:54:29.467 +07:00 [DBG] Attempting to bind property 'App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO.TopicVersionId' of type 'System.Nullable`1[System.Int32]' using the name 'TopicVersionId' in request data ...
+2025-09-29 03:54:29.477 +07:00 [DBG] Could not find a value in the request with name 'TopicVersionId' for binding property 'App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO.TopicVersionId' of type 'System.Nullable`1[System.Int32]'.
+2025-09-29 03:54:29.467 +07:00 [DBG] Entity Framework Core 8.0.16 initialized 'MyDbContext' using provider 'Microsoft.EntityFrameworkCore.SqlServer:8.0.13' with options: MigrationsAssembly=App.DAL 
+2025-09-29 03:54:29.479 +07:00 [DBG] Done attempting to bind property 'App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO.TopicVersionId' of type 'System.Nullable`1[System.Int32]'.
+2025-09-29 03:54:29.480 +07:00 [DBG] Attempting to bind property 'App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO.PhaseId' of type 'System.Nullable`1[System.Int32]' using the name 'PhaseId' in request data ...
+2025-09-29 03:54:29.480 +07:00 [DBG] Could not find a value in the request with name 'PhaseId' for binding property 'App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO.PhaseId' of type 'System.Nullable`1[System.Int32]'.
+2025-09-29 03:54:29.483 +07:00 [DBG] Done attempting to bind property 'App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO.PhaseId' of type 'System.Nullable`1[System.Int32]'.
+2025-09-29 03:54:29.480 +07:00 [DBG] Creating DbConnection.
+2025-09-29 03:54:29.483 +07:00 [DBG] Attempting to bind property 'App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO.SemesterId' of type 'System.Nullable`1[System.Int32]' using the name 'SemesterId' in request data ...
+2025-09-29 03:54:29.483 +07:00 [DBG] Could not find a value in the request with name 'SemesterId' for binding property 'App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO.SemesterId' of type 'System.Nullable`1[System.Int32]'.
+2025-09-29 03:54:29.483 +07:00 [DBG] Created DbConnection. (3ms).
+2025-09-29 03:54:29.483 +07:00 [DBG] Done attempting to bind property 'App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO.SemesterId' of type 'System.Nullable`1[System.Int32]'.
+2025-09-29 03:54:29.483 +07:00 [DBG] Opening connection to database 'capbot_db' on server 'localhost'.
+2025-09-29 03:54:29.484 +07:00 [DBG] Attempting to bind property 'App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO.Status' of type 'System.Nullable`1[App.Entities.Enums.SubmissionStatus]' using the name 'Status' in request data ...
+2025-09-29 03:54:29.484 +07:00 [DBG] Opened connection to database 'capbot_db' on server 'localhost'.
+2025-09-29 03:54:29.487 +07:00 [DBG] Creating DbCommand for 'ExecuteReader'.
+2025-09-29 03:54:29.487 +07:00 [DBG] Created DbCommand for 'ExecuteReader' (0ms).
+2025-09-29 03:54:29.487 +07:00 [DBG] Could not find a value in the request with name 'Status' for binding property 'App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO.Status' of type 'System.Nullable`1[App.Entities.Enums.SubmissionStatus]'.
+2025-09-29 03:54:29.487 +07:00 [DBG] Done attempting to bind property 'App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO.Status' of type 'System.Nullable`1[App.Entities.Enums.SubmissionStatus]'.
+2025-09-29 03:54:29.487 +07:00 [DBG] Attempting to bind property 'App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO.PageNumber' of type 'System.Int32' using the name 'PageNumber' in request data ...
+2025-09-29 03:54:29.487 +07:00 [DBG] Initialized DbCommand for 'ExecuteReader' (0ms).
+2025-09-29 03:54:29.487 +07:00 [DBG] Done attempting to bind property 'App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO.PageNumber' of type 'System.Int32'.
+2025-09-29 03:54:29.488 +07:00 [DBG] Executing DbCommand [Parameters=[@__targetUserId_0='?' (DbType = Int32)], CommandType='"Text"', CommandTimeout='30']
+SELECT TOP(1) [p].[Id], [p].[Address], [p].[Avatar], [p].[CoverImage], [p].[CreatedAt], [p].[CreatedBy], [p].[DeletedAt], [p].[FullName], [p].[IsActive], [p].[LastModifiedAt], [p].[LastModifiedBy], [p].[UserId]
+FROM [profiles] AS [p]
+WHERE [p].[UserId] = @__targetUserId_0 AND [p].[IsActive] = CAST(1 AS bit) AND [p].[DeletedAt] IS NULL AND [p].[DeletedAt] IS NULL
+2025-09-29 03:54:29.490 +07:00 [DBG] Attempting to bind property 'App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO.PageSize' of type 'System.Int32' using the name 'PageSize' in request data ...
+2025-09-29 03:54:29.490 +07:00 [DBG] Done attempting to bind property 'App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO.PageSize' of type 'System.Int32'.
+2025-09-29 03:54:29.490 +07:00 [DBG] Attempting to bind property 'App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO.Keyword' of type 'System.String' using the name 'Keyword' in request data ...
+2025-09-29 03:54:29.491 +07:00 [DBG] Could not find a value in the request with name 'Keyword' for binding property 'App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO.Keyword' of type 'System.String'.
+2025-09-29 03:54:29.491 +07:00 [DBG] Done attempting to bind property 'App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO.Keyword' of type 'System.String'.
+2025-09-29 03:54:29.491 +07:00 [DBG] Attempting to bind property 'App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO.TotalRecord' of type 'System.Int32' using the name 'TotalRecord' in request data ...
+2025-09-29 03:54:29.491 +07:00 [DBG] Could not find a value in the request with name 'TotalRecord' for binding property 'App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO.TotalRecord' of type 'System.Int32'.
+2025-09-29 03:54:29.491 +07:00 [DBG] Done attempting to bind property 'App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO.TotalRecord' of type 'System.Int32'.
+2025-09-29 03:54:29.491 +07:00 [DBG] Done attempting to bind parameter 'query' of type 'App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO'.
+2025-09-29 03:54:29.491 +07:00 [DBG] Done attempting to bind parameter 'query' of type 'App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO'.
+2025-09-29 03:54:29.492 +07:00 [DBG] Attempting to validate the bound parameter 'query' of type 'App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO' ...
+2025-09-29 03:54:29.492 +07:00 [DBG] Done attempting to validate the bound parameter 'query' of type 'App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO'.
+2025-09-29 03:54:29.493 +07:00 [DBG] Entity Framework Core 8.0.16 initialized 'MyDbContext' using provider 'Microsoft.EntityFrameworkCore.SqlServer:8.0.13' with options: MigrationsAssembly=App.DAL 
+2025-09-29 03:54:29.493 +07:00 [DBG] Creating DbConnection.
+2025-09-29 03:54:29.493 +07:00 [DBG] Created DbConnection. (0ms).
+2025-09-29 03:54:29.493 +07:00 [DBG] Opening connection to database 'capbot_db' on server 'localhost'.
+2025-09-29 03:54:29.507 +07:00 [INF] Executed DbCommand (19ms) [Parameters=[@__targetUserId_0='?' (DbType = Int32)], CommandType='"Text"', CommandTimeout='30']
+SELECT TOP(1) [p].[Id], [p].[Address], [p].[Avatar], [p].[CoverImage], [p].[CreatedAt], [p].[CreatedBy], [p].[DeletedAt], [p].[FullName], [p].[IsActive], [p].[LastModifiedAt], [p].[LastModifiedBy], [p].[UserId]
+FROM [profiles] AS [p]
+WHERE [p].[UserId] = @__targetUserId_0 AND [p].[IsActive] = CAST(1 AS bit) AND [p].[DeletedAt] IS NULL AND [p].[DeletedAt] IS NULL
+2025-09-29 03:54:29.508 +07:00 [DBG] Closing data reader to 'capbot_db' on server 'localhost'.
+2025-09-29 03:54:29.508 +07:00 [DBG] A data reader for 'capbot_db' on server 'localhost' is being disposed after spending 0ms reading results.
+2025-09-29 03:54:29.509 +07:00 [DBG] Closing connection to database 'capbot_db' on server 'localhost'.
+2025-09-29 03:54:29.509 +07:00 [DBG] Closed connection to database 'capbot_db' on server 'localhost' (0ms).
+2025-09-29 03:54:29.509 +07:00 [DBG] Opened connection to database 'capbot_db' on server 'localhost'.
+2025-09-29 03:54:29.510 +07:00 [DBG] List of registered output formatters, in the following order: ["Microsoft.AspNetCore.OData.Formatter.ODataOutputFormatter","Microsoft.AspNetCore.OData.Formatter.ODataOutputFormatter","Microsoft.AspNetCore.OData.Formatter.ODataOutputFormatter","Microsoft.AspNetCore.Mvc.Formatters.HttpNoContentOutputFormatter","Microsoft.AspNetCore.Mvc.Formatters.StringOutputFormatter","Microsoft.AspNetCore.Mvc.Formatters.StreamOutputFormatter","Microsoft.AspNetCore.Mvc.Formatters.SystemTextJsonOutputFormatter"]
+2025-09-29 03:54:29.510 +07:00 [DBG] Creating DbCommand for 'ExecuteReader'.
+2025-09-29 03:54:29.510 +07:00 [DBG] No information found on request to perform content negotiation.
+2025-09-29 03:54:29.510 +07:00 [DBG] Attempting to select an output formatter without using a content type as no explicit content types were specified for the response.
+2025-09-29 03:54:29.510 +07:00 [DBG] Created DbCommand for 'ExecuteReader' (0ms).
+2025-09-29 03:54:29.510 +07:00 [DBG] Attempting to select the first formatter in the output formatters list which can write the result.
+2025-09-29 03:54:29.510 +07:00 [DBG] Initialized DbCommand for 'ExecuteReader' (0ms).
+2025-09-29 03:54:29.510 +07:00 [DBG] Selected output formatter 'Microsoft.AspNetCore.Mvc.Formatters.SystemTextJsonOutputFormatter' and content type 'application/json' to write the response.
+2025-09-29 03:54:29.510 +07:00 [DBG] Executing DbCommand [Parameters=[], CommandType='"Text"', CommandTimeout='30']
+SELECT COUNT(*)
+FROM [submissions] AS [s]
+2025-09-29 03:54:29.510 +07:00 [INF] Executing ObjectResult, writing value of type 'FS.Commons.FSResponse'.
+2025-09-29 03:54:29.510 +07:00 [INF] Executed action CapBot.api.Controllers.UserProfileController.GetMyProfile (CapBot.api) in 53.5577ms
+2025-09-29 03:54:29.510 +07:00 [INF] Executed endpoint 'CapBot.api.Controllers.UserProfileController.GetMyProfile (CapBot.api)'
+2025-09-29 03:54:29.511 +07:00 [DBG] Connection id "0HNFUQ4FJ9UMK" completed keep alive response.
+2025-09-29 03:54:29.511 +07:00 [DBG] 'MyDbContext' disposed.
+2025-09-29 03:54:29.511 +07:00 [DBG] Disposing connection to database 'capbot_db' on server 'localhost'.
+2025-09-29 03:54:29.511 +07:00 [DBG] Disposed connection to database '' on server '' (0ms).
+2025-09-29 03:54:29.511 +07:00 [INF] Request finished HTTP/1.1 GET http://localhost:5207/api/user-profiles/me - 200 null application/json; charset=utf-8 59.1462ms
+2025-09-29 03:54:29.518 +07:00 [INF] Executed DbCommand (8ms) [Parameters=[], CommandType='"Text"', CommandTimeout='30']
+SELECT COUNT(*)
+FROM [submissions] AS [s]
+2025-09-29 03:54:29.518 +07:00 [DBG] Closing data reader to 'capbot_db' on server 'localhost'.
+2025-09-29 03:54:29.519 +07:00 [DBG] A data reader for 'capbot_db' on server 'localhost' is being disposed after spending 0ms reading results.
+2025-09-29 03:54:29.519 +07:00 [DBG] Closing connection to database 'capbot_db' on server 'localhost'.
+2025-09-29 03:54:29.519 +07:00 [DBG] Closed connection to database 'capbot_db' on server 'localhost' (0ms).
+2025-09-29 03:54:29.521 +07:00 [DBG] Opening connection to database 'capbot_db' on server 'localhost'.
+2025-09-29 03:54:29.521 +07:00 [DBG] Opened connection to database 'capbot_db' on server 'localhost'.
+2025-09-29 03:54:29.522 +07:00 [DBG] Creating DbCommand for 'ExecuteReader'.
+2025-09-29 03:54:29.522 +07:00 [DBG] Created DbCommand for 'ExecuteReader' (0ms).
+2025-09-29 03:54:29.522 +07:00 [DBG] Initialized DbCommand for 'ExecuteReader' (0ms).
+2025-09-29 03:54:29.522 +07:00 [DBG] Executing DbCommand [Parameters=[@__p_0='?' (DbType = Int32), @__p_1='?' (DbType = Int32)], CommandType='"Text"', CommandTimeout='30']
+SELECT [t].[Id], [t].[AdditionalNotes], [t].[AiCheckDetails], [t].[AiCheckScore], [t].[AiCheckStatus], [t].[CreatedAt], [t].[CreatedBy], [t].[DeletedAt], [t].[DocumentUrl], [t].[IsActive], [t].[LastModifiedAt], [t].[LastModifiedBy], [t].[PhaseId], [t].[Status], [t].[SubmissionRound], [t].[SubmittedAt], [t].[SubmittedBy], [t].[TopicId], [t].[TopicVersionId], [u].[Id], [u].[AccessFailedCount], [u].[ConcurrencyStamp], [u].[CreatedAt], [u].[DeletedAt], [u].[Email], [u].[EmailConfirmed], [u].[LastModifiedAt], [u].[LastModifiedBy], [u].[LockoutEnabled], [u].[LockoutEnd], [u].[NormalizedEmail], [u].[NormalizedUserName], [u].[PasswordHash], [u].[PhoneNumber], [u].[PhoneNumberConfirmed], [u].[SecurityStamp], [u].[TwoFactorEnabled], [u].[UserName], [t0].[Id], [t0].[Abbreviation], [t0].[CategoryId], [t0].[Content], [t0].[Context], [t0].[CreatedAt], [t0].[CreatedBy], [t0].[DeletedAt], [t0].[Description], [t0].[EN_Title], [t0].[IsActive], [t0].[IsApproved], [t0].[IsLegacy], [t0].[LastModifiedAt], [t0].[LastModifiedBy], [t0].[MaxStudents], [t0].[Objectives], [t0].[PotentialDuplicate], [t0].[Problem], [t0].[SemesterId], [t0].[SupervisorId], [t0].[VN_title]
+FROM (
+    SELECT [s].[Id], [s].[AdditionalNotes], [s].[AiCheckDetails], [s].[AiCheckScore], [s].[AiCheckStatus], [s].[CreatedAt], [s].[CreatedBy], [s].[DeletedAt], [s].[DocumentUrl], [s].[IsActive], [s].[LastModifiedAt], [s].[LastModifiedBy], [s].[PhaseId], [s].[Status], [s].[SubmissionRound], [s].[SubmittedAt], [s].[SubmittedBy], [s].[TopicId], [s].[TopicVersionId]
+    FROM [submissions] AS [s]
+    ORDER BY [s].[SubmittedAt] DESC
+    OFFSET @__p_0 ROWS FETCH NEXT @__p_1 ROWS ONLY
+) AS [t]
+INNER JOIN [users] AS [u] ON [t].[SubmittedBy] = [u].[Id]
+LEFT JOIN [topics] AS [t0] ON [t].[TopicId] = [t0].[Id]
+ORDER BY [t].[SubmittedAt] DESC
+2025-09-29 03:54:29.525 +07:00 [INF] Request starting HTTP/1.1 GET http://localhost:5207/images/entities/11111111.png - null null
+2025-09-29 03:54:29.525 +07:00 [DBG] The request path /images/entities/11111111.png does not match an existing file
+2025-09-29 03:54:29.525 +07:00 [DBG] The request path /images/entities/11111111.png does not match an existing file
+2025-09-29 03:54:29.525 +07:00 [DBG] No candidates found for the request path '/images/entities/11111111.png'
+2025-09-29 03:54:29.525 +07:00 [DBG] Request did not match any endpoints
+2025-09-29 03:54:29.525 +07:00 [DBG] AuthenticationScheme: Bearer was not authenticated.
+2025-09-29 03:54:29.526 +07:00 [DBG] Connection id "0HNFUQ4FJ9UMI" completed keep alive response.
+2025-09-29 03:54:29.526 +07:00 [INF] Request finished HTTP/1.1 GET http://localhost:5207/images/entities/11111111.png - 404 0 null 1.0585ms
+2025-09-29 03:54:29.526 +07:00 [INF] Request reached the end of the middleware pipeline without being handled by application code. Request path: GET http://localhost:5207/images/entities/11111111.png, Response status code: 404
+2025-09-29 03:54:29.538 +07:00 [INF] Executed DbCommand (17ms) [Parameters=[@__p_0='?' (DbType = Int32), @__p_1='?' (DbType = Int32)], CommandType='"Text"', CommandTimeout='30']
+SELECT [t].[Id], [t].[AdditionalNotes], [t].[AiCheckDetails], [t].[AiCheckScore], [t].[AiCheckStatus], [t].[CreatedAt], [t].[CreatedBy], [t].[DeletedAt], [t].[DocumentUrl], [t].[IsActive], [t].[LastModifiedAt], [t].[LastModifiedBy], [t].[PhaseId], [t].[Status], [t].[SubmissionRound], [t].[SubmittedAt], [t].[SubmittedBy], [t].[TopicId], [t].[TopicVersionId], [u].[Id], [u].[AccessFailedCount], [u].[ConcurrencyStamp], [u].[CreatedAt], [u].[DeletedAt], [u].[Email], [u].[EmailConfirmed], [u].[LastModifiedAt], [u].[LastModifiedBy], [u].[LockoutEnabled], [u].[LockoutEnd], [u].[NormalizedEmail], [u].[NormalizedUserName], [u].[PasswordHash], [u].[PhoneNumber], [u].[PhoneNumberConfirmed], [u].[SecurityStamp], [u].[TwoFactorEnabled], [u].[UserName], [t0].[Id], [t0].[Abbreviation], [t0].[CategoryId], [t0].[Content], [t0].[Context], [t0].[CreatedAt], [t0].[CreatedBy], [t0].[DeletedAt], [t0].[Description], [t0].[EN_Title], [t0].[IsActive], [t0].[IsApproved], [t0].[IsLegacy], [t0].[LastModifiedAt], [t0].[LastModifiedBy], [t0].[MaxStudents], [t0].[Objectives], [t0].[PotentialDuplicate], [t0].[Problem], [t0].[SemesterId], [t0].[SupervisorId], [t0].[VN_title]
+FROM (
+    SELECT [s].[Id], [s].[AdditionalNotes], [s].[AiCheckDetails], [s].[AiCheckScore], [s].[AiCheckStatus], [s].[CreatedAt], [s].[CreatedBy], [s].[DeletedAt], [s].[DocumentUrl], [s].[IsActive], [s].[LastModifiedAt], [s].[LastModifiedBy], [s].[PhaseId], [s].[Status], [s].[SubmissionRound], [s].[SubmittedAt], [s].[SubmittedBy], [s].[TopicId], [s].[TopicVersionId]
+    FROM [submissions] AS [s]
+    ORDER BY [s].[SubmittedAt] DESC
+    OFFSET @__p_0 ROWS FETCH NEXT @__p_1 ROWS ONLY
+) AS [t]
+INNER JOIN [users] AS [u] ON [t].[SubmittedBy] = [u].[Id]
+LEFT JOIN [topics] AS [t0] ON [t].[TopicId] = [t0].[Id]
+ORDER BY [t].[SubmittedAt] DESC
+2025-09-29 03:54:29.539 +07:00 [DBG] Closing data reader to 'capbot_db' on server 'localhost'.
+2025-09-29 03:54:29.539 +07:00 [DBG] A data reader for 'capbot_db' on server 'localhost' is being disposed after spending 0ms reading results.
+2025-09-29 03:54:29.539 +07:00 [DBG] Closing connection to database 'capbot_db' on server 'localhost'.
+2025-09-29 03:54:29.539 +07:00 [DBG] Closed connection to database 'capbot_db' on server 'localhost' (0ms).
+2025-09-29 03:54:29.539 +07:00 [DBG] List of registered output formatters, in the following order: ["Microsoft.AspNetCore.OData.Formatter.ODataOutputFormatter","Microsoft.AspNetCore.OData.Formatter.ODataOutputFormatter","Microsoft.AspNetCore.OData.Formatter.ODataOutputFormatter","Microsoft.AspNetCore.Mvc.Formatters.HttpNoContentOutputFormatter","Microsoft.AspNetCore.Mvc.Formatters.StringOutputFormatter","Microsoft.AspNetCore.Mvc.Formatters.StreamOutputFormatter","Microsoft.AspNetCore.Mvc.Formatters.SystemTextJsonOutputFormatter"]
+2025-09-29 03:54:29.539 +07:00 [DBG] No information found on request to perform content negotiation.
+2025-09-29 03:54:29.539 +07:00 [DBG] Attempting to select the first output formatter in the output formatters list which supports a content type from the explicitly specified content types '["application/json"]'.
+2025-09-29 03:54:29.540 +07:00 [DBG] Selected output formatter 'Microsoft.AspNetCore.Mvc.Formatters.SystemTextJsonOutputFormatter' and content type 'application/json' to write the response.
+2025-09-29 03:54:29.540 +07:00 [INF] Executing ObjectResult, writing value of type 'FS.Commons.FSResponse'.
+2025-09-29 03:54:29.541 +07:00 [INF] Executed action CapBot.api.Controllers.SubmissionController.List (CapBot.api) in 76.3206ms
+2025-09-29 03:54:29.541 +07:00 [INF] Executed endpoint 'CapBot.api.Controllers.SubmissionController.List (CapBot.api)'
+2025-09-29 03:54:29.542 +07:00 [DBG] Connection id "0HNFUQ4FJ9UML" completed keep alive response.
+2025-09-29 03:54:29.542 +07:00 [DBG] 'MyDbContext' disposed.
+2025-09-29 03:54:29.542 +07:00 [DBG] Disposing connection to database 'capbot_db' on server 'localhost'.
+2025-09-29 03:54:29.542 +07:00 [DBG] Disposed connection to database '' on server '' (0ms).
+2025-09-29 03:54:29.542 +07:00 [INF] Request finished HTTP/1.1 GET http://localhost:5207/api/submission/list?PageNumber=1&PageSize=10 - 200 null application/json; charset=utf-8 89.8908ms
+2025-09-29 03:54:30.826 +07:00 [INF] Request starting HTTP/1.1 GET http://localhost:5207/api/submission/list?PageNumber=1&PageSize=10 - null null
+2025-09-29 03:54:30.826 +07:00 [INF] Request starting HTTP/1.1 GET http://localhost:5207/api/user-profiles/me - null null
+2025-09-29 03:54:30.826 +07:00 [DBG] The request path /api/submission/list does not match a supported file type
+2025-09-29 03:54:30.826 +07:00 [DBG] The request path /api/user-profiles/me does not match a supported file type
+2025-09-29 03:54:30.826 +07:00 [DBG] The request path /api/submission/list does not match a supported file type
+2025-09-29 03:54:30.826 +07:00 [DBG] The request path /api/user-profiles/me does not match a supported file type
+2025-09-29 03:54:30.826 +07:00 [DBG] The request has an origin header: 'http://localhost:3000'.
+2025-09-29 03:54:30.826 +07:00 [DBG] The request has an origin header: 'http://localhost:3000'.
+2025-09-29 03:54:30.826 +07:00 [INF] CORS policy execution successful.
+2025-09-29 03:54:30.826 +07:00 [INF] CORS policy execution successful.
+2025-09-29 03:54:30.826 +07:00 [DBG] 1 candidate(s) found for the request path '/api/submission/list'
+2025-09-29 03:54:30.826 +07:00 [DBG] 2 candidate(s) found for the request path '/api/user-profiles/me'
+2025-09-29 03:54:30.826 +07:00 [DBG] Endpoint 'CapBot.api.Controllers.SubmissionController.List (CapBot.api)' with route pattern 'api/submission/list' is valid for the request path '/api/submission/list'
+2025-09-29 03:54:30.826 +07:00 [DBG] Endpoint 'CapBot.api.Controllers.UserProfileController.GetMyProfile (CapBot.api)' with route pattern 'api/user-profiles/me' is valid for the request path '/api/user-profiles/me'
+2025-09-29 03:54:30.826 +07:00 [DBG] Request matched endpoint 'CapBot.api.Controllers.SubmissionController.List (CapBot.api)'
+2025-09-29 03:54:30.826 +07:00 [DBG] Endpoint 'CapBot.api.Controllers.UserProfileController.GetById (CapBot.api)' with route pattern 'api/user-profiles/{id}' is valid for the request path '/api/user-profiles/me'
+2025-09-29 03:54:30.826 +07:00 [DBG] Request matched endpoint 'CapBot.api.Controllers.UserProfileController.GetMyProfile (CapBot.api)'
+2025-09-29 03:54:30.826 +07:00 [DBG] Successfully validated the token.
+2025-09-29 03:54:30.826 +07:00 [DBG] Successfully validated the token.
+2025-09-29 03:54:30.826 +07:00 [DBG] AuthenticationScheme: Bearer was successfully authenticated.
+2025-09-29 03:54:30.826 +07:00 [DBG] AuthenticationScheme: Bearer was successfully authenticated.
+2025-09-29 03:54:30.827 +07:00 [DBG] Authorization was successful.
+2025-09-29 03:54:30.827 +07:00 [DBG] Authorization was successful.
+2025-09-29 03:54:30.827 +07:00 [INF] Executing endpoint 'CapBot.api.Controllers.SubmissionController.List (CapBot.api)'
+2025-09-29 03:54:30.827 +07:00 [INF] Executing endpoint 'CapBot.api.Controllers.UserProfileController.GetMyProfile (CapBot.api)'
+2025-09-29 03:54:30.827 +07:00 [INF] Route matched with {action = "List", controller = "Submission"}. Executing controller action with signature System.Threading.Tasks.Task`1[Microsoft.AspNetCore.Mvc.IActionResult] List(App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO) on controller CapBot.api.Controllers.SubmissionController (CapBot.api).
+2025-09-29 03:54:30.827 +07:00 [INF] Route matched with {action = "GetMyProfile", controller = "UserProfile"}. Executing controller action with signature System.Threading.Tasks.Task`1[Microsoft.AspNetCore.Mvc.IActionResult] GetMyProfile() on controller CapBot.api.Controllers.UserProfileController (CapBot.api).
+2025-09-29 03:54:30.827 +07:00 [DBG] Execution plan of authorization filters (in the following order): ["None"]
+2025-09-29 03:54:30.827 +07:00 [DBG] Execution plan of authorization filters (in the following order): ["None"]
+2025-09-29 03:54:30.827 +07:00 [DBG] Execution plan of resource filters (in the following order): ["None"]
+2025-09-29 03:54:30.827 +07:00 [DBG] Execution plan of resource filters (in the following order): ["None"]
+2025-09-29 03:54:30.827 +07:00 [DBG] Execution plan of action filters (in the following order): ["Microsoft.AspNetCore.Mvc.ModelBinding.UnsupportedContentTypeFilter (Order: -3000)"]
+2025-09-29 03:54:30.827 +07:00 [DBG] Execution plan of action filters (in the following order): ["Microsoft.AspNetCore.Mvc.ModelBinding.UnsupportedContentTypeFilter (Order: -3000)"]
+2025-09-29 03:54:30.827 +07:00 [DBG] Execution plan of exception filters (in the following order): ["None"]
+2025-09-29 03:54:30.827 +07:00 [DBG] Execution plan of result filters (in the following order): ["Microsoft.AspNetCore.Mvc.Infrastructure.ClientErrorResultFilter (Order: -2000)","Microsoft.AspNetCore.Mvc.ProducesAttribute (Order: 0)"]
+2025-09-29 03:54:30.827 +07:00 [DBG] Executing controller factory for controller CapBot.api.Controllers.SubmissionController (CapBot.api)
+2025-09-29 03:54:30.827 +07:00 [DBG] Execution plan of exception filters (in the following order): ["None"]
+2025-09-29 03:54:30.827 +07:00 [DBG] Execution plan of result filters (in the following order): ["Microsoft.AspNetCore.Mvc.Infrastructure.ClientErrorResultFilter (Order: -2000)"]
+2025-09-29 03:54:30.828 +07:00 [DBG] Executing controller factory for controller CapBot.api.Controllers.UserProfileController (CapBot.api)
+2025-09-29 03:54:30.827 +07:00 [DBG] Executed controller factory for controller CapBot.api.Controllers.SubmissionController (CapBot.api)
+2025-09-29 03:54:30.828 +07:00 [DBG] Attempting to bind parameter 'query' of type 'App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO' ...
+2025-09-29 03:54:30.828 +07:00 [DBG] Executed controller factory for controller CapBot.api.Controllers.UserProfileController (CapBot.api)
+2025-09-29 03:54:30.828 +07:00 [DBG] Attempting to bind parameter 'query' of type 'App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO' using the name '' in request data ...
+2025-09-29 03:54:30.828 +07:00 [DBG] Attempting to bind property 'App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO.TopicVersionId' of type 'System.Nullable`1[System.Int32]' using the name 'TopicVersionId' in request data ...
+2025-09-29 03:54:30.828 +07:00 [DBG] Could not find a value in the request with name 'TopicVersionId' for binding property 'App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO.TopicVersionId' of type 'System.Nullable`1[System.Int32]'.
+2025-09-29 03:54:30.829 +07:00 [DBG] Entity Framework Core 8.0.16 initialized 'MyDbContext' using provider 'Microsoft.EntityFrameworkCore.SqlServer:8.0.13' with options: MigrationsAssembly=App.DAL 
+2025-09-29 03:54:30.832 +07:00 [DBG] Done attempting to bind property 'App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO.TopicVersionId' of type 'System.Nullable`1[System.Int32]'.
+2025-09-29 03:54:30.833 +07:00 [DBG] Attempting to bind property 'App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO.PhaseId' of type 'System.Nullable`1[System.Int32]' using the name 'PhaseId' in request data ...
+2025-09-29 03:54:30.833 +07:00 [DBG] Could not find a value in the request with name 'PhaseId' for binding property 'App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO.PhaseId' of type 'System.Nullable`1[System.Int32]'.
+2025-09-29 03:54:30.833 +07:00 [DBG] Done attempting to bind property 'App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO.PhaseId' of type 'System.Nullable`1[System.Int32]'.
+2025-09-29 03:54:30.833 +07:00 [DBG] Attempting to bind property 'App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO.SemesterId' of type 'System.Nullable`1[System.Int32]' using the name 'SemesterId' in request data ...
+2025-09-29 03:54:30.833 +07:00 [DBG] Creating DbConnection.
+2025-09-29 03:54:30.834 +07:00 [DBG] Could not find a value in the request with name 'SemesterId' for binding property 'App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO.SemesterId' of type 'System.Nullable`1[System.Int32]'.
+2025-09-29 03:54:30.835 +07:00 [DBG] Done attempting to bind property 'App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO.SemesterId' of type 'System.Nullable`1[System.Int32]'.
+2025-09-29 03:54:30.835 +07:00 [DBG] Created DbConnection. (1ms).
+2025-09-29 03:54:30.835 +07:00 [DBG] Attempting to bind property 'App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO.Status' of type 'System.Nullable`1[App.Entities.Enums.SubmissionStatus]' using the name 'Status' in request data ...
+2025-09-29 03:54:30.835 +07:00 [DBG] Opening connection to database 'capbot_db' on server 'localhost'.
+2025-09-29 03:54:30.835 +07:00 [DBG] Could not find a value in the request with name 'Status' for binding property 'App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO.Status' of type 'System.Nullable`1[App.Entities.Enums.SubmissionStatus]'.
+2025-09-29 03:54:30.837 +07:00 [DBG] Done attempting to bind property 'App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO.Status' of type 'System.Nullable`1[App.Entities.Enums.SubmissionStatus]'.
+2025-09-29 03:54:30.837 +07:00 [DBG] Attempting to bind property 'App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO.PageNumber' of type 'System.Int32' using the name 'PageNumber' in request data ...
+2025-09-29 03:54:30.838 +07:00 [DBG] Done attempting to bind property 'App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO.PageNumber' of type 'System.Int32'.
+2025-09-29 03:54:30.838 +07:00 [DBG] Attempting to bind property 'App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO.PageSize' of type 'System.Int32' using the name 'PageSize' in request data ...
+2025-09-29 03:54:30.838 +07:00 [DBG] Done attempting to bind property 'App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO.PageSize' of type 'System.Int32'.
+2025-09-29 03:54:30.835 +07:00 [DBG] Opened connection to database 'capbot_db' on server 'localhost'.
+2025-09-29 03:54:30.838 +07:00 [DBG] Attempting to bind property 'App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO.Keyword' of type 'System.String' using the name 'Keyword' in request data ...
+2025-09-29 03:54:30.841 +07:00 [DBG] Could not find a value in the request with name 'Keyword' for binding property 'App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO.Keyword' of type 'System.String'.
+2025-09-29 03:54:30.839 +07:00 [DBG] Creating DbCommand for 'ExecuteReader'.
+2025-09-29 03:54:30.841 +07:00 [DBG] Done attempting to bind property 'App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO.Keyword' of type 'System.String'.
+2025-09-29 03:54:30.841 +07:00 [DBG] Created DbCommand for 'ExecuteReader' (2ms).
+2025-09-29 03:54:30.842 +07:00 [DBG] Attempting to bind property 'App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO.TotalRecord' of type 'System.Int32' using the name 'TotalRecord' in request data ...
+2025-09-29 03:54:30.842 +07:00 [DBG] Initialized DbCommand for 'ExecuteReader' (2ms).
+2025-09-29 03:54:30.842 +07:00 [DBG] Could not find a value in the request with name 'TotalRecord' for binding property 'App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO.TotalRecord' of type 'System.Int32'.
+2025-09-29 03:54:30.842 +07:00 [DBG] Executing DbCommand [Parameters=[@__targetUserId_0='?' (DbType = Int32)], CommandType='"Text"', CommandTimeout='30']
+SELECT TOP(1) [p].[Id], [p].[Address], [p].[Avatar], [p].[CoverImage], [p].[CreatedAt], [p].[CreatedBy], [p].[DeletedAt], [p].[FullName], [p].[IsActive], [p].[LastModifiedAt], [p].[LastModifiedBy], [p].[UserId]
+FROM [profiles] AS [p]
+WHERE [p].[UserId] = @__targetUserId_0 AND [p].[IsActive] = CAST(1 AS bit) AND [p].[DeletedAt] IS NULL AND [p].[DeletedAt] IS NULL
+2025-09-29 03:54:30.843 +07:00 [DBG] Done attempting to bind property 'App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO.TotalRecord' of type 'System.Int32'.
+2025-09-29 03:54:30.843 +07:00 [DBG] Done attempting to bind parameter 'query' of type 'App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO'.
+2025-09-29 03:54:30.843 +07:00 [DBG] Done attempting to bind parameter 'query' of type 'App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO'.
+2025-09-29 03:54:30.844 +07:00 [DBG] Attempting to validate the bound parameter 'query' of type 'App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO' ...
+2025-09-29 03:54:30.849 +07:00 [DBG] Done attempting to validate the bound parameter 'query' of type 'App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO'.
+2025-09-29 03:54:30.851 +07:00 [DBG] Entity Framework Core 8.0.16 initialized 'MyDbContext' using provider 'Microsoft.EntityFrameworkCore.SqlServer:8.0.13' with options: MigrationsAssembly=App.DAL 
+2025-09-29 03:54:30.852 +07:00 [DBG] Creating DbConnection.
+2025-09-29 03:54:30.852 +07:00 [DBG] Created DbConnection. (0ms).
+2025-09-29 03:54:30.852 +07:00 [DBG] Opening connection to database 'capbot_db' on server 'localhost'.
+2025-09-29 03:54:30.852 +07:00 [DBG] Opened connection to database 'capbot_db' on server 'localhost'.
+2025-09-29 03:54:30.852 +07:00 [DBG] Creating DbCommand for 'ExecuteReader'.
+2025-09-29 03:54:30.853 +07:00 [DBG] Created DbCommand for 'ExecuteReader' (0ms).
+2025-09-29 03:54:30.854 +07:00 [DBG] Initialized DbCommand for 'ExecuteReader' (1ms).
+2025-09-29 03:54:30.854 +07:00 [DBG] Executing DbCommand [Parameters=[], CommandType='"Text"', CommandTimeout='30']
+SELECT COUNT(*)
+FROM [submissions] AS [s]
+2025-09-29 03:54:30.857 +07:00 [INF] Executed DbCommand (15ms) [Parameters=[@__targetUserId_0='?' (DbType = Int32)], CommandType='"Text"', CommandTimeout='30']
+SELECT TOP(1) [p].[Id], [p].[Address], [p].[Avatar], [p].[CoverImage], [p].[CreatedAt], [p].[CreatedBy], [p].[DeletedAt], [p].[FullName], [p].[IsActive], [p].[LastModifiedAt], [p].[LastModifiedBy], [p].[UserId]
+FROM [profiles] AS [p]
+WHERE [p].[UserId] = @__targetUserId_0 AND [p].[IsActive] = CAST(1 AS bit) AND [p].[DeletedAt] IS NULL AND [p].[DeletedAt] IS NULL
+2025-09-29 03:54:30.857 +07:00 [DBG] Closing data reader to 'capbot_db' on server 'localhost'.
+2025-09-29 03:54:30.858 +07:00 [DBG] A data reader for 'capbot_db' on server 'localhost' is being disposed after spending 0ms reading results.
+2025-09-29 03:54:30.858 +07:00 [DBG] Closing connection to database 'capbot_db' on server 'localhost'.
+2025-09-29 03:54:30.858 +07:00 [DBG] Closed connection to database 'capbot_db' on server 'localhost' (0ms).
+2025-09-29 03:54:30.858 +07:00 [DBG] List of registered output formatters, in the following order: ["Microsoft.AspNetCore.OData.Formatter.ODataOutputFormatter","Microsoft.AspNetCore.OData.Formatter.ODataOutputFormatter","Microsoft.AspNetCore.OData.Formatter.ODataOutputFormatter","Microsoft.AspNetCore.Mvc.Formatters.HttpNoContentOutputFormatter","Microsoft.AspNetCore.Mvc.Formatters.StringOutputFormatter","Microsoft.AspNetCore.Mvc.Formatters.StreamOutputFormatter","Microsoft.AspNetCore.Mvc.Formatters.SystemTextJsonOutputFormatter"]
+2025-09-29 03:54:30.863 +07:00 [DBG] No information found on request to perform content negotiation.
+2025-09-29 03:54:30.863 +07:00 [DBG] Attempting to select an output formatter without using a content type as no explicit content types were specified for the response.
+2025-09-29 03:54:30.863 +07:00 [DBG] Attempting to select the first formatter in the output formatters list which can write the result.
+2025-09-29 03:54:30.863 +07:00 [DBG] Selected output formatter 'Microsoft.AspNetCore.Mvc.Formatters.SystemTextJsonOutputFormatter' and content type 'application/json' to write the response.
+2025-09-29 03:54:30.863 +07:00 [INF] Executing ObjectResult, writing value of type 'FS.Commons.FSResponse'.
+2025-09-29 03:54:30.863 +07:00 [INF] Executed action CapBot.api.Controllers.UserProfileController.GetMyProfile (CapBot.api) in 35.8751ms
+2025-09-29 03:54:30.864 +07:00 [INF] Executed endpoint 'CapBot.api.Controllers.UserProfileController.GetMyProfile (CapBot.api)'
+2025-09-29 03:54:30.864 +07:00 [DBG] Connection id "0HNFUQ4FJ9UML" completed keep alive response.
+2025-09-29 03:54:30.864 +07:00 [DBG] 'MyDbContext' disposed.
+2025-09-29 03:54:30.865 +07:00 [DBG] Disposing connection to database 'capbot_db' on server 'localhost'.
+2025-09-29 03:54:30.865 +07:00 [DBG] Disposed connection to database '' on server '' (0ms).
+2025-09-29 03:54:30.866 +07:00 [INF] Request finished HTTP/1.1 GET http://localhost:5207/api/user-profiles/me - 200 null application/json; charset=utf-8 39.8956ms
+2025-09-29 03:54:30.867 +07:00 [INF] Executed DbCommand (12ms) [Parameters=[], CommandType='"Text"', CommandTimeout='30']
+SELECT COUNT(*)
+FROM [submissions] AS [s]
+2025-09-29 03:54:30.867 +07:00 [DBG] Closing data reader to 'capbot_db' on server 'localhost'.
+2025-09-29 03:54:30.867 +07:00 [DBG] A data reader for 'capbot_db' on server 'localhost' is being disposed after spending 0ms reading results.
+2025-09-29 03:54:30.867 +07:00 [DBG] Closing connection to database 'capbot_db' on server 'localhost'.
+2025-09-29 03:54:30.867 +07:00 [DBG] Closed connection to database 'capbot_db' on server 'localhost' (0ms).
+2025-09-29 03:54:30.869 +07:00 [DBG] Opening connection to database 'capbot_db' on server 'localhost'.
+2025-09-29 03:54:30.870 +07:00 [DBG] Opened connection to database 'capbot_db' on server 'localhost'.
+2025-09-29 03:54:30.870 +07:00 [DBG] Creating DbCommand for 'ExecuteReader'.
+2025-09-29 03:54:30.870 +07:00 [DBG] Created DbCommand for 'ExecuteReader' (0ms).
+2025-09-29 03:54:30.871 +07:00 [DBG] Initialized DbCommand for 'ExecuteReader' (0ms).
+2025-09-29 03:54:30.871 +07:00 [DBG] Executing DbCommand [Parameters=[@__p_0='?' (DbType = Int32), @__p_1='?' (DbType = Int32)], CommandType='"Text"', CommandTimeout='30']
+SELECT [t].[Id], [t].[AdditionalNotes], [t].[AiCheckDetails], [t].[AiCheckScore], [t].[AiCheckStatus], [t].[CreatedAt], [t].[CreatedBy], [t].[DeletedAt], [t].[DocumentUrl], [t].[IsActive], [t].[LastModifiedAt], [t].[LastModifiedBy], [t].[PhaseId], [t].[Status], [t].[SubmissionRound], [t].[SubmittedAt], [t].[SubmittedBy], [t].[TopicId], [t].[TopicVersionId], [u].[Id], [u].[AccessFailedCount], [u].[ConcurrencyStamp], [u].[CreatedAt], [u].[DeletedAt], [u].[Email], [u].[EmailConfirmed], [u].[LastModifiedAt], [u].[LastModifiedBy], [u].[LockoutEnabled], [u].[LockoutEnd], [u].[NormalizedEmail], [u].[NormalizedUserName], [u].[PasswordHash], [u].[PhoneNumber], [u].[PhoneNumberConfirmed], [u].[SecurityStamp], [u].[TwoFactorEnabled], [u].[UserName], [t0].[Id], [t0].[Abbreviation], [t0].[CategoryId], [t0].[Content], [t0].[Context], [t0].[CreatedAt], [t0].[CreatedBy], [t0].[DeletedAt], [t0].[Description], [t0].[EN_Title], [t0].[IsActive], [t0].[IsApproved], [t0].[IsLegacy], [t0].[LastModifiedAt], [t0].[LastModifiedBy], [t0].[MaxStudents], [t0].[Objectives], [t0].[PotentialDuplicate], [t0].[Problem], [t0].[SemesterId], [t0].[SupervisorId], [t0].[VN_title]
+FROM (
+    SELECT [s].[Id], [s].[AdditionalNotes], [s].[AiCheckDetails], [s].[AiCheckScore], [s].[AiCheckStatus], [s].[CreatedAt], [s].[CreatedBy], [s].[DeletedAt], [s].[DocumentUrl], [s].[IsActive], [s].[LastModifiedAt], [s].[LastModifiedBy], [s].[PhaseId], [s].[Status], [s].[SubmissionRound], [s].[SubmittedAt], [s].[SubmittedBy], [s].[TopicId], [s].[TopicVersionId]
+    FROM [submissions] AS [s]
+    ORDER BY [s].[SubmittedAt] DESC
+    OFFSET @__p_0 ROWS FETCH NEXT @__p_1 ROWS ONLY
+) AS [t]
+INNER JOIN [users] AS [u] ON [t].[SubmittedBy] = [u].[Id]
+LEFT JOIN [topics] AS [t0] ON [t].[TopicId] = [t0].[Id]
+ORDER BY [t].[SubmittedAt] DESC
+2025-09-29 03:54:30.878 +07:00 [INF] Request starting HTTP/1.1 GET http://localhost:5207/images/entities/11111111.png - null null
+2025-09-29 03:54:30.879 +07:00 [DBG] The request path /images/entities/11111111.png does not match an existing file
+2025-09-29 03:54:30.880 +07:00 [DBG] The request path /images/entities/11111111.png does not match an existing file
+2025-09-29 03:54:30.880 +07:00 [DBG] No candidates found for the request path '/images/entities/11111111.png'
+2025-09-29 03:54:30.880 +07:00 [DBG] Request did not match any endpoints
+2025-09-29 03:54:30.880 +07:00 [DBG] AuthenticationScheme: Bearer was not authenticated.
+2025-09-29 03:54:30.880 +07:00 [DBG] Connection id "0HNFUQ4FJ9UMI" completed keep alive response.
+2025-09-29 03:54:30.881 +07:00 [INF] Request finished HTTP/1.1 GET http://localhost:5207/images/entities/11111111.png - 404 0 null 3.55ms
+2025-09-29 03:54:30.881 +07:00 [INF] Request reached the end of the middleware pipeline without being handled by application code. Request path: GET http://localhost:5207/images/entities/11111111.png, Response status code: 404
+2025-09-29 03:54:30.897 +07:00 [INF] Executed DbCommand (26ms) [Parameters=[@__p_0='?' (DbType = Int32), @__p_1='?' (DbType = Int32)], CommandType='"Text"', CommandTimeout='30']
+SELECT [t].[Id], [t].[AdditionalNotes], [t].[AiCheckDetails], [t].[AiCheckScore], [t].[AiCheckStatus], [t].[CreatedAt], [t].[CreatedBy], [t].[DeletedAt], [t].[DocumentUrl], [t].[IsActive], [t].[LastModifiedAt], [t].[LastModifiedBy], [t].[PhaseId], [t].[Status], [t].[SubmissionRound], [t].[SubmittedAt], [t].[SubmittedBy], [t].[TopicId], [t].[TopicVersionId], [u].[Id], [u].[AccessFailedCount], [u].[ConcurrencyStamp], [u].[CreatedAt], [u].[DeletedAt], [u].[Email], [u].[EmailConfirmed], [u].[LastModifiedAt], [u].[LastModifiedBy], [u].[LockoutEnabled], [u].[LockoutEnd], [u].[NormalizedEmail], [u].[NormalizedUserName], [u].[PasswordHash], [u].[PhoneNumber], [u].[PhoneNumberConfirmed], [u].[SecurityStamp], [u].[TwoFactorEnabled], [u].[UserName], [t0].[Id], [t0].[Abbreviation], [t0].[CategoryId], [t0].[Content], [t0].[Context], [t0].[CreatedAt], [t0].[CreatedBy], [t0].[DeletedAt], [t0].[Description], [t0].[EN_Title], [t0].[IsActive], [t0].[IsApproved], [t0].[IsLegacy], [t0].[LastModifiedAt], [t0].[LastModifiedBy], [t0].[MaxStudents], [t0].[Objectives], [t0].[PotentialDuplicate], [t0].[Problem], [t0].[SemesterId], [t0].[SupervisorId], [t0].[VN_title]
+FROM (
+    SELECT [s].[Id], [s].[AdditionalNotes], [s].[AiCheckDetails], [s].[AiCheckScore], [s].[AiCheckStatus], [s].[CreatedAt], [s].[CreatedBy], [s].[DeletedAt], [s].[DocumentUrl], [s].[IsActive], [s].[LastModifiedAt], [s].[LastModifiedBy], [s].[PhaseId], [s].[Status], [s].[SubmissionRound], [s].[SubmittedAt], [s].[SubmittedBy], [s].[TopicId], [s].[TopicVersionId]
+    FROM [submissions] AS [s]
+    ORDER BY [s].[SubmittedAt] DESC
+    OFFSET @__p_0 ROWS FETCH NEXT @__p_1 ROWS ONLY
+) AS [t]
+INNER JOIN [users] AS [u] ON [t].[SubmittedBy] = [u].[Id]
+LEFT JOIN [topics] AS [t0] ON [t].[TopicId] = [t0].[Id]
+ORDER BY [t].[SubmittedAt] DESC
+2025-09-29 03:54:30.897 +07:00 [DBG] Closing data reader to 'capbot_db' on server 'localhost'.
+2025-09-29 03:54:30.897 +07:00 [DBG] A data reader for 'capbot_db' on server 'localhost' is being disposed after spending 0ms reading results.
+2025-09-29 03:54:30.897 +07:00 [DBG] Closing connection to database 'capbot_db' on server 'localhost'.
+2025-09-29 03:54:30.897 +07:00 [DBG] Closed connection to database 'capbot_db' on server 'localhost' (0ms).
+2025-09-29 03:54:30.897 +07:00 [DBG] List of registered output formatters, in the following order: ["Microsoft.AspNetCore.OData.Formatter.ODataOutputFormatter","Microsoft.AspNetCore.OData.Formatter.ODataOutputFormatter","Microsoft.AspNetCore.OData.Formatter.ODataOutputFormatter","Microsoft.AspNetCore.Mvc.Formatters.HttpNoContentOutputFormatter","Microsoft.AspNetCore.Mvc.Formatters.StringOutputFormatter","Microsoft.AspNetCore.Mvc.Formatters.StreamOutputFormatter","Microsoft.AspNetCore.Mvc.Formatters.SystemTextJsonOutputFormatter"]
+2025-09-29 03:54:30.898 +07:00 [DBG] No information found on request to perform content negotiation.
+2025-09-29 03:54:30.898 +07:00 [DBG] Attempting to select the first output formatter in the output formatters list which supports a content type from the explicitly specified content types '["application/json"]'.
+2025-09-29 03:54:30.898 +07:00 [DBG] Selected output formatter 'Microsoft.AspNetCore.Mvc.Formatters.SystemTextJsonOutputFormatter' and content type 'application/json' to write the response.
+2025-09-29 03:54:30.898 +07:00 [INF] Executing ObjectResult, writing value of type 'FS.Commons.FSResponse'.
+2025-09-29 03:54:30.898 +07:00 [INF] Executed action CapBot.api.Controllers.SubmissionController.List (CapBot.api) in 70.9659ms
+2025-09-29 03:54:30.898 +07:00 [INF] Executed endpoint 'CapBot.api.Controllers.SubmissionController.List (CapBot.api)'
+2025-09-29 03:54:30.898 +07:00 [DBG] Connection id "0HNFUQ4FJ9UMK" completed keep alive response.
+2025-09-29 03:54:30.899 +07:00 [DBG] 'MyDbContext' disposed.
+2025-09-29 03:54:30.899 +07:00 [DBG] Disposing connection to database 'capbot_db' on server 'localhost'.
+2025-09-29 03:54:30.899 +07:00 [DBG] Disposed connection to database '' on server '' (0ms).
+2025-09-29 03:54:30.899 +07:00 [INF] Request finished HTTP/1.1 GET http://localhost:5207/api/submission/list?PageNumber=1&PageSize=10 - 200 null application/json; charset=utf-8 73.2125ms
+2025-09-29 03:54:33.333 +07:00 [INF] Request starting HTTP/1.1 GET http://localhost:5207/api/submission/list?PageNumber=1&PageSize=10 - null null
+2025-09-29 03:54:33.333 +07:00 [DBG] The request path /api/submission/list does not match a supported file type
+2025-09-29 03:54:33.333 +07:00 [INF] Request starting HTTP/1.1 GET http://localhost:5207/api/user-profiles/me - null null
+2025-09-29 03:54:33.333 +07:00 [DBG] The request path /api/submission/list does not match a supported file type
+2025-09-29 03:54:33.333 +07:00 [DBG] The request has an origin header: 'http://localhost:3000'.
+2025-09-29 03:54:33.333 +07:00 [INF] CORS policy execution successful.
+2025-09-29 03:54:33.333 +07:00 [DBG] The request path /api/user-profiles/me does not match a supported file type
+2025-09-29 03:54:33.333 +07:00 [DBG] The request path /api/user-profiles/me does not match a supported file type
+2025-09-29 03:54:33.333 +07:00 [DBG] 1 candidate(s) found for the request path '/api/submission/list'
+2025-09-29 03:54:33.333 +07:00 [DBG] The request has an origin header: 'http://localhost:3000'.
+2025-09-29 03:54:33.334 +07:00 [DBG] Endpoint 'CapBot.api.Controllers.SubmissionController.List (CapBot.api)' with route pattern 'api/submission/list' is valid for the request path '/api/submission/list'
+2025-09-29 03:54:33.334 +07:00 [INF] CORS policy execution successful.
+2025-09-29 03:54:33.334 +07:00 [DBG] Request matched endpoint 'CapBot.api.Controllers.SubmissionController.List (CapBot.api)'
+2025-09-29 03:54:33.334 +07:00 [DBG] 2 candidate(s) found for the request path '/api/user-profiles/me'
+2025-09-29 03:54:33.334 +07:00 [DBG] Endpoint 'CapBot.api.Controllers.UserProfileController.GetMyProfile (CapBot.api)' with route pattern 'api/user-profiles/me' is valid for the request path '/api/user-profiles/me'
+2025-09-29 03:54:33.334 +07:00 [DBG] Endpoint 'CapBot.api.Controllers.UserProfileController.GetById (CapBot.api)' with route pattern 'api/user-profiles/{id}' is valid for the request path '/api/user-profiles/me'
+2025-09-29 03:54:33.334 +07:00 [DBG] Request matched endpoint 'CapBot.api.Controllers.UserProfileController.GetMyProfile (CapBot.api)'
+2025-09-29 03:54:33.336 +07:00 [DBG] Successfully validated the token.
+2025-09-29 03:54:33.336 +07:00 [DBG] AuthenticationScheme: Bearer was successfully authenticated.
+2025-09-29 03:54:33.337 +07:00 [DBG] Successfully validated the token.
+2025-09-29 03:54:33.337 +07:00 [DBG] AuthenticationScheme: Bearer was successfully authenticated.
+2025-09-29 03:54:33.337 +07:00 [DBG] Authorization was successful.
+2025-09-29 03:54:33.337 +07:00 [INF] Executing endpoint 'CapBot.api.Controllers.UserProfileController.GetMyProfile (CapBot.api)'
+2025-09-29 03:54:33.337 +07:00 [DBG] Authorization was successful.
+2025-09-29 03:54:33.337 +07:00 [INF] Route matched with {action = "GetMyProfile", controller = "UserProfile"}. Executing controller action with signature System.Threading.Tasks.Task`1[Microsoft.AspNetCore.Mvc.IActionResult] GetMyProfile() on controller CapBot.api.Controllers.UserProfileController (CapBot.api).
+2025-09-29 03:54:33.338 +07:00 [INF] Executing endpoint 'CapBot.api.Controllers.SubmissionController.List (CapBot.api)'
+2025-09-29 03:54:33.338 +07:00 [DBG] Execution plan of authorization filters (in the following order): ["None"]
+2025-09-29 03:54:33.338 +07:00 [DBG] Execution plan of resource filters (in the following order): ["None"]
+2025-09-29 03:54:33.338 +07:00 [INF] Route matched with {action = "List", controller = "Submission"}. Executing controller action with signature System.Threading.Tasks.Task`1[Microsoft.AspNetCore.Mvc.IActionResult] List(App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO) on controller CapBot.api.Controllers.SubmissionController (CapBot.api).
+2025-09-29 03:54:33.338 +07:00 [DBG] Execution plan of action filters (in the following order): ["Microsoft.AspNetCore.Mvc.ModelBinding.UnsupportedContentTypeFilter (Order: -3000)"]
+2025-09-29 03:54:33.338 +07:00 [DBG] Execution plan of authorization filters (in the following order): ["None"]
+2025-09-29 03:54:33.338 +07:00 [DBG] Execution plan of exception filters (in the following order): ["None"]
+2025-09-29 03:54:33.338 +07:00 [DBG] Execution plan of resource filters (in the following order): ["None"]
+2025-09-29 03:54:33.338 +07:00 [DBG] Execution plan of result filters (in the following order): ["Microsoft.AspNetCore.Mvc.Infrastructure.ClientErrorResultFilter (Order: -2000)"]
+2025-09-29 03:54:33.338 +07:00 [DBG] Execution plan of action filters (in the following order): ["Microsoft.AspNetCore.Mvc.ModelBinding.UnsupportedContentTypeFilter (Order: -3000)"]
+2025-09-29 03:54:33.338 +07:00 [DBG] Execution plan of exception filters (in the following order): ["None"]
+2025-09-29 03:54:33.338 +07:00 [DBG] Executing controller factory for controller CapBot.api.Controllers.UserProfileController (CapBot.api)
+2025-09-29 03:54:33.338 +07:00 [DBG] Execution plan of result filters (in the following order): ["Microsoft.AspNetCore.Mvc.Infrastructure.ClientErrorResultFilter (Order: -2000)","Microsoft.AspNetCore.Mvc.ProducesAttribute (Order: 0)"]
+2025-09-29 03:54:33.338 +07:00 [DBG] Executing controller factory for controller CapBot.api.Controllers.SubmissionController (CapBot.api)
+2025-09-29 03:54:33.339 +07:00 [DBG] Executed controller factory for controller CapBot.api.Controllers.UserProfileController (CapBot.api)
+2025-09-29 03:54:33.339 +07:00 [DBG] Executed controller factory for controller CapBot.api.Controllers.SubmissionController (CapBot.api)
+2025-09-29 03:54:33.339 +07:00 [DBG] Attempting to bind parameter 'query' of type 'App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO' ...
+2025-09-29 03:54:33.340 +07:00 [DBG] Attempting to bind parameter 'query' of type 'App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO' using the name '' in request data ...
+2025-09-29 03:54:33.340 +07:00 [DBG] Attempting to bind property 'App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO.TopicVersionId' of type 'System.Nullable`1[System.Int32]' using the name 'TopicVersionId' in request data ...
+2025-09-29 03:54:33.340 +07:00 [DBG] Could not find a value in the request with name 'TopicVersionId' for binding property 'App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO.TopicVersionId' of type 'System.Nullable`1[System.Int32]'.
+2025-09-29 03:54:33.341 +07:00 [DBG] Done attempting to bind property 'App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO.TopicVersionId' of type 'System.Nullable`1[System.Int32]'.
+2025-09-29 03:54:33.340 +07:00 [DBG] Entity Framework Core 8.0.16 initialized 'MyDbContext' using provider 'Microsoft.EntityFrameworkCore.SqlServer:8.0.13' with options: MigrationsAssembly=App.DAL 
+2025-09-29 03:54:33.341 +07:00 [DBG] Attempting to bind property 'App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO.PhaseId' of type 'System.Nullable`1[System.Int32]' using the name 'PhaseId' in request data ...
+2025-09-29 03:54:33.341 +07:00 [DBG] Could not find a value in the request with name 'PhaseId' for binding property 'App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO.PhaseId' of type 'System.Nullable`1[System.Int32]'.
+2025-09-29 03:54:33.342 +07:00 [DBG] Done attempting to bind property 'App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO.PhaseId' of type 'System.Nullable`1[System.Int32]'.
+2025-09-29 03:54:33.342 +07:00 [DBG] Attempting to bind property 'App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO.SemesterId' of type 'System.Nullable`1[System.Int32]' using the name 'SemesterId' in request data ...
+2025-09-29 03:54:33.343 +07:00 [DBG] Creating DbConnection.
+2025-09-29 03:54:33.344 +07:00 [DBG] Could not find a value in the request with name 'SemesterId' for binding property 'App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO.SemesterId' of type 'System.Nullable`1[System.Int32]'.
+2025-09-29 03:54:33.344 +07:00 [DBG] Created DbConnection. (0ms).
+2025-09-29 03:54:33.344 +07:00 [DBG] Done attempting to bind property 'App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO.SemesterId' of type 'System.Nullable`1[System.Int32]'.
+2025-09-29 03:54:33.344 +07:00 [DBG] Opening connection to database 'capbot_db' on server 'localhost'.
+2025-09-29 03:54:33.344 +07:00 [DBG] Attempting to bind property 'App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO.Status' of type 'System.Nullable`1[App.Entities.Enums.SubmissionStatus]' using the name 'Status' in request data ...
+2025-09-29 03:54:33.344 +07:00 [DBG] Could not find a value in the request with name 'Status' for binding property 'App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO.Status' of type 'System.Nullable`1[App.Entities.Enums.SubmissionStatus]'.
+2025-09-29 03:54:33.344 +07:00 [DBG] Opened connection to database 'capbot_db' on server 'localhost'.
+2025-09-29 03:54:33.344 +07:00 [DBG] Done attempting to bind property 'App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO.Status' of type 'System.Nullable`1[App.Entities.Enums.SubmissionStatus]'.
+2025-09-29 03:54:33.344 +07:00 [DBG] Creating DbCommand for 'ExecuteReader'.
+2025-09-29 03:54:33.344 +07:00 [DBG] Attempting to bind property 'App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO.PageNumber' of type 'System.Int32' using the name 'PageNumber' in request data ...
+2025-09-29 03:54:33.344 +07:00 [DBG] Created DbCommand for 'ExecuteReader' (0ms).
+2025-09-29 03:54:33.344 +07:00 [DBG] Done attempting to bind property 'App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO.PageNumber' of type 'System.Int32'.
+2025-09-29 03:54:33.344 +07:00 [DBG] Initialized DbCommand for 'ExecuteReader' (0ms).
+2025-09-29 03:54:33.344 +07:00 [DBG] Attempting to bind property 'App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO.PageSize' of type 'System.Int32' using the name 'PageSize' in request data ...
+2025-09-29 03:54:33.344 +07:00 [DBG] Executing DbCommand [Parameters=[@__targetUserId_0='?' (DbType = Int32)], CommandType='"Text"', CommandTimeout='30']
+SELECT TOP(1) [p].[Id], [p].[Address], [p].[Avatar], [p].[CoverImage], [p].[CreatedAt], [p].[CreatedBy], [p].[DeletedAt], [p].[FullName], [p].[IsActive], [p].[LastModifiedAt], [p].[LastModifiedBy], [p].[UserId]
+FROM [profiles] AS [p]
+WHERE [p].[UserId] = @__targetUserId_0 AND [p].[IsActive] = CAST(1 AS bit) AND [p].[DeletedAt] IS NULL AND [p].[DeletedAt] IS NULL
+2025-09-29 03:54:33.345 +07:00 [DBG] Done attempting to bind property 'App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO.PageSize' of type 'System.Int32'.
+2025-09-29 03:54:33.345 +07:00 [DBG] Attempting to bind property 'App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO.Keyword' of type 'System.String' using the name 'Keyword' in request data ...
+2025-09-29 03:54:33.345 +07:00 [DBG] Could not find a value in the request with name 'Keyword' for binding property 'App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO.Keyword' of type 'System.String'.
+2025-09-29 03:54:33.345 +07:00 [DBG] Done attempting to bind property 'App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO.Keyword' of type 'System.String'.
+2025-09-29 03:54:33.345 +07:00 [DBG] Attempting to bind property 'App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO.TotalRecord' of type 'System.Int32' using the name 'TotalRecord' in request data ...
+2025-09-29 03:54:33.345 +07:00 [DBG] Could not find a value in the request with name 'TotalRecord' for binding property 'App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO.TotalRecord' of type 'System.Int32'.
+2025-09-29 03:54:33.345 +07:00 [DBG] Done attempting to bind property 'App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO.TotalRecord' of type 'System.Int32'.
+2025-09-29 03:54:33.346 +07:00 [DBG] Done attempting to bind parameter 'query' of type 'App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO'.
+2025-09-29 03:54:33.346 +07:00 [DBG] Done attempting to bind parameter 'query' of type 'App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO'.
+2025-09-29 03:54:33.346 +07:00 [DBG] Attempting to validate the bound parameter 'query' of type 'App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO' ...
+2025-09-29 03:54:33.346 +07:00 [DBG] Done attempting to validate the bound parameter 'query' of type 'App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO'.
+2025-09-29 03:54:33.346 +07:00 [DBG] Entity Framework Core 8.0.16 initialized 'MyDbContext' using provider 'Microsoft.EntityFrameworkCore.SqlServer:8.0.13' with options: MigrationsAssembly=App.DAL 
+2025-09-29 03:54:33.347 +07:00 [DBG] Creating DbConnection.
+2025-09-29 03:54:33.347 +07:00 [DBG] Created DbConnection. (0ms).
+2025-09-29 03:54:33.347 +07:00 [DBG] Opening connection to database 'capbot_db' on server 'localhost'.
+2025-09-29 03:54:33.347 +07:00 [DBG] Opened connection to database 'capbot_db' on server 'localhost'.
+2025-09-29 03:54:33.347 +07:00 [DBG] Creating DbCommand for 'ExecuteReader'.
+2025-09-29 03:54:33.347 +07:00 [DBG] Created DbCommand for 'ExecuteReader' (0ms).
+2025-09-29 03:54:33.347 +07:00 [DBG] Initialized DbCommand for 'ExecuteReader' (0ms).
+2025-09-29 03:54:33.347 +07:00 [DBG] Executing DbCommand [Parameters=[], CommandType='"Text"', CommandTimeout='30']
+SELECT COUNT(*)
+FROM [submissions] AS [s]
+2025-09-29 03:54:33.355 +07:00 [INF] Executed DbCommand (8ms) [Parameters=[], CommandType='"Text"', CommandTimeout='30']
+SELECT COUNT(*)
+FROM [submissions] AS [s]
+2025-09-29 03:54:33.356 +07:00 [DBG] Closing data reader to 'capbot_db' on server 'localhost'.
+2025-09-29 03:54:33.356 +07:00 [DBG] A data reader for 'capbot_db' on server 'localhost' is being disposed after spending 0ms reading results.
+2025-09-29 03:54:33.356 +07:00 [DBG] Closing connection to database 'capbot_db' on server 'localhost'.
+2025-09-29 03:54:33.359 +07:00 [DBG] Closed connection to database 'capbot_db' on server 'localhost' (2ms).
+2025-09-29 03:54:33.359 +07:00 [INF] Executed DbCommand (14ms) [Parameters=[@__targetUserId_0='?' (DbType = Int32)], CommandType='"Text"', CommandTimeout='30']
+SELECT TOP(1) [p].[Id], [p].[Address], [p].[Avatar], [p].[CoverImage], [p].[CreatedAt], [p].[CreatedBy], [p].[DeletedAt], [p].[FullName], [p].[IsActive], [p].[LastModifiedAt], [p].[LastModifiedBy], [p].[UserId]
+FROM [profiles] AS [p]
+WHERE [p].[UserId] = @__targetUserId_0 AND [p].[IsActive] = CAST(1 AS bit) AND [p].[DeletedAt] IS NULL AND [p].[DeletedAt] IS NULL
+2025-09-29 03:54:33.359 +07:00 [DBG] Closing data reader to 'capbot_db' on server 'localhost'.
+2025-09-29 03:54:33.360 +07:00 [DBG] A data reader for 'capbot_db' on server 'localhost' is being disposed after spending 0ms reading results.
+2025-09-29 03:54:33.360 +07:00 [DBG] Closing connection to database 'capbot_db' on server 'localhost'.
+2025-09-29 03:54:33.360 +07:00 [DBG] Closed connection to database 'capbot_db' on server 'localhost' (0ms).
+2025-09-29 03:54:33.360 +07:00 [DBG] List of registered output formatters, in the following order: ["Microsoft.AspNetCore.OData.Formatter.ODataOutputFormatter","Microsoft.AspNetCore.OData.Formatter.ODataOutputFormatter","Microsoft.AspNetCore.OData.Formatter.ODataOutputFormatter","Microsoft.AspNetCore.Mvc.Formatters.HttpNoContentOutputFormatter","Microsoft.AspNetCore.Mvc.Formatters.StringOutputFormatter","Microsoft.AspNetCore.Mvc.Formatters.StreamOutputFormatter","Microsoft.AspNetCore.Mvc.Formatters.SystemTextJsonOutputFormatter"]
+2025-09-29 03:54:33.361 +07:00 [DBG] No information found on request to perform content negotiation.
+2025-09-29 03:54:33.361 +07:00 [DBG] Opening connection to database 'capbot_db' on server 'localhost'.
+2025-09-29 03:54:33.361 +07:00 [DBG] Attempting to select an output formatter without using a content type as no explicit content types were specified for the response.
+2025-09-29 03:54:33.361 +07:00 [DBG] Attempting to select the first formatter in the output formatters list which can write the result.
+2025-09-29 03:54:33.361 +07:00 [DBG] Opened connection to database 'capbot_db' on server 'localhost'.
+2025-09-29 03:54:33.361 +07:00 [DBG] Creating DbCommand for 'ExecuteReader'.
+2025-09-29 03:54:33.361 +07:00 [DBG] Created DbCommand for 'ExecuteReader' (0ms).
+2025-09-29 03:54:33.361 +07:00 [DBG] Selected output formatter 'Microsoft.AspNetCore.Mvc.Formatters.SystemTextJsonOutputFormatter' and content type 'application/json' to write the response.
+2025-09-29 03:54:33.362 +07:00 [DBG] Initialized DbCommand for 'ExecuteReader' (0ms).
+2025-09-29 03:54:33.362 +07:00 [DBG] Executing DbCommand [Parameters=[@__p_0='?' (DbType = Int32), @__p_1='?' (DbType = Int32)], CommandType='"Text"', CommandTimeout='30']
+SELECT [t].[Id], [t].[AdditionalNotes], [t].[AiCheckDetails], [t].[AiCheckScore], [t].[AiCheckStatus], [t].[CreatedAt], [t].[CreatedBy], [t].[DeletedAt], [t].[DocumentUrl], [t].[IsActive], [t].[LastModifiedAt], [t].[LastModifiedBy], [t].[PhaseId], [t].[Status], [t].[SubmissionRound], [t].[SubmittedAt], [t].[SubmittedBy], [t].[TopicId], [t].[TopicVersionId], [u].[Id], [u].[AccessFailedCount], [u].[ConcurrencyStamp], [u].[CreatedAt], [u].[DeletedAt], [u].[Email], [u].[EmailConfirmed], [u].[LastModifiedAt], [u].[LastModifiedBy], [u].[LockoutEnabled], [u].[LockoutEnd], [u].[NormalizedEmail], [u].[NormalizedUserName], [u].[PasswordHash], [u].[PhoneNumber], [u].[PhoneNumberConfirmed], [u].[SecurityStamp], [u].[TwoFactorEnabled], [u].[UserName], [t0].[Id], [t0].[Abbreviation], [t0].[CategoryId], [t0].[Content], [t0].[Context], [t0].[CreatedAt], [t0].[CreatedBy], [t0].[DeletedAt], [t0].[Description], [t0].[EN_Title], [t0].[IsActive], [t0].[IsApproved], [t0].[IsLegacy], [t0].[LastModifiedAt], [t0].[LastModifiedBy], [t0].[MaxStudents], [t0].[Objectives], [t0].[PotentialDuplicate], [t0].[Problem], [t0].[SemesterId], [t0].[SupervisorId], [t0].[VN_title]
+FROM (
+    SELECT [s].[Id], [s].[AdditionalNotes], [s].[AiCheckDetails], [s].[AiCheckScore], [s].[AiCheckStatus], [s].[CreatedAt], [s].[CreatedBy], [s].[DeletedAt], [s].[DocumentUrl], [s].[IsActive], [s].[LastModifiedAt], [s].[LastModifiedBy], [s].[PhaseId], [s].[Status], [s].[SubmissionRound], [s].[SubmittedAt], [s].[SubmittedBy], [s].[TopicId], [s].[TopicVersionId]
+    FROM [submissions] AS [s]
+    ORDER BY [s].[SubmittedAt] DESC
+    OFFSET @__p_0 ROWS FETCH NEXT @__p_1 ROWS ONLY
+) AS [t]
+INNER JOIN [users] AS [u] ON [t].[SubmittedBy] = [u].[Id]
+LEFT JOIN [topics] AS [t0] ON [t].[TopicId] = [t0].[Id]
+ORDER BY [t].[SubmittedAt] DESC
+2025-09-29 03:54:33.362 +07:00 [INF] Executing ObjectResult, writing value of type 'FS.Commons.FSResponse'.
+2025-09-29 03:54:33.364 +07:00 [INF] Executed action CapBot.api.Controllers.UserProfileController.GetMyProfile (CapBot.api) in 26.0569ms
+2025-09-29 03:54:33.364 +07:00 [INF] Executed endpoint 'CapBot.api.Controllers.UserProfileController.GetMyProfile (CapBot.api)'
+2025-09-29 03:54:33.365 +07:00 [DBG] Connection id "0HNFUQ4FJ9UMK" completed keep alive response.
+2025-09-29 03:54:33.366 +07:00 [DBG] 'MyDbContext' disposed.
+2025-09-29 03:54:33.369 +07:00 [DBG] Disposing connection to database 'capbot_db' on server 'localhost'.
+2025-09-29 03:54:33.369 +07:00 [DBG] Disposed connection to database '' on server '' (0ms).
+2025-09-29 03:54:33.369 +07:00 [INF] Request finished HTTP/1.1 GET http://localhost:5207/api/user-profiles/me - 200 null application/json; charset=utf-8 35.8316ms
+2025-09-29 03:54:33.385 +07:00 [INF] Executed DbCommand (23ms) [Parameters=[@__p_0='?' (DbType = Int32), @__p_1='?' (DbType = Int32)], CommandType='"Text"', CommandTimeout='30']
+SELECT [t].[Id], [t].[AdditionalNotes], [t].[AiCheckDetails], [t].[AiCheckScore], [t].[AiCheckStatus], [t].[CreatedAt], [t].[CreatedBy], [t].[DeletedAt], [t].[DocumentUrl], [t].[IsActive], [t].[LastModifiedAt], [t].[LastModifiedBy], [t].[PhaseId], [t].[Status], [t].[SubmissionRound], [t].[SubmittedAt], [t].[SubmittedBy], [t].[TopicId], [t].[TopicVersionId], [u].[Id], [u].[AccessFailedCount], [u].[ConcurrencyStamp], [u].[CreatedAt], [u].[DeletedAt], [u].[Email], [u].[EmailConfirmed], [u].[LastModifiedAt], [u].[LastModifiedBy], [u].[LockoutEnabled], [u].[LockoutEnd], [u].[NormalizedEmail], [u].[NormalizedUserName], [u].[PasswordHash], [u].[PhoneNumber], [u].[PhoneNumberConfirmed], [u].[SecurityStamp], [u].[TwoFactorEnabled], [u].[UserName], [t0].[Id], [t0].[Abbreviation], [t0].[CategoryId], [t0].[Content], [t0].[Context], [t0].[CreatedAt], [t0].[CreatedBy], [t0].[DeletedAt], [t0].[Description], [t0].[EN_Title], [t0].[IsActive], [t0].[IsApproved], [t0].[IsLegacy], [t0].[LastModifiedAt], [t0].[LastModifiedBy], [t0].[MaxStudents], [t0].[Objectives], [t0].[PotentialDuplicate], [t0].[Problem], [t0].[SemesterId], [t0].[SupervisorId], [t0].[VN_title]
+FROM (
+    SELECT [s].[Id], [s].[AdditionalNotes], [s].[AiCheckDetails], [s].[AiCheckScore], [s].[AiCheckStatus], [s].[CreatedAt], [s].[CreatedBy], [s].[DeletedAt], [s].[DocumentUrl], [s].[IsActive], [s].[LastModifiedAt], [s].[LastModifiedBy], [s].[PhaseId], [s].[Status], [s].[SubmissionRound], [s].[SubmittedAt], [s].[SubmittedBy], [s].[TopicId], [s].[TopicVersionId]
+    FROM [submissions] AS [s]
+    ORDER BY [s].[SubmittedAt] DESC
+    OFFSET @__p_0 ROWS FETCH NEXT @__p_1 ROWS ONLY
+) AS [t]
+INNER JOIN [users] AS [u] ON [t].[SubmittedBy] = [u].[Id]
+LEFT JOIN [topics] AS [t0] ON [t].[TopicId] = [t0].[Id]
+ORDER BY [t].[SubmittedAt] DESC
+2025-09-29 03:54:33.386 +07:00 [DBG] Closing data reader to 'capbot_db' on server 'localhost'.
+2025-09-29 03:54:33.386 +07:00 [DBG] A data reader for 'capbot_db' on server 'localhost' is being disposed after spending 1ms reading results.
+2025-09-29 03:54:33.386 +07:00 [DBG] Closing connection to database 'capbot_db' on server 'localhost'.
+2025-09-29 03:54:33.387 +07:00 [DBG] Closed connection to database 'capbot_db' on server 'localhost' (0ms).
+2025-09-29 03:54:33.387 +07:00 [DBG] List of registered output formatters, in the following order: ["Microsoft.AspNetCore.OData.Formatter.ODataOutputFormatter","Microsoft.AspNetCore.OData.Formatter.ODataOutputFormatter","Microsoft.AspNetCore.OData.Formatter.ODataOutputFormatter","Microsoft.AspNetCore.Mvc.Formatters.HttpNoContentOutputFormatter","Microsoft.AspNetCore.Mvc.Formatters.StringOutputFormatter","Microsoft.AspNetCore.Mvc.Formatters.StreamOutputFormatter","Microsoft.AspNetCore.Mvc.Formatters.SystemTextJsonOutputFormatter"]
+2025-09-29 03:54:33.387 +07:00 [DBG] No information found on request to perform content negotiation.
+2025-09-29 03:54:33.387 +07:00 [DBG] Attempting to select the first output formatter in the output formatters list which supports a content type from the explicitly specified content types '["application/json"]'.
+2025-09-29 03:54:33.392 +07:00 [INF] Request starting HTTP/1.1 GET http://localhost:5207/images/entities/11111111.png - null null
+2025-09-29 03:54:33.393 +07:00 [DBG] The request path /images/entities/11111111.png does not match an existing file
+2025-09-29 03:54:33.393 +07:00 [DBG] Selected output formatter 'Microsoft.AspNetCore.Mvc.Formatters.SystemTextJsonOutputFormatter' and content type 'application/json' to write the response.
+2025-09-29 03:54:33.394 +07:00 [INF] Executing ObjectResult, writing value of type 'FS.Commons.FSResponse'.
+2025-09-29 03:54:33.394 +07:00 [DBG] The request path /images/entities/11111111.png does not match an existing file
+2025-09-29 03:54:33.394 +07:00 [DBG] No candidates found for the request path '/images/entities/11111111.png'
+2025-09-29 03:54:33.394 +07:00 [INF] Executed action CapBot.api.Controllers.SubmissionController.List (CapBot.api) in 56.1462ms
+2025-09-29 03:54:33.395 +07:00 [DBG] Request did not match any endpoints
+2025-09-29 03:54:33.395 +07:00 [INF] Executed endpoint 'CapBot.api.Controllers.SubmissionController.List (CapBot.api)'
+2025-09-29 03:54:33.395 +07:00 [DBG] Connection id "0HNFUQ4FJ9UML" completed keep alive response.
+2025-09-29 03:54:33.395 +07:00 [DBG] AuthenticationScheme: Bearer was not authenticated.
+2025-09-29 03:54:33.395 +07:00 [DBG] 'MyDbContext' disposed.
+2025-09-29 03:54:33.395 +07:00 [DBG] Disposing connection to database 'capbot_db' on server 'localhost'.
+2025-09-29 03:54:33.395 +07:00 [DBG] Connection id "0HNFUQ4FJ9UMI" completed keep alive response.
+2025-09-29 03:54:33.395 +07:00 [DBG] Disposed connection to database '' on server '' (0ms).
+2025-09-29 03:54:33.395 +07:00 [INF] Request finished HTTP/1.1 GET http://localhost:5207/images/entities/11111111.png - 404 0 null 3.5978ms
+2025-09-29 03:54:33.395 +07:00 [INF] Request finished HTTP/1.1 GET http://localhost:5207/api/submission/list?PageNumber=1&PageSize=10 - 200 null application/json; charset=utf-8 62.318ms
+2025-09-29 03:54:33.395 +07:00 [INF] Request reached the end of the middleware pipeline without being handled by application code. Request path: GET http://localhost:5207/images/entities/11111111.png, Response status code: 404
+2025-09-29 03:54:35.247 +07:00 [INF] Request starting HTTP/1.1 OPTIONS http://localhost:5207/api/user-profiles/me - null null
+2025-09-29 03:54:35.247 +07:00 [DBG] OPTIONS requests are not supported
+2025-09-29 03:54:35.247 +07:00 [DBG] OPTIONS requests are not supported
+2025-09-29 03:54:35.247 +07:00 [DBG] The request has an origin header: 'http://localhost:3000'.
+2025-09-29 03:54:35.247 +07:00 [INF] CORS policy execution successful.
+2025-09-29 03:54:35.247 +07:00 [DBG] The request is a preflight request.
+2025-09-29 03:54:35.247 +07:00 [DBG] Connection id "0HNFUQ4FJ9UML" completed keep alive response.
+2025-09-29 03:54:35.247 +07:00 [INF] Request finished HTTP/1.1 OPTIONS http://localhost:5207/api/user-profiles/me - 204 null null 0.4392ms
+2025-09-29 03:54:35.247 +07:00 [INF] Request starting HTTP/1.1 OPTIONS http://localhost:5207/api/submission/list?PageNumber=1&PageSize=10 - null null
+2025-09-29 03:54:35.247 +07:00 [DBG] OPTIONS requests are not supported
+2025-09-29 03:54:35.247 +07:00 [DBG] OPTIONS requests are not supported
+2025-09-29 03:54:35.247 +07:00 [DBG] The request has an origin header: 'http://localhost:3000'.
+2025-09-29 03:54:35.247 +07:00 [INF] CORS policy execution successful.
+2025-09-29 03:54:35.247 +07:00 [DBG] The request is a preflight request.
+2025-09-29 03:54:35.248 +07:00 [DBG] Connection id "0HNFUQ4FJ9UMK" completed keep alive response.
+2025-09-29 03:54:35.248 +07:00 [INF] Request finished HTTP/1.1 OPTIONS http://localhost:5207/api/submission/list?PageNumber=1&PageSize=10 - 204 null null 0.3764ms
+2025-09-29 03:54:35.250 +07:00 [INF] Request starting HTTP/1.1 GET http://localhost:5207/api/user-profiles/me - null null
+2025-09-29 03:54:35.250 +07:00 [INF] Request starting HTTP/1.1 GET http://localhost:5207/api/submission/list?PageNumber=1&PageSize=10 - null null
+2025-09-29 03:54:35.251 +07:00 [DBG] The request path /api/user-profiles/me does not match a supported file type
+2025-09-29 03:54:35.251 +07:00 [DBG] The request path /api/user-profiles/me does not match a supported file type
+2025-09-29 03:54:35.251 +07:00 [DBG] The request has an origin header: 'http://localhost:3000'.
+2025-09-29 03:54:35.251 +07:00 [DBG] The request path /api/submission/list does not match a supported file type
+2025-09-29 03:54:35.251 +07:00 [INF] CORS policy execution successful.
+2025-09-29 03:54:35.251 +07:00 [DBG] The request path /api/submission/list does not match a supported file type
+2025-09-29 03:54:35.251 +07:00 [DBG] 2 candidate(s) found for the request path '/api/user-profiles/me'
+2025-09-29 03:54:35.251 +07:00 [DBG] The request has an origin header: 'http://localhost:3000'.
+2025-09-29 03:54:35.251 +07:00 [DBG] Endpoint 'CapBot.api.Controllers.UserProfileController.GetMyProfile (CapBot.api)' with route pattern 'api/user-profiles/me' is valid for the request path '/api/user-profiles/me'
+2025-09-29 03:54:35.251 +07:00 [INF] CORS policy execution successful.
+2025-09-29 03:54:35.251 +07:00 [DBG] Endpoint 'CapBot.api.Controllers.UserProfileController.GetById (CapBot.api)' with route pattern 'api/user-profiles/{id}' is valid for the request path '/api/user-profiles/me'
+2025-09-29 03:54:35.251 +07:00 [DBG] Request matched endpoint 'CapBot.api.Controllers.UserProfileController.GetMyProfile (CapBot.api)'
+2025-09-29 03:54:35.251 +07:00 [DBG] 1 candidate(s) found for the request path '/api/submission/list'
+2025-09-29 03:54:35.251 +07:00 [DBG] Endpoint 'CapBot.api.Controllers.SubmissionController.List (CapBot.api)' with route pattern 'api/submission/list' is valid for the request path '/api/submission/list'
+2025-09-29 03:54:35.252 +07:00 [DBG] Request matched endpoint 'CapBot.api.Controllers.SubmissionController.List (CapBot.api)'
+2025-09-29 03:54:35.252 +07:00 [DBG] Successfully validated the token.
+2025-09-29 03:54:35.252 +07:00 [DBG] Successfully validated the token.
+2025-09-29 03:54:35.252 +07:00 [DBG] AuthenticationScheme: Bearer was successfully authenticated.
+2025-09-29 03:54:35.252 +07:00 [DBG] AuthenticationScheme: Bearer was successfully authenticated.
+2025-09-29 03:54:35.252 +07:00 [DBG] Authorization was successful.
+2025-09-29 03:54:35.253 +07:00 [INF] Executing endpoint 'CapBot.api.Controllers.SubmissionController.List (CapBot.api)'
+2025-09-29 03:54:35.253 +07:00 [INF] Route matched with {action = "List", controller = "Submission"}. Executing controller action with signature System.Threading.Tasks.Task`1[Microsoft.AspNetCore.Mvc.IActionResult] List(App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO) on controller CapBot.api.Controllers.SubmissionController (CapBot.api).
+2025-09-29 03:54:35.253 +07:00 [DBG] Authorization was successful.
+2025-09-29 03:54:35.253 +07:00 [DBG] Execution plan of authorization filters (in the following order): ["None"]
+2025-09-29 03:54:35.254 +07:00 [INF] Executing endpoint 'CapBot.api.Controllers.UserProfileController.GetMyProfile (CapBot.api)'
+2025-09-29 03:54:35.254 +07:00 [DBG] Execution plan of resource filters (in the following order): ["None"]
+2025-09-29 03:54:35.254 +07:00 [INF] Route matched with {action = "GetMyProfile", controller = "UserProfile"}. Executing controller action with signature System.Threading.Tasks.Task`1[Microsoft.AspNetCore.Mvc.IActionResult] GetMyProfile() on controller CapBot.api.Controllers.UserProfileController (CapBot.api).
+2025-09-29 03:54:35.255 +07:00 [DBG] Execution plan of authorization filters (in the following order): ["None"]
+2025-09-29 03:54:35.255 +07:00 [DBG] Execution plan of resource filters (in the following order): ["None"]
+2025-09-29 03:54:35.255 +07:00 [DBG] Execution plan of action filters (in the following order): ["Microsoft.AspNetCore.Mvc.ModelBinding.UnsupportedContentTypeFilter (Order: -3000)"]
+2025-09-29 03:54:35.255 +07:00 [DBG] Execution plan of action filters (in the following order): ["Microsoft.AspNetCore.Mvc.ModelBinding.UnsupportedContentTypeFilter (Order: -3000)"]
+2025-09-29 03:54:35.255 +07:00 [DBG] Execution plan of exception filters (in the following order): ["None"]
+2025-09-29 03:54:35.255 +07:00 [DBG] Execution plan of exception filters (in the following order): ["None"]
+2025-09-29 03:54:35.255 +07:00 [DBG] Execution plan of result filters (in the following order): ["Microsoft.AspNetCore.Mvc.Infrastructure.ClientErrorResultFilter (Order: -2000)"]
+2025-09-29 03:54:35.268 +07:00 [DBG] Executing controller factory for controller CapBot.api.Controllers.UserProfileController (CapBot.api)
+2025-09-29 03:54:35.255 +07:00 [DBG] Execution plan of result filters (in the following order): ["Microsoft.AspNetCore.Mvc.Infrastructure.ClientErrorResultFilter (Order: -2000)","Microsoft.AspNetCore.Mvc.ProducesAttribute (Order: 0)"]
+2025-09-29 03:54:35.268 +07:00 [DBG] Executing controller factory for controller CapBot.api.Controllers.SubmissionController (CapBot.api)
+2025-09-29 03:54:35.269 +07:00 [DBG] Executed controller factory for controller CapBot.api.Controllers.UserProfileController (CapBot.api)
+2025-09-29 03:54:35.269 +07:00 [DBG] Executed controller factory for controller CapBot.api.Controllers.SubmissionController (CapBot.api)
+2025-09-29 03:54:35.269 +07:00 [DBG] Attempting to bind parameter 'query' of type 'App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO' ...
+2025-09-29 03:54:35.269 +07:00 [DBG] Attempting to bind parameter 'query' of type 'App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO' using the name '' in request data ...
+2025-09-29 03:54:35.270 +07:00 [DBG] Entity Framework Core 8.0.16 initialized 'MyDbContext' using provider 'Microsoft.EntityFrameworkCore.SqlServer:8.0.13' with options: MigrationsAssembly=App.DAL 
+2025-09-29 03:54:35.275 +07:00 [DBG] Attempting to bind property 'App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO.TopicVersionId' of type 'System.Nullable`1[System.Int32]' using the name 'TopicVersionId' in request data ...
+2025-09-29 03:54:35.275 +07:00 [DBG] Could not find a value in the request with name 'TopicVersionId' for binding property 'App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO.TopicVersionId' of type 'System.Nullable`1[System.Int32]'.
+2025-09-29 03:54:35.275 +07:00 [DBG] Done attempting to bind property 'App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO.TopicVersionId' of type 'System.Nullable`1[System.Int32]'.
+2025-09-29 03:54:35.275 +07:00 [DBG] Attempting to bind property 'App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO.PhaseId' of type 'System.Nullable`1[System.Int32]' using the name 'PhaseId' in request data ...
+2025-09-29 03:54:35.275 +07:00 [DBG] Could not find a value in the request with name 'PhaseId' for binding property 'App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO.PhaseId' of type 'System.Nullable`1[System.Int32]'.
+2025-09-29 03:54:35.277 +07:00 [DBG] Done attempting to bind property 'App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO.PhaseId' of type 'System.Nullable`1[System.Int32]'.
+2025-09-29 03:54:35.277 +07:00 [DBG] Attempting to bind property 'App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO.SemesterId' of type 'System.Nullable`1[System.Int32]' using the name 'SemesterId' in request data ...
+2025-09-29 03:54:35.277 +07:00 [DBG] Could not find a value in the request with name 'SemesterId' for binding property 'App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO.SemesterId' of type 'System.Nullable`1[System.Int32]'.
+2025-09-29 03:54:35.277 +07:00 [DBG] Done attempting to bind property 'App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO.SemesterId' of type 'System.Nullable`1[System.Int32]'.
+2025-09-29 03:54:35.277 +07:00 [DBG] Attempting to bind property 'App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO.Status' of type 'System.Nullable`1[App.Entities.Enums.SubmissionStatus]' using the name 'Status' in request data ...
+2025-09-29 03:54:35.275 +07:00 [DBG] Creating DbConnection.
+2025-09-29 03:54:35.282 +07:00 [DBG] Could not find a value in the request with name 'Status' for binding property 'App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO.Status' of type 'System.Nullable`1[App.Entities.Enums.SubmissionStatus]'.
+2025-09-29 03:54:35.282 +07:00 [DBG] Created DbConnection. (6ms).
+2025-09-29 03:54:35.282 +07:00 [DBG] Done attempting to bind property 'App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO.Status' of type 'System.Nullable`1[App.Entities.Enums.SubmissionStatus]'.
+2025-09-29 03:54:35.282 +07:00 [DBG] Opening connection to database 'capbot_db' on server 'localhost'.
+2025-09-29 03:54:35.282 +07:00 [DBG] Attempting to bind property 'App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO.PageNumber' of type 'System.Int32' using the name 'PageNumber' in request data ...
+2025-09-29 03:54:35.282 +07:00 [DBG] Done attempting to bind property 'App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO.PageNumber' of type 'System.Int32'.
+2025-09-29 03:54:35.282 +07:00 [DBG] Opened connection to database 'capbot_db' on server 'localhost'.
+2025-09-29 03:54:35.282 +07:00 [DBG] Attempting to bind property 'App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO.PageSize' of type 'System.Int32' using the name 'PageSize' in request data ...
+2025-09-29 03:54:35.289 +07:00 [DBG] Creating DbCommand for 'ExecuteReader'.
+2025-09-29 03:54:35.289 +07:00 [DBG] Done attempting to bind property 'App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO.PageSize' of type 'System.Int32'.
+2025-09-29 03:54:35.289 +07:00 [DBG] Created DbCommand for 'ExecuteReader' (0ms).
+2025-09-29 03:54:35.289 +07:00 [DBG] Attempting to bind property 'App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO.Keyword' of type 'System.String' using the name 'Keyword' in request data ...
+2025-09-29 03:54:35.289 +07:00 [DBG] Could not find a value in the request with name 'Keyword' for binding property 'App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO.Keyword' of type 'System.String'.
+2025-09-29 03:54:35.289 +07:00 [DBG] Initialized DbCommand for 'ExecuteReader' (0ms).
+2025-09-29 03:54:35.289 +07:00 [DBG] Done attempting to bind property 'App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO.Keyword' of type 'System.String'.
+2025-09-29 03:54:35.289 +07:00 [DBG] Attempting to bind property 'App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO.TotalRecord' of type 'System.Int32' using the name 'TotalRecord' in request data ...
+2025-09-29 03:54:35.289 +07:00 [DBG] Executing DbCommand [Parameters=[@__targetUserId_0='?' (DbType = Int32)], CommandType='"Text"', CommandTimeout='30']
+SELECT TOP(1) [p].[Id], [p].[Address], [p].[Avatar], [p].[CoverImage], [p].[CreatedAt], [p].[CreatedBy], [p].[DeletedAt], [p].[FullName], [p].[IsActive], [p].[LastModifiedAt], [p].[LastModifiedBy], [p].[UserId]
+FROM [profiles] AS [p]
+WHERE [p].[UserId] = @__targetUserId_0 AND [p].[IsActive] = CAST(1 AS bit) AND [p].[DeletedAt] IS NULL AND [p].[DeletedAt] IS NULL
+2025-09-29 03:54:35.292 +07:00 [DBG] Could not find a value in the request with name 'TotalRecord' for binding property 'App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO.TotalRecord' of type 'System.Int32'.
+2025-09-29 03:54:35.292 +07:00 [DBG] Done attempting to bind property 'App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO.TotalRecord' of type 'System.Int32'.
+2025-09-29 03:54:35.292 +07:00 [DBG] Done attempting to bind parameter 'query' of type 'App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO'.
+2025-09-29 03:54:35.296 +07:00 [DBG] Done attempting to bind parameter 'query' of type 'App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO'.
+2025-09-29 03:54:35.296 +07:00 [DBG] Attempting to validate the bound parameter 'query' of type 'App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO' ...
+2025-09-29 03:54:35.296 +07:00 [DBG] Done attempting to validate the bound parameter 'query' of type 'App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO'.
+2025-09-29 03:54:35.297 +07:00 [DBG] Entity Framework Core 8.0.16 initialized 'MyDbContext' using provider 'Microsoft.EntityFrameworkCore.SqlServer:8.0.13' with options: MigrationsAssembly=App.DAL 
+2025-09-29 03:54:35.294 +07:00 [INF] Executed DbCommand (5ms) [Parameters=[@__targetUserId_0='?' (DbType = Int32)], CommandType='"Text"', CommandTimeout='30']
+SELECT TOP(1) [p].[Id], [p].[Address], [p].[Avatar], [p].[CoverImage], [p].[CreatedAt], [p].[CreatedBy], [p].[DeletedAt], [p].[FullName], [p].[IsActive], [p].[LastModifiedAt], [p].[LastModifiedBy], [p].[UserId]
+FROM [profiles] AS [p]
+WHERE [p].[UserId] = @__targetUserId_0 AND [p].[IsActive] = CAST(1 AS bit) AND [p].[DeletedAt] IS NULL AND [p].[DeletedAt] IS NULL
+2025-09-29 03:54:35.298 +07:00 [DBG] Creating DbConnection.
+2025-09-29 03:54:35.303 +07:00 [DBG] Closing data reader to 'capbot_db' on server 'localhost'.
+2025-09-29 03:54:35.304 +07:00 [DBG] Created DbConnection. (5ms).
+2025-09-29 03:54:35.304 +07:00 [DBG] A data reader for 'capbot_db' on server 'localhost' is being disposed after spending 0ms reading results.
+2025-09-29 03:54:35.304 +07:00 [DBG] Opening connection to database 'capbot_db' on server 'localhost'.
+2025-09-29 03:54:35.304 +07:00 [DBG] Closing connection to database 'capbot_db' on server 'localhost'.
+2025-09-29 03:54:35.304 +07:00 [DBG] Closed connection to database 'capbot_db' on server 'localhost' (0ms).
+2025-09-29 03:54:35.304 +07:00 [DBG] Opened connection to database 'capbot_db' on server 'localhost'.
+2025-09-29 03:54:35.304 +07:00 [DBG] Creating DbCommand for 'ExecuteReader'.
+2025-09-29 03:54:35.304 +07:00 [DBG] List of registered output formatters, in the following order: ["Microsoft.AspNetCore.OData.Formatter.ODataOutputFormatter","Microsoft.AspNetCore.OData.Formatter.ODataOutputFormatter","Microsoft.AspNetCore.OData.Formatter.ODataOutputFormatter","Microsoft.AspNetCore.Mvc.Formatters.HttpNoContentOutputFormatter","Microsoft.AspNetCore.Mvc.Formatters.StringOutputFormatter","Microsoft.AspNetCore.Mvc.Formatters.StreamOutputFormatter","Microsoft.AspNetCore.Mvc.Formatters.SystemTextJsonOutputFormatter"]
+2025-09-29 03:54:35.304 +07:00 [DBG] Created DbCommand for 'ExecuteReader' (0ms).
+2025-09-29 03:54:35.309 +07:00 [DBG] No information found on request to perform content negotiation.
+2025-09-29 03:54:35.309 +07:00 [DBG] Attempting to select an output formatter without using a content type as no explicit content types were specified for the response.
+2025-09-29 03:54:35.309 +07:00 [DBG] Initialized DbCommand for 'ExecuteReader' (5ms).
+2025-09-29 03:54:35.309 +07:00 [DBG] Attempting to select the first formatter in the output formatters list which can write the result.
+2025-09-29 03:54:35.310 +07:00 [DBG] Executing DbCommand [Parameters=[], CommandType='"Text"', CommandTimeout='30']
+SELECT COUNT(*)
+FROM [submissions] AS [s]
+2025-09-29 03:54:35.310 +07:00 [DBG] Selected output formatter 'Microsoft.AspNetCore.Mvc.Formatters.SystemTextJsonOutputFormatter' and content type 'application/json' to write the response.
+2025-09-29 03:54:35.311 +07:00 [INF] Executing ObjectResult, writing value of type 'FS.Commons.FSResponse'.
+2025-09-29 03:54:35.311 +07:00 [INF] Executed action CapBot.api.Controllers.UserProfileController.GetMyProfile (CapBot.api) in 43.5569ms
+2025-09-29 03:54:35.311 +07:00 [INF] Executed endpoint 'CapBot.api.Controllers.UserProfileController.GetMyProfile (CapBot.api)'
+2025-09-29 03:54:35.311 +07:00 [DBG] Connection id "0HNFUQ4FJ9UMK" completed keep alive response.
+2025-09-29 03:54:35.311 +07:00 [INF] Executed DbCommand (1ms) [Parameters=[], CommandType='"Text"', CommandTimeout='30']
+SELECT COUNT(*)
+FROM [submissions] AS [s]
+2025-09-29 03:54:35.312 +07:00 [DBG] 'MyDbContext' disposed.
+2025-09-29 03:54:35.312 +07:00 [DBG] Closing data reader to 'capbot_db' on server 'localhost'.
+2025-09-29 03:54:35.312 +07:00 [DBG] A data reader for 'capbot_db' on server 'localhost' is being disposed after spending 0ms reading results.
+2025-09-29 03:54:35.312 +07:00 [DBG] Closing connection to database 'capbot_db' on server 'localhost'.
+2025-09-29 03:54:35.312 +07:00 [DBG] Disposing connection to database 'capbot_db' on server 'localhost'.
+2025-09-29 03:54:35.312 +07:00 [DBG] Closed connection to database 'capbot_db' on server 'localhost' (0ms).
+2025-09-29 03:54:35.312 +07:00 [DBG] Disposed connection to database '' on server '' (0ms).
+2025-09-29 03:54:35.315 +07:00 [INF] Request finished HTTP/1.1 GET http://localhost:5207/api/user-profiles/me - 200 null application/json; charset=utf-8 64.6312ms
+2025-09-29 03:54:35.315 +07:00 [DBG] Opening connection to database 'capbot_db' on server 'localhost'.
+2025-09-29 03:54:35.316 +07:00 [DBG] Opened connection to database 'capbot_db' on server 'localhost'.
+2025-09-29 03:54:35.316 +07:00 [DBG] Creating DbCommand for 'ExecuteReader'.
+2025-09-29 03:54:35.316 +07:00 [DBG] Created DbCommand for 'ExecuteReader' (0ms).
+2025-09-29 03:54:35.316 +07:00 [DBG] Initialized DbCommand for 'ExecuteReader' (0ms).
+2025-09-29 03:54:35.316 +07:00 [DBG] Executing DbCommand [Parameters=[@__p_0='?' (DbType = Int32), @__p_1='?' (DbType = Int32)], CommandType='"Text"', CommandTimeout='30']
+SELECT [t].[Id], [t].[AdditionalNotes], [t].[AiCheckDetails], [t].[AiCheckScore], [t].[AiCheckStatus], [t].[CreatedAt], [t].[CreatedBy], [t].[DeletedAt], [t].[DocumentUrl], [t].[IsActive], [t].[LastModifiedAt], [t].[LastModifiedBy], [t].[PhaseId], [t].[Status], [t].[SubmissionRound], [t].[SubmittedAt], [t].[SubmittedBy], [t].[TopicId], [t].[TopicVersionId], [u].[Id], [u].[AccessFailedCount], [u].[ConcurrencyStamp], [u].[CreatedAt], [u].[DeletedAt], [u].[Email], [u].[EmailConfirmed], [u].[LastModifiedAt], [u].[LastModifiedBy], [u].[LockoutEnabled], [u].[LockoutEnd], [u].[NormalizedEmail], [u].[NormalizedUserName], [u].[PasswordHash], [u].[PhoneNumber], [u].[PhoneNumberConfirmed], [u].[SecurityStamp], [u].[TwoFactorEnabled], [u].[UserName], [t0].[Id], [t0].[Abbreviation], [t0].[CategoryId], [t0].[Content], [t0].[Context], [t0].[CreatedAt], [t0].[CreatedBy], [t0].[DeletedAt], [t0].[Description], [t0].[EN_Title], [t0].[IsActive], [t0].[IsApproved], [t0].[IsLegacy], [t0].[LastModifiedAt], [t0].[LastModifiedBy], [t0].[MaxStudents], [t0].[Objectives], [t0].[PotentialDuplicate], [t0].[Problem], [t0].[SemesterId], [t0].[SupervisorId], [t0].[VN_title]
+FROM (
+    SELECT [s].[Id], [s].[AdditionalNotes], [s].[AiCheckDetails], [s].[AiCheckScore], [s].[AiCheckStatus], [s].[CreatedAt], [s].[CreatedBy], [s].[DeletedAt], [s].[DocumentUrl], [s].[IsActive], [s].[LastModifiedAt], [s].[LastModifiedBy], [s].[PhaseId], [s].[Status], [s].[SubmissionRound], [s].[SubmittedAt], [s].[SubmittedBy], [s].[TopicId], [s].[TopicVersionId]
+    FROM [submissions] AS [s]
+    ORDER BY [s].[SubmittedAt] DESC
+    OFFSET @__p_0 ROWS FETCH NEXT @__p_1 ROWS ONLY
+) AS [t]
+INNER JOIN [users] AS [u] ON [t].[SubmittedBy] = [u].[Id]
+LEFT JOIN [topics] AS [t0] ON [t].[TopicId] = [t0].[Id]
+ORDER BY [t].[SubmittedAt] DESC
+2025-09-29 03:54:35.320 +07:00 [INF] Executed DbCommand (4ms) [Parameters=[@__p_0='?' (DbType = Int32), @__p_1='?' (DbType = Int32)], CommandType='"Text"', CommandTimeout='30']
+SELECT [t].[Id], [t].[AdditionalNotes], [t].[AiCheckDetails], [t].[AiCheckScore], [t].[AiCheckStatus], [t].[CreatedAt], [t].[CreatedBy], [t].[DeletedAt], [t].[DocumentUrl], [t].[IsActive], [t].[LastModifiedAt], [t].[LastModifiedBy], [t].[PhaseId], [t].[Status], [t].[SubmissionRound], [t].[SubmittedAt], [t].[SubmittedBy], [t].[TopicId], [t].[TopicVersionId], [u].[Id], [u].[AccessFailedCount], [u].[ConcurrencyStamp], [u].[CreatedAt], [u].[DeletedAt], [u].[Email], [u].[EmailConfirmed], [u].[LastModifiedAt], [u].[LastModifiedBy], [u].[LockoutEnabled], [u].[LockoutEnd], [u].[NormalizedEmail], [u].[NormalizedUserName], [u].[PasswordHash], [u].[PhoneNumber], [u].[PhoneNumberConfirmed], [u].[SecurityStamp], [u].[TwoFactorEnabled], [u].[UserName], [t0].[Id], [t0].[Abbreviation], [t0].[CategoryId], [t0].[Content], [t0].[Context], [t0].[CreatedAt], [t0].[CreatedBy], [t0].[DeletedAt], [t0].[Description], [t0].[EN_Title], [t0].[IsActive], [t0].[IsApproved], [t0].[IsLegacy], [t0].[LastModifiedAt], [t0].[LastModifiedBy], [t0].[MaxStudents], [t0].[Objectives], [t0].[PotentialDuplicate], [t0].[Problem], [t0].[SemesterId], [t0].[SupervisorId], [t0].[VN_title]
+FROM (
+    SELECT [s].[Id], [s].[AdditionalNotes], [s].[AiCheckDetails], [s].[AiCheckScore], [s].[AiCheckStatus], [s].[CreatedAt], [s].[CreatedBy], [s].[DeletedAt], [s].[DocumentUrl], [s].[IsActive], [s].[LastModifiedAt], [s].[LastModifiedBy], [s].[PhaseId], [s].[Status], [s].[SubmissionRound], [s].[SubmittedAt], [s].[SubmittedBy], [s].[TopicId], [s].[TopicVersionId]
+    FROM [submissions] AS [s]
+    ORDER BY [s].[SubmittedAt] DESC
+    OFFSET @__p_0 ROWS FETCH NEXT @__p_1 ROWS ONLY
+) AS [t]
+INNER JOIN [users] AS [u] ON [t].[SubmittedBy] = [u].[Id]
+LEFT JOIN [topics] AS [t0] ON [t].[TopicId] = [t0].[Id]
+ORDER BY [t].[SubmittedAt] DESC
+2025-09-29 03:54:35.323 +07:00 [DBG] Closing data reader to 'capbot_db' on server 'localhost'.
+2025-09-29 03:54:35.323 +07:00 [DBG] A data reader for 'capbot_db' on server 'localhost' is being disposed after spending 0ms reading results.
+2025-09-29 03:54:35.323 +07:00 [DBG] Closing connection to database 'capbot_db' on server 'localhost'.
+2025-09-29 03:54:35.323 +07:00 [DBG] Closed connection to database 'capbot_db' on server 'localhost' (0ms).
+2025-09-29 03:54:35.324 +07:00 [DBG] List of registered output formatters, in the following order: ["Microsoft.AspNetCore.OData.Formatter.ODataOutputFormatter","Microsoft.AspNetCore.OData.Formatter.ODataOutputFormatter","Microsoft.AspNetCore.OData.Formatter.ODataOutputFormatter","Microsoft.AspNetCore.Mvc.Formatters.HttpNoContentOutputFormatter","Microsoft.AspNetCore.Mvc.Formatters.StringOutputFormatter","Microsoft.AspNetCore.Mvc.Formatters.StreamOutputFormatter","Microsoft.AspNetCore.Mvc.Formatters.SystemTextJsonOutputFormatter"]
+2025-09-29 03:54:35.324 +07:00 [DBG] No information found on request to perform content negotiation.
+2025-09-29 03:54:35.324 +07:00 [DBG] Attempting to select the first output formatter in the output formatters list which supports a content type from the explicitly specified content types '["application/json"]'.
+2025-09-29 03:54:35.324 +07:00 [DBG] Selected output formatter 'Microsoft.AspNetCore.Mvc.Formatters.SystemTextJsonOutputFormatter' and content type 'application/json' to write the response.
+2025-09-29 03:54:35.324 +07:00 [INF] Executing ObjectResult, writing value of type 'FS.Commons.FSResponse'.
+2025-09-29 03:54:35.324 +07:00 [INF] Executed action CapBot.api.Controllers.SubmissionController.List (CapBot.api) in 56.015ms
+2025-09-29 03:54:35.324 +07:00 [INF] Executed endpoint 'CapBot.api.Controllers.SubmissionController.List (CapBot.api)'
+2025-09-29 03:54:35.325 +07:00 [DBG] Connection id "0HNFUQ4FJ9UML" completed keep alive response.
+2025-09-29 03:54:35.325 +07:00 [DBG] 'MyDbContext' disposed.
+2025-09-29 03:54:35.325 +07:00 [DBG] Disposing connection to database 'capbot_db' on server 'localhost'.
+2025-09-29 03:54:35.325 +07:00 [DBG] Disposed connection to database '' on server '' (0ms).
+2025-09-29 03:54:35.325 +07:00 [INF] Request finished HTTP/1.1 GET http://localhost:5207/api/submission/list?PageNumber=1&PageSize=10 - 200 null application/json; charset=utf-8 74.408ms
+2025-09-29 03:54:35.326 +07:00 [INF] Request starting HTTP/1.1 GET http://localhost:5207/images/entities/11111111.png - null null
+2025-09-29 03:54:35.327 +07:00 [DBG] The request path /images/entities/11111111.png does not match an existing file
+2025-09-29 03:54:35.327 +07:00 [DBG] The request path /images/entities/11111111.png does not match an existing file
+2025-09-29 03:54:35.327 +07:00 [DBG] No candidates found for the request path '/images/entities/11111111.png'
+2025-09-29 03:54:35.327 +07:00 [DBG] Request did not match any endpoints
+2025-09-29 03:54:35.328 +07:00 [DBG] AuthenticationScheme: Bearer was not authenticated.
+2025-09-29 03:54:35.328 +07:00 [DBG] Connection id "0HNFUQ4FJ9UMI" completed keep alive response.
+2025-09-29 03:54:35.329 +07:00 [INF] Request finished HTTP/1.1 GET http://localhost:5207/images/entities/11111111.png - 404 0 null 3.244ms
+2025-09-29 03:54:35.329 +07:00 [INF] Request reached the end of the middleware pipeline without being handled by application code. Request path: GET http://localhost:5207/images/entities/11111111.png, Response status code: 404
+2025-09-29 03:54:37.144 +07:00 [INF] Request starting HTTP/1.1 GET http://localhost:5207/api/user-profiles/me - null null
+2025-09-29 03:54:37.144 +07:00 [INF] Request starting HTTP/1.1 GET http://localhost:5207/api/submission/list?PageNumber=1&PageSize=10 - null null
+2025-09-29 03:54:37.144 +07:00 [DBG] The request path /api/user-profiles/me does not match a supported file type
+2025-09-29 03:54:37.144 +07:00 [DBG] The request path /api/user-profiles/me does not match a supported file type
+2025-09-29 03:54:37.144 +07:00 [DBG] The request has an origin header: 'http://localhost:3000'.
+2025-09-29 03:54:37.144 +07:00 [INF] CORS policy execution successful.
+2025-09-29 03:54:37.144 +07:00 [DBG] 2 candidate(s) found for the request path '/api/user-profiles/me'
+2025-09-29 03:54:37.144 +07:00 [DBG] Endpoint 'CapBot.api.Controllers.UserProfileController.GetMyProfile (CapBot.api)' with route pattern 'api/user-profiles/me' is valid for the request path '/api/user-profiles/me'
+2025-09-29 03:54:37.144 +07:00 [DBG] Endpoint 'CapBot.api.Controllers.UserProfileController.GetById (CapBot.api)' with route pattern 'api/user-profiles/{id}' is valid for the request path '/api/user-profiles/me'
+2025-09-29 03:54:37.144 +07:00 [DBG] The request path /api/submission/list does not match a supported file type
+2025-09-29 03:54:37.144 +07:00 [DBG] The request path /api/submission/list does not match a supported file type
+2025-09-29 03:54:37.144 +07:00 [DBG] The request has an origin header: 'http://localhost:3000'.
+2025-09-29 03:54:37.144 +07:00 [INF] CORS policy execution successful.
+2025-09-29 03:54:37.144 +07:00 [DBG] 1 candidate(s) found for the request path '/api/submission/list'
+2025-09-29 03:54:37.144 +07:00 [DBG] Endpoint 'CapBot.api.Controllers.SubmissionController.List (CapBot.api)' with route pattern 'api/submission/list' is valid for the request path '/api/submission/list'
+2025-09-29 03:54:37.144 +07:00 [DBG] Request matched endpoint 'CapBot.api.Controllers.SubmissionController.List (CapBot.api)'
+2025-09-29 03:54:37.145 +07:00 [DBG] Successfully validated the token.
+2025-09-29 03:54:37.145 +07:00 [DBG] AuthenticationScheme: Bearer was successfully authenticated.
+2025-09-29 03:54:37.145 +07:00 [DBG] Authorization was successful.
+2025-09-29 03:54:37.145 +07:00 [INF] Executing endpoint 'CapBot.api.Controllers.SubmissionController.List (CapBot.api)'
+2025-09-29 03:54:37.145 +07:00 [INF] Route matched with {action = "List", controller = "Submission"}. Executing controller action with signature System.Threading.Tasks.Task`1[Microsoft.AspNetCore.Mvc.IActionResult] List(App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO) on controller CapBot.api.Controllers.SubmissionController (CapBot.api).
+2025-09-29 03:54:37.145 +07:00 [DBG] Execution plan of authorization filters (in the following order): ["None"]
+2025-09-29 03:54:37.145 +07:00 [DBG] Execution plan of resource filters (in the following order): ["None"]
+2025-09-29 03:54:37.145 +07:00 [DBG] Execution plan of action filters (in the following order): ["Microsoft.AspNetCore.Mvc.ModelBinding.UnsupportedContentTypeFilter (Order: -3000)"]
+2025-09-29 03:54:37.144 +07:00 [DBG] Request matched endpoint 'CapBot.api.Controllers.UserProfileController.GetMyProfile (CapBot.api)'
+2025-09-29 03:54:37.147 +07:00 [DBG] Execution plan of exception filters (in the following order): ["None"]
+2025-09-29 03:54:37.147 +07:00 [DBG] Execution plan of result filters (in the following order): ["Microsoft.AspNetCore.Mvc.Infrastructure.ClientErrorResultFilter (Order: -2000)","Microsoft.AspNetCore.Mvc.ProducesAttribute (Order: 0)"]
+2025-09-29 03:54:37.147 +07:00 [DBG] Executing controller factory for controller CapBot.api.Controllers.SubmissionController (CapBot.api)
+2025-09-29 03:54:37.147 +07:00 [DBG] Successfully validated the token.
+2025-09-29 03:54:37.148 +07:00 [DBG] AuthenticationScheme: Bearer was successfully authenticated.
+2025-09-29 03:54:37.148 +07:00 [DBG] Authorization was successful.
+2025-09-29 03:54:37.148 +07:00 [DBG] Executed controller factory for controller CapBot.api.Controllers.SubmissionController (CapBot.api)
+2025-09-29 03:54:37.148 +07:00 [INF] Executing endpoint 'CapBot.api.Controllers.UserProfileController.GetMyProfile (CapBot.api)'
+2025-09-29 03:54:37.148 +07:00 [DBG] Attempting to bind parameter 'query' of type 'App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO' ...
+2025-09-29 03:54:37.148 +07:00 [INF] Route matched with {action = "GetMyProfile", controller = "UserProfile"}. Executing controller action with signature System.Threading.Tasks.Task`1[Microsoft.AspNetCore.Mvc.IActionResult] GetMyProfile() on controller CapBot.api.Controllers.UserProfileController (CapBot.api).
+2025-09-29 03:54:37.148 +07:00 [DBG] Execution plan of authorization filters (in the following order): ["None"]
+2025-09-29 03:54:37.148 +07:00 [DBG] Attempting to bind parameter 'query' of type 'App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO' using the name '' in request data ...
+2025-09-29 03:54:37.148 +07:00 [DBG] Execution plan of resource filters (in the following order): ["None"]
+2025-09-29 03:54:37.148 +07:00 [DBG] Attempting to bind property 'App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO.TopicVersionId' of type 'System.Nullable`1[System.Int32]' using the name 'TopicVersionId' in request data ...
+2025-09-29 03:54:37.149 +07:00 [DBG] Execution plan of action filters (in the following order): ["Microsoft.AspNetCore.Mvc.ModelBinding.UnsupportedContentTypeFilter (Order: -3000)"]
+2025-09-29 03:54:37.149 +07:00 [DBG] Execution plan of exception filters (in the following order): ["None"]
+2025-09-29 03:54:37.149 +07:00 [DBG] Could not find a value in the request with name 'TopicVersionId' for binding property 'App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO.TopicVersionId' of type 'System.Nullable`1[System.Int32]'.
+2025-09-29 03:54:37.149 +07:00 [DBG] Execution plan of result filters (in the following order): ["Microsoft.AspNetCore.Mvc.Infrastructure.ClientErrorResultFilter (Order: -2000)"]
+2025-09-29 03:54:37.149 +07:00 [DBG] Done attempting to bind property 'App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO.TopicVersionId' of type 'System.Nullable`1[System.Int32]'.
+2025-09-29 03:54:37.149 +07:00 [DBG] Executing controller factory for controller CapBot.api.Controllers.UserProfileController (CapBot.api)
+2025-09-29 03:54:37.152 +07:00 [DBG] Attempting to bind property 'App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO.PhaseId' of type 'System.Nullable`1[System.Int32]' using the name 'PhaseId' in request data ...
+2025-09-29 03:54:37.152 +07:00 [DBG] Could not find a value in the request with name 'PhaseId' for binding property 'App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO.PhaseId' of type 'System.Nullable`1[System.Int32]'.
+2025-09-29 03:54:37.152 +07:00 [DBG] Done attempting to bind property 'App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO.PhaseId' of type 'System.Nullable`1[System.Int32]'.
+2025-09-29 03:54:37.152 +07:00 [DBG] Attempting to bind property 'App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO.SemesterId' of type 'System.Nullable`1[System.Int32]' using the name 'SemesterId' in request data ...
+2025-09-29 03:54:37.152 +07:00 [DBG] Could not find a value in the request with name 'SemesterId' for binding property 'App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO.SemesterId' of type 'System.Nullable`1[System.Int32]'.
+2025-09-29 03:54:37.153 +07:00 [DBG] Executed controller factory for controller CapBot.api.Controllers.UserProfileController (CapBot.api)
+2025-09-29 03:54:37.153 +07:00 [DBG] Done attempting to bind property 'App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO.SemesterId' of type 'System.Nullable`1[System.Int32]'.
+2025-09-29 03:54:37.154 +07:00 [DBG] Attempting to bind property 'App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO.Status' of type 'System.Nullable`1[App.Entities.Enums.SubmissionStatus]' using the name 'Status' in request data ...
+2025-09-29 03:54:37.154 +07:00 [DBG] Could not find a value in the request with name 'Status' for binding property 'App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO.Status' of type 'System.Nullable`1[App.Entities.Enums.SubmissionStatus]'.
+2025-09-29 03:54:37.154 +07:00 [DBG] Done attempting to bind property 'App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO.Status' of type 'System.Nullable`1[App.Entities.Enums.SubmissionStatus]'.
+2025-09-29 03:54:37.154 +07:00 [DBG] Attempting to bind property 'App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO.PageNumber' of type 'System.Int32' using the name 'PageNumber' in request data ...
+2025-09-29 03:54:37.154 +07:00 [DBG] Entity Framework Core 8.0.16 initialized 'MyDbContext' using provider 'Microsoft.EntityFrameworkCore.SqlServer:8.0.13' with options: MigrationsAssembly=App.DAL 
+2025-09-29 03:54:37.155 +07:00 [DBG] Done attempting to bind property 'App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO.PageNumber' of type 'System.Int32'.
+2025-09-29 03:54:37.155 +07:00 [DBG] Attempting to bind property 'App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO.PageSize' of type 'System.Int32' using the name 'PageSize' in request data ...
+2025-09-29 03:54:37.155 +07:00 [DBG] Done attempting to bind property 'App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO.PageSize' of type 'System.Int32'.
+2025-09-29 03:54:37.155 +07:00 [DBG] Attempting to bind property 'App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO.Keyword' of type 'System.String' using the name 'Keyword' in request data ...
+2025-09-29 03:54:37.155 +07:00 [DBG] Could not find a value in the request with name 'Keyword' for binding property 'App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO.Keyword' of type 'System.String'.
+2025-09-29 03:54:37.155 +07:00 [DBG] Done attempting to bind property 'App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO.Keyword' of type 'System.String'.
+2025-09-29 03:54:37.155 +07:00 [DBG] Attempting to bind property 'App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO.TotalRecord' of type 'System.Int32' using the name 'TotalRecord' in request data ...
+2025-09-29 03:54:37.156 +07:00 [DBG] Could not find a value in the request with name 'TotalRecord' for binding property 'App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO.TotalRecord' of type 'System.Int32'.
+2025-09-29 03:54:37.156 +07:00 [DBG] Done attempting to bind property 'App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO.TotalRecord' of type 'System.Int32'.
+2025-09-29 03:54:37.156 +07:00 [DBG] Done attempting to bind parameter 'query' of type 'App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO'.
+2025-09-29 03:54:37.156 +07:00 [DBG] Done attempting to bind parameter 'query' of type 'App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO'.
+2025-09-29 03:54:37.156 +07:00 [DBG] Attempting to validate the bound parameter 'query' of type 'App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO' ...
+2025-09-29 03:54:37.155 +07:00 [DBG] Creating DbConnection.
+2025-09-29 03:54:37.158 +07:00 [DBG] Done attempting to validate the bound parameter 'query' of type 'App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO'.
+2025-09-29 03:54:37.158 +07:00 [DBG] Created DbConnection. (3ms).
+2025-09-29 03:54:37.159 +07:00 [DBG] Opening connection to database 'capbot_db' on server 'localhost'.
+2025-09-29 03:54:37.159 +07:00 [DBG] Opened connection to database 'capbot_db' on server 'localhost'.
+2025-09-29 03:54:37.159 +07:00 [DBG] Creating DbCommand for 'ExecuteReader'.
+2025-09-29 03:54:37.159 +07:00 [DBG] Created DbCommand for 'ExecuteReader' (0ms).
+2025-09-29 03:54:37.159 +07:00 [DBG] Initialized DbCommand for 'ExecuteReader' (0ms).
+2025-09-29 03:54:37.159 +07:00 [DBG] Executing DbCommand [Parameters=[@__targetUserId_0='?' (DbType = Int32)], CommandType='"Text"', CommandTimeout='30']
+SELECT TOP(1) [p].[Id], [p].[Address], [p].[Avatar], [p].[CoverImage], [p].[CreatedAt], [p].[CreatedBy], [p].[DeletedAt], [p].[FullName], [p].[IsActive], [p].[LastModifiedAt], [p].[LastModifiedBy], [p].[UserId]
+FROM [profiles] AS [p]
+WHERE [p].[UserId] = @__targetUserId_0 AND [p].[IsActive] = CAST(1 AS bit) AND [p].[DeletedAt] IS NULL AND [p].[DeletedAt] IS NULL
+2025-09-29 03:54:37.159 +07:00 [DBG] Entity Framework Core 8.0.16 initialized 'MyDbContext' using provider 'Microsoft.EntityFrameworkCore.SqlServer:8.0.13' with options: MigrationsAssembly=App.DAL 
+2025-09-29 03:54:37.160 +07:00 [DBG] Creating DbConnection.
+2025-09-29 03:54:37.160 +07:00 [DBG] Created DbConnection. (0ms).
+2025-09-29 03:54:37.161 +07:00 [DBG] Opening connection to database 'capbot_db' on server 'localhost'.
+2025-09-29 03:54:37.161 +07:00 [DBG] Opened connection to database 'capbot_db' on server 'localhost'.
+2025-09-29 03:54:37.161 +07:00 [DBG] Creating DbCommand for 'ExecuteReader'.
+2025-09-29 03:54:37.161 +07:00 [DBG] Created DbCommand for 'ExecuteReader' (0ms).
+2025-09-29 03:54:37.161 +07:00 [DBG] Initialized DbCommand for 'ExecuteReader' (0ms).
+2025-09-29 03:54:37.161 +07:00 [DBG] Executing DbCommand [Parameters=[], CommandType='"Text"', CommandTimeout='30']
+SELECT COUNT(*)
+FROM [submissions] AS [s]
+2025-09-29 03:54:37.161 +07:00 [INF] Executed DbCommand (2ms) [Parameters=[@__targetUserId_0='?' (DbType = Int32)], CommandType='"Text"', CommandTimeout='30']
+SELECT TOP(1) [p].[Id], [p].[Address], [p].[Avatar], [p].[CoverImage], [p].[CreatedAt], [p].[CreatedBy], [p].[DeletedAt], [p].[FullName], [p].[IsActive], [p].[LastModifiedAt], [p].[LastModifiedBy], [p].[UserId]
+FROM [profiles] AS [p]
+WHERE [p].[UserId] = @__targetUserId_0 AND [p].[IsActive] = CAST(1 AS bit) AND [p].[DeletedAt] IS NULL AND [p].[DeletedAt] IS NULL
+2025-09-29 03:54:37.162 +07:00 [INF] Executed DbCommand (1ms) [Parameters=[], CommandType='"Text"', CommandTimeout='30']
+SELECT COUNT(*)
+FROM [submissions] AS [s]
+2025-09-29 03:54:37.162 +07:00 [DBG] Closing data reader to 'capbot_db' on server 'localhost'.
+2025-09-29 03:54:37.162 +07:00 [DBG] A data reader for 'capbot_db' on server 'localhost' is being disposed after spending 0ms reading results.
+2025-09-29 03:54:37.162 +07:00 [DBG] Closing connection to database 'capbot_db' on server 'localhost'.
+2025-09-29 03:54:37.162 +07:00 [DBG] Closed connection to database 'capbot_db' on server 'localhost' (0ms).
+2025-09-29 03:54:37.162 +07:00 [DBG] List of registered output formatters, in the following order: ["Microsoft.AspNetCore.OData.Formatter.ODataOutputFormatter","Microsoft.AspNetCore.OData.Formatter.ODataOutputFormatter","Microsoft.AspNetCore.OData.Formatter.ODataOutputFormatter","Microsoft.AspNetCore.Mvc.Formatters.HttpNoContentOutputFormatter","Microsoft.AspNetCore.Mvc.Formatters.StringOutputFormatter","Microsoft.AspNetCore.Mvc.Formatters.StreamOutputFormatter","Microsoft.AspNetCore.Mvc.Formatters.SystemTextJsonOutputFormatter"]
+2025-09-29 03:54:37.162 +07:00 [DBG] Closing data reader to 'capbot_db' on server 'localhost'.
+2025-09-29 03:54:37.163 +07:00 [DBG] No information found on request to perform content negotiation.
+2025-09-29 03:54:37.163 +07:00 [DBG] A data reader for 'capbot_db' on server 'localhost' is being disposed after spending 1ms reading results.
+2025-09-29 03:54:37.163 +07:00 [DBG] Closing connection to database 'capbot_db' on server 'localhost'.
+2025-09-29 03:54:37.163 +07:00 [DBG] Attempting to select an output formatter without using a content type as no explicit content types were specified for the response.
+2025-09-29 03:54:37.163 +07:00 [DBG] Closed connection to database 'capbot_db' on server 'localhost' (0ms).
+2025-09-29 03:54:37.163 +07:00 [DBG] Attempting to select the first formatter in the output formatters list which can write the result.
+2025-09-29 03:54:37.164 +07:00 [DBG] Opening connection to database 'capbot_db' on server 'localhost'.
+2025-09-29 03:54:37.164 +07:00 [DBG] Selected output formatter 'Microsoft.AspNetCore.Mvc.Formatters.SystemTextJsonOutputFormatter' and content type 'application/json' to write the response.
+2025-09-29 03:54:37.164 +07:00 [INF] Executing ObjectResult, writing value of type 'FS.Commons.FSResponse'.
+2025-09-29 03:54:37.164 +07:00 [DBG] Opened connection to database 'capbot_db' on server 'localhost'.
+2025-09-29 03:54:37.165 +07:00 [DBG] Creating DbCommand for 'ExecuteReader'.
+2025-09-29 03:54:37.165 +07:00 [INF] Executed action CapBot.api.Controllers.UserProfileController.GetMyProfile (CapBot.api) in 15.8102ms
+2025-09-29 03:54:37.165 +07:00 [DBG] Created DbCommand for 'ExecuteReader' (0ms).
+2025-09-29 03:54:37.165 +07:00 [INF] Executed endpoint 'CapBot.api.Controllers.UserProfileController.GetMyProfile (CapBot.api)'
+2025-09-29 03:54:37.165 +07:00 [DBG] Initialized DbCommand for 'ExecuteReader' (0ms).
+2025-09-29 03:54:37.165 +07:00 [DBG] Connection id "0HNFUQ4FJ9UML" completed keep alive response.
+2025-09-29 03:54:37.165 +07:00 [DBG] Executing DbCommand [Parameters=[@__p_0='?' (DbType = Int32), @__p_1='?' (DbType = Int32)], CommandType='"Text"', CommandTimeout='30']
+SELECT [t].[Id], [t].[AdditionalNotes], [t].[AiCheckDetails], [t].[AiCheckScore], [t].[AiCheckStatus], [t].[CreatedAt], [t].[CreatedBy], [t].[DeletedAt], [t].[DocumentUrl], [t].[IsActive], [t].[LastModifiedAt], [t].[LastModifiedBy], [t].[PhaseId], [t].[Status], [t].[SubmissionRound], [t].[SubmittedAt], [t].[SubmittedBy], [t].[TopicId], [t].[TopicVersionId], [u].[Id], [u].[AccessFailedCount], [u].[ConcurrencyStamp], [u].[CreatedAt], [u].[DeletedAt], [u].[Email], [u].[EmailConfirmed], [u].[LastModifiedAt], [u].[LastModifiedBy], [u].[LockoutEnabled], [u].[LockoutEnd], [u].[NormalizedEmail], [u].[NormalizedUserName], [u].[PasswordHash], [u].[PhoneNumber], [u].[PhoneNumberConfirmed], [u].[SecurityStamp], [u].[TwoFactorEnabled], [u].[UserName], [t0].[Id], [t0].[Abbreviation], [t0].[CategoryId], [t0].[Content], [t0].[Context], [t0].[CreatedAt], [t0].[CreatedBy], [t0].[DeletedAt], [t0].[Description], [t0].[EN_Title], [t0].[IsActive], [t0].[IsApproved], [t0].[IsLegacy], [t0].[LastModifiedAt], [t0].[LastModifiedBy], [t0].[MaxStudents], [t0].[Objectives], [t0].[PotentialDuplicate], [t0].[Problem], [t0].[SemesterId], [t0].[SupervisorId], [t0].[VN_title]
+FROM (
+    SELECT [s].[Id], [s].[AdditionalNotes], [s].[AiCheckDetails], [s].[AiCheckScore], [s].[AiCheckStatus], [s].[CreatedAt], [s].[CreatedBy], [s].[DeletedAt], [s].[DocumentUrl], [s].[IsActive], [s].[LastModifiedAt], [s].[LastModifiedBy], [s].[PhaseId], [s].[Status], [s].[SubmissionRound], [s].[SubmittedAt], [s].[SubmittedBy], [s].[TopicId], [s].[TopicVersionId]
+    FROM [submissions] AS [s]
+    ORDER BY [s].[SubmittedAt] DESC
+    OFFSET @__p_0 ROWS FETCH NEXT @__p_1 ROWS ONLY
+) AS [t]
+INNER JOIN [users] AS [u] ON [t].[SubmittedBy] = [u].[Id]
+LEFT JOIN [topics] AS [t0] ON [t].[TopicId] = [t0].[Id]
+ORDER BY [t].[SubmittedAt] DESC
+2025-09-29 03:54:37.165 +07:00 [DBG] 'MyDbContext' disposed.
+2025-09-29 03:54:37.168 +07:00 [DBG] Disposing connection to database 'capbot_db' on server 'localhost'.
+2025-09-29 03:54:37.168 +07:00 [DBG] Disposed connection to database '' on server '' (0ms).
+2025-09-29 03:54:37.169 +07:00 [INF] Request finished HTTP/1.1 GET http://localhost:5207/api/user-profiles/me - 200 null application/json; charset=utf-8 25.3405ms
+2025-09-29 03:54:37.169 +07:00 [INF] Executed DbCommand (4ms) [Parameters=[@__p_0='?' (DbType = Int32), @__p_1='?' (DbType = Int32)], CommandType='"Text"', CommandTimeout='30']
+SELECT [t].[Id], [t].[AdditionalNotes], [t].[AiCheckDetails], [t].[AiCheckScore], [t].[AiCheckStatus], [t].[CreatedAt], [t].[CreatedBy], [t].[DeletedAt], [t].[DocumentUrl], [t].[IsActive], [t].[LastModifiedAt], [t].[LastModifiedBy], [t].[PhaseId], [t].[Status], [t].[SubmissionRound], [t].[SubmittedAt], [t].[SubmittedBy], [t].[TopicId], [t].[TopicVersionId], [u].[Id], [u].[AccessFailedCount], [u].[ConcurrencyStamp], [u].[CreatedAt], [u].[DeletedAt], [u].[Email], [u].[EmailConfirmed], [u].[LastModifiedAt], [u].[LastModifiedBy], [u].[LockoutEnabled], [u].[LockoutEnd], [u].[NormalizedEmail], [u].[NormalizedUserName], [u].[PasswordHash], [u].[PhoneNumber], [u].[PhoneNumberConfirmed], [u].[SecurityStamp], [u].[TwoFactorEnabled], [u].[UserName], [t0].[Id], [t0].[Abbreviation], [t0].[CategoryId], [t0].[Content], [t0].[Context], [t0].[CreatedAt], [t0].[CreatedBy], [t0].[DeletedAt], [t0].[Description], [t0].[EN_Title], [t0].[IsActive], [t0].[IsApproved], [t0].[IsLegacy], [t0].[LastModifiedAt], [t0].[LastModifiedBy], [t0].[MaxStudents], [t0].[Objectives], [t0].[PotentialDuplicate], [t0].[Problem], [t0].[SemesterId], [t0].[SupervisorId], [t0].[VN_title]
+FROM (
+    SELECT [s].[Id], [s].[AdditionalNotes], [s].[AiCheckDetails], [s].[AiCheckScore], [s].[AiCheckStatus], [s].[CreatedAt], [s].[CreatedBy], [s].[DeletedAt], [s].[DocumentUrl], [s].[IsActive], [s].[LastModifiedAt], [s].[LastModifiedBy], [s].[PhaseId], [s].[Status], [s].[SubmissionRound], [s].[SubmittedAt], [s].[SubmittedBy], [s].[TopicId], [s].[TopicVersionId]
+    FROM [submissions] AS [s]
+    ORDER BY [s].[SubmittedAt] DESC
+    OFFSET @__p_0 ROWS FETCH NEXT @__p_1 ROWS ONLY
+) AS [t]
+INNER JOIN [users] AS [u] ON [t].[SubmittedBy] = [u].[Id]
+LEFT JOIN [topics] AS [t0] ON [t].[TopicId] = [t0].[Id]
+ORDER BY [t].[SubmittedAt] DESC
+2025-09-29 03:54:37.173 +07:00 [DBG] Closing data reader to 'capbot_db' on server 'localhost'.
+2025-09-29 03:54:37.173 +07:00 [DBG] A data reader for 'capbot_db' on server 'localhost' is being disposed after spending 0ms reading results.
+2025-09-29 03:54:37.173 +07:00 [DBG] Closing connection to database 'capbot_db' on server 'localhost'.
+2025-09-29 03:54:37.173 +07:00 [DBG] Closed connection to database 'capbot_db' on server 'localhost' (0ms).
+2025-09-29 03:54:37.173 +07:00 [DBG] List of registered output formatters, in the following order: ["Microsoft.AspNetCore.OData.Formatter.ODataOutputFormatter","Microsoft.AspNetCore.OData.Formatter.ODataOutputFormatter","Microsoft.AspNetCore.OData.Formatter.ODataOutputFormatter","Microsoft.AspNetCore.Mvc.Formatters.HttpNoContentOutputFormatter","Microsoft.AspNetCore.Mvc.Formatters.StringOutputFormatter","Microsoft.AspNetCore.Mvc.Formatters.StreamOutputFormatter","Microsoft.AspNetCore.Mvc.Formatters.SystemTextJsonOutputFormatter"]
+2025-09-29 03:54:37.173 +07:00 [DBG] No information found on request to perform content negotiation.
+2025-09-29 03:54:37.173 +07:00 [DBG] Attempting to select the first output formatter in the output formatters list which supports a content type from the explicitly specified content types '["application/json"]'.
+2025-09-29 03:54:37.174 +07:00 [DBG] Selected output formatter 'Microsoft.AspNetCore.Mvc.Formatters.SystemTextJsonOutputFormatter' and content type 'application/json' to write the response.
+2025-09-29 03:54:37.174 +07:00 [INF] Executing ObjectResult, writing value of type 'FS.Commons.FSResponse'.
+2025-09-29 03:54:37.174 +07:00 [INF] Executed action CapBot.api.Controllers.SubmissionController.List (CapBot.api) in 27.0091ms
+2025-09-29 03:54:37.174 +07:00 [INF] Executed endpoint 'CapBot.api.Controllers.SubmissionController.List (CapBot.api)'
+2025-09-29 03:54:37.174 +07:00 [DBG] Connection id "0HNFUQ4FJ9UMK" completed keep alive response.
+2025-09-29 03:54:37.174 +07:00 [DBG] 'MyDbContext' disposed.
+2025-09-29 03:54:37.174 +07:00 [DBG] Disposing connection to database 'capbot_db' on server 'localhost'.
+2025-09-29 03:54:37.174 +07:00 [DBG] Disposed connection to database '' on server '' (0ms).
+2025-09-29 03:54:37.174 +07:00 [INF] Request finished HTTP/1.1 GET http://localhost:5207/api/submission/list?PageNumber=1&PageSize=10 - 200 null application/json; charset=utf-8 30.7263ms
+2025-09-29 03:54:37.178 +07:00 [INF] Request starting HTTP/1.1 GET http://localhost:5207/images/entities/11111111.png - null null
+2025-09-29 03:54:37.178 +07:00 [DBG] The request path /images/entities/11111111.png does not match an existing file
+2025-09-29 03:54:37.178 +07:00 [DBG] The request path /images/entities/11111111.png does not match an existing file
+2025-09-29 03:54:37.178 +07:00 [DBG] No candidates found for the request path '/images/entities/11111111.png'
+2025-09-29 03:54:37.179 +07:00 [DBG] Request did not match any endpoints
+2025-09-29 03:54:37.180 +07:00 [DBG] AuthenticationScheme: Bearer was not authenticated.
+2025-09-29 03:54:37.180 +07:00 [DBG] Connection id "0HNFUQ4FJ9UMI" completed keep alive response.
+2025-09-29 03:54:37.180 +07:00 [INF] Request finished HTTP/1.1 GET http://localhost:5207/images/entities/11111111.png - 404 0 null 2.2489ms
+2025-09-29 03:54:37.180 +07:00 [INF] Request reached the end of the middleware pipeline without being handled by application code. Request path: GET http://localhost:5207/images/entities/11111111.png, Response status code: 404
+2025-09-29 03:54:38.406 +07:00 [INF] Request starting HTTP/1.1 GET http://localhost:5207/api/user-profiles/me - null null
+2025-09-29 03:54:38.406 +07:00 [INF] Request starting HTTP/1.1 GET http://localhost:5207/api/submission/list?PageNumber=1&PageSize=10 - null null
+2025-09-29 03:54:38.406 +07:00 [DBG] The request path /api/user-profiles/me does not match a supported file type
+2025-09-29 03:54:38.406 +07:00 [DBG] The request path /api/submission/list does not match a supported file type
+2025-09-29 03:54:38.406 +07:00 [DBG] The request path /api/user-profiles/me does not match a supported file type
+2025-09-29 03:54:38.406 +07:00 [DBG] The request path /api/submission/list does not match a supported file type
+2025-09-29 03:54:38.406 +07:00 [DBG] The request has an origin header: 'http://localhost:3000'.
+2025-09-29 03:54:38.406 +07:00 [DBG] The request has an origin header: 'http://localhost:3000'.
+2025-09-29 03:54:38.406 +07:00 [INF] CORS policy execution successful.
+2025-09-29 03:54:38.406 +07:00 [INF] CORS policy execution successful.
+2025-09-29 03:54:38.406 +07:00 [DBG] 2 candidate(s) found for the request path '/api/user-profiles/me'
+2025-09-29 03:54:38.406 +07:00 [DBG] Endpoint 'CapBot.api.Controllers.UserProfileController.GetMyProfile (CapBot.api)' with route pattern 'api/user-profiles/me' is valid for the request path '/api/user-profiles/me'
+2025-09-29 03:54:38.406 +07:00 [DBG] Endpoint 'CapBot.api.Controllers.UserProfileController.GetById (CapBot.api)' with route pattern 'api/user-profiles/{id}' is valid for the request path '/api/user-profiles/me'
+2025-09-29 03:54:38.406 +07:00 [DBG] 1 candidate(s) found for the request path '/api/submission/list'
+2025-09-29 03:54:38.407 +07:00 [DBG] Endpoint 'CapBot.api.Controllers.SubmissionController.List (CapBot.api)' with route pattern 'api/submission/list' is valid for the request path '/api/submission/list'
+2025-09-29 03:54:38.407 +07:00 [DBG] Request matched endpoint 'CapBot.api.Controllers.SubmissionController.List (CapBot.api)'
+2025-09-29 03:54:38.407 +07:00 [DBG] Request matched endpoint 'CapBot.api.Controllers.UserProfileController.GetMyProfile (CapBot.api)'
+2025-09-29 03:54:38.407 +07:00 [DBG] Successfully validated the token.
+2025-09-29 03:54:38.407 +07:00 [DBG] Successfully validated the token.
+2025-09-29 03:54:38.407 +07:00 [DBG] AuthenticationScheme: Bearer was successfully authenticated.
+2025-09-29 03:54:38.407 +07:00 [DBG] Authorization was successful.
+2025-09-29 03:54:38.407 +07:00 [DBG] AuthenticationScheme: Bearer was successfully authenticated.
+2025-09-29 03:54:38.407 +07:00 [INF] Executing endpoint 'CapBot.api.Controllers.UserProfileController.GetMyProfile (CapBot.api)'
+2025-09-29 03:54:38.407 +07:00 [DBG] Authorization was successful.
+2025-09-29 03:54:38.407 +07:00 [INF] Executing endpoint 'CapBot.api.Controllers.SubmissionController.List (CapBot.api)'
+2025-09-29 03:54:38.407 +07:00 [INF] Route matched with {action = "GetMyProfile", controller = "UserProfile"}. Executing controller action with signature System.Threading.Tasks.Task`1[Microsoft.AspNetCore.Mvc.IActionResult] GetMyProfile() on controller CapBot.api.Controllers.UserProfileController (CapBot.api).
+2025-09-29 03:54:38.408 +07:00 [INF] Route matched with {action = "List", controller = "Submission"}. Executing controller action with signature System.Threading.Tasks.Task`1[Microsoft.AspNetCore.Mvc.IActionResult] List(App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO) on controller CapBot.api.Controllers.SubmissionController (CapBot.api).
+2025-09-29 03:54:38.408 +07:00 [DBG] Execution plan of authorization filters (in the following order): ["None"]
+2025-09-29 03:54:38.408 +07:00 [DBG] Execution plan of authorization filters (in the following order): ["None"]
+2025-09-29 03:54:38.408 +07:00 [DBG] Execution plan of resource filters (in the following order): ["None"]
+2025-09-29 03:54:38.408 +07:00 [DBG] Execution plan of resource filters (in the following order): ["None"]
+2025-09-29 03:54:38.408 +07:00 [DBG] Execution plan of action filters (in the following order): ["Microsoft.AspNetCore.Mvc.ModelBinding.UnsupportedContentTypeFilter (Order: -3000)"]
+2025-09-29 03:54:38.408 +07:00 [DBG] Execution plan of action filters (in the following order): ["Microsoft.AspNetCore.Mvc.ModelBinding.UnsupportedContentTypeFilter (Order: -3000)"]
+2025-09-29 03:54:38.408 +07:00 [DBG] Execution plan of exception filters (in the following order): ["None"]
+2025-09-29 03:54:38.408 +07:00 [DBG] Execution plan of exception filters (in the following order): ["None"]
+2025-09-29 03:54:38.408 +07:00 [DBG] Execution plan of result filters (in the following order): ["Microsoft.AspNetCore.Mvc.Infrastructure.ClientErrorResultFilter (Order: -2000)","Microsoft.AspNetCore.Mvc.ProducesAttribute (Order: 0)"]
+2025-09-29 03:54:38.408 +07:00 [DBG] Execution plan of result filters (in the following order): ["Microsoft.AspNetCore.Mvc.Infrastructure.ClientErrorResultFilter (Order: -2000)"]
+2025-09-29 03:54:38.408 +07:00 [DBG] Executing controller factory for controller CapBot.api.Controllers.SubmissionController (CapBot.api)
+2025-09-29 03:54:38.408 +07:00 [DBG] Executing controller factory for controller CapBot.api.Controllers.UserProfileController (CapBot.api)
+2025-09-29 03:54:38.408 +07:00 [DBG] Executed controller factory for controller CapBot.api.Controllers.UserProfileController (CapBot.api)
+2025-09-29 03:54:38.408 +07:00 [DBG] Executed controller factory for controller CapBot.api.Controllers.SubmissionController (CapBot.api)
+2025-09-29 03:54:38.409 +07:00 [DBG] Attempting to bind parameter 'query' of type 'App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO' ...
+2025-09-29 03:54:38.409 +07:00 [DBG] Attempting to bind parameter 'query' of type 'App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO' using the name '' in request data ...
+2025-09-29 03:54:38.409 +07:00 [DBG] Attempting to bind property 'App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO.TopicVersionId' of type 'System.Nullable`1[System.Int32]' using the name 'TopicVersionId' in request data ...
+2025-09-29 03:54:38.409 +07:00 [DBG] Entity Framework Core 8.0.16 initialized 'MyDbContext' using provider 'Microsoft.EntityFrameworkCore.SqlServer:8.0.13' with options: MigrationsAssembly=App.DAL 
+2025-09-29 03:54:38.409 +07:00 [DBG] Could not find a value in the request with name 'TopicVersionId' for binding property 'App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO.TopicVersionId' of type 'System.Nullable`1[System.Int32]'.
+2025-09-29 03:54:38.410 +07:00 [DBG] Done attempting to bind property 'App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO.TopicVersionId' of type 'System.Nullable`1[System.Int32]'.
+2025-09-29 03:54:38.410 +07:00 [DBG] Attempting to bind property 'App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO.PhaseId' of type 'System.Nullable`1[System.Int32]' using the name 'PhaseId' in request data ...
+2025-09-29 03:54:38.410 +07:00 [DBG] Could not find a value in the request with name 'PhaseId' for binding property 'App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO.PhaseId' of type 'System.Nullable`1[System.Int32]'.
+2025-09-29 03:54:38.410 +07:00 [DBG] Creating DbConnection.
+2025-09-29 03:54:38.410 +07:00 [DBG] Done attempting to bind property 'App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO.PhaseId' of type 'System.Nullable`1[System.Int32]'.
+2025-09-29 03:54:38.411 +07:00 [DBG] Attempting to bind property 'App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO.SemesterId' of type 'System.Nullable`1[System.Int32]' using the name 'SemesterId' in request data ...
+2025-09-29 03:54:38.410 +07:00 [DBG] Created DbConnection. (0ms).
+2025-09-29 03:54:38.411 +07:00 [DBG] Could not find a value in the request with name 'SemesterId' for binding property 'App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO.SemesterId' of type 'System.Nullable`1[System.Int32]'.
+2025-09-29 03:54:38.411 +07:00 [DBG] Opening connection to database 'capbot_db' on server 'localhost'.
+2025-09-29 03:54:38.411 +07:00 [DBG] Done attempting to bind property 'App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO.SemesterId' of type 'System.Nullable`1[System.Int32]'.
+2025-09-29 03:54:38.411 +07:00 [DBG] Attempting to bind property 'App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO.Status' of type 'System.Nullable`1[App.Entities.Enums.SubmissionStatus]' using the name 'Status' in request data ...
+2025-09-29 03:54:38.411 +07:00 [DBG] Could not find a value in the request with name 'Status' for binding property 'App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO.Status' of type 'System.Nullable`1[App.Entities.Enums.SubmissionStatus]'.
+2025-09-29 03:54:38.411 +07:00 [DBG] Opened connection to database 'capbot_db' on server 'localhost'.
+2025-09-29 03:54:38.413 +07:00 [DBG] Done attempting to bind property 'App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO.Status' of type 'System.Nullable`1[App.Entities.Enums.SubmissionStatus]'.
+2025-09-29 03:54:38.413 +07:00 [DBG] Creating DbCommand for 'ExecuteReader'.
+2025-09-29 03:54:38.413 +07:00 [DBG] Attempting to bind property 'App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO.PageNumber' of type 'System.Int32' using the name 'PageNumber' in request data ...
+2025-09-29 03:54:38.413 +07:00 [DBG] Done attempting to bind property 'App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO.PageNumber' of type 'System.Int32'.
+2025-09-29 03:54:38.413 +07:00 [DBG] Created DbCommand for 'ExecuteReader' (0ms).
+2025-09-29 03:54:38.414 +07:00 [DBG] Attempting to bind property 'App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO.PageSize' of type 'System.Int32' using the name 'PageSize' in request data ...
+2025-09-29 03:54:38.414 +07:00 [DBG] Done attempting to bind property 'App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO.PageSize' of type 'System.Int32'.
+2025-09-29 03:54:38.414 +07:00 [DBG] Initialized DbCommand for 'ExecuteReader' (0ms).
+2025-09-29 03:54:38.415 +07:00 [DBG] Attempting to bind property 'App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO.Keyword' of type 'System.String' using the name 'Keyword' in request data ...
+2025-09-29 03:54:38.415 +07:00 [DBG] Executing DbCommand [Parameters=[@__targetUserId_0='?' (DbType = Int32)], CommandType='"Text"', CommandTimeout='30']
+SELECT TOP(1) [p].[Id], [p].[Address], [p].[Avatar], [p].[CoverImage], [p].[CreatedAt], [p].[CreatedBy], [p].[DeletedAt], [p].[FullName], [p].[IsActive], [p].[LastModifiedAt], [p].[LastModifiedBy], [p].[UserId]
+FROM [profiles] AS [p]
+WHERE [p].[UserId] = @__targetUserId_0 AND [p].[IsActive] = CAST(1 AS bit) AND [p].[DeletedAt] IS NULL AND [p].[DeletedAt] IS NULL
+2025-09-29 03:54:38.415 +07:00 [DBG] Could not find a value in the request with name 'Keyword' for binding property 'App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO.Keyword' of type 'System.String'.
+2025-09-29 03:54:38.416 +07:00 [DBG] Done attempting to bind property 'App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO.Keyword' of type 'System.String'.
+2025-09-29 03:54:38.416 +07:00 [DBG] Attempting to bind property 'App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO.TotalRecord' of type 'System.Int32' using the name 'TotalRecord' in request data ...
+2025-09-29 03:54:38.416 +07:00 [DBG] Could not find a value in the request with name 'TotalRecord' for binding property 'App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO.TotalRecord' of type 'System.Int32'.
+2025-09-29 03:54:38.416 +07:00 [INF] Executed DbCommand (1ms) [Parameters=[@__targetUserId_0='?' (DbType = Int32)], CommandType='"Text"', CommandTimeout='30']
+SELECT TOP(1) [p].[Id], [p].[Address], [p].[Avatar], [p].[CoverImage], [p].[CreatedAt], [p].[CreatedBy], [p].[DeletedAt], [p].[FullName], [p].[IsActive], [p].[LastModifiedAt], [p].[LastModifiedBy], [p].[UserId]
+FROM [profiles] AS [p]
+WHERE [p].[UserId] = @__targetUserId_0 AND [p].[IsActive] = CAST(1 AS bit) AND [p].[DeletedAt] IS NULL AND [p].[DeletedAt] IS NULL
+2025-09-29 03:54:38.416 +07:00 [DBG] Done attempting to bind property 'App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO.TotalRecord' of type 'System.Int32'.
+2025-09-29 03:54:38.416 +07:00 [DBG] Done attempting to bind parameter 'query' of type 'App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO'.
+2025-09-29 03:54:38.416 +07:00 [DBG] Closing data reader to 'capbot_db' on server 'localhost'.
+2025-09-29 03:54:38.416 +07:00 [DBG] Done attempting to bind parameter 'query' of type 'App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO'.
+2025-09-29 03:54:38.416 +07:00 [DBG] Attempting to validate the bound parameter 'query' of type 'App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO' ...
+2025-09-29 03:54:38.416 +07:00 [DBG] A data reader for 'capbot_db' on server 'localhost' is being disposed after spending 0ms reading results.
+2025-09-29 03:54:38.416 +07:00 [DBG] Closing connection to database 'capbot_db' on server 'localhost'.
+2025-09-29 03:54:38.416 +07:00 [DBG] Done attempting to validate the bound parameter 'query' of type 'App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO'.
+2025-09-29 03:54:38.416 +07:00 [DBG] Closed connection to database 'capbot_db' on server 'localhost' (0ms).
+2025-09-29 03:54:38.417 +07:00 [DBG] Entity Framework Core 8.0.16 initialized 'MyDbContext' using provider 'Microsoft.EntityFrameworkCore.SqlServer:8.0.13' with options: MigrationsAssembly=App.DAL 
+2025-09-29 03:54:38.417 +07:00 [DBG] List of registered output formatters, in the following order: ["Microsoft.AspNetCore.OData.Formatter.ODataOutputFormatter","Microsoft.AspNetCore.OData.Formatter.ODataOutputFormatter","Microsoft.AspNetCore.OData.Formatter.ODataOutputFormatter","Microsoft.AspNetCore.Mvc.Formatters.HttpNoContentOutputFormatter","Microsoft.AspNetCore.Mvc.Formatters.StringOutputFormatter","Microsoft.AspNetCore.Mvc.Formatters.StreamOutputFormatter","Microsoft.AspNetCore.Mvc.Formatters.SystemTextJsonOutputFormatter"]
+2025-09-29 03:54:38.417 +07:00 [DBG] No information found on request to perform content negotiation.
+2025-09-29 03:54:38.417 +07:00 [DBG] Attempting to select an output formatter without using a content type as no explicit content types were specified for the response.
+2025-09-29 03:54:38.417 +07:00 [DBG] Attempting to select the first formatter in the output formatters list which can write the result.
+2025-09-29 03:54:38.417 +07:00 [DBG] Creating DbConnection.
+2025-09-29 03:54:38.420 +07:00 [DBG] Selected output formatter 'Microsoft.AspNetCore.Mvc.Formatters.SystemTextJsonOutputFormatter' and content type 'application/json' to write the response.
+2025-09-29 03:54:38.420 +07:00 [DBG] Created DbConnection. (2ms).
+2025-09-29 03:54:38.420 +07:00 [INF] Executing ObjectResult, writing value of type 'FS.Commons.FSResponse'.
+2025-09-29 03:54:38.420 +07:00 [DBG] Opening connection to database 'capbot_db' on server 'localhost'.
+2025-09-29 03:54:38.420 +07:00 [DBG] Opened connection to database 'capbot_db' on server 'localhost'.
+2025-09-29 03:54:38.420 +07:00 [DBG] Creating DbCommand for 'ExecuteReader'.
+2025-09-29 03:54:38.420 +07:00 [INF] Executed action CapBot.api.Controllers.UserProfileController.GetMyProfile (CapBot.api) in 12.1548ms
+2025-09-29 03:54:38.420 +07:00 [DBG] Created DbCommand for 'ExecuteReader' (0ms).
+2025-09-29 03:54:38.420 +07:00 [INF] Executed endpoint 'CapBot.api.Controllers.UserProfileController.GetMyProfile (CapBot.api)'
+2025-09-29 03:54:38.420 +07:00 [DBG] Initialized DbCommand for 'ExecuteReader' (0ms).
+2025-09-29 03:54:38.420 +07:00 [DBG] Executing DbCommand [Parameters=[], CommandType='"Text"', CommandTimeout='30']
+SELECT COUNT(*)
+FROM [submissions] AS [s]
+2025-09-29 03:54:38.420 +07:00 [DBG] Connection id "0HNFUQ4FJ9UMK" completed keep alive response.
+2025-09-29 03:54:38.424 +07:00 [DBG] 'MyDbContext' disposed.
+2025-09-29 03:54:38.424 +07:00 [DBG] Disposing connection to database 'capbot_db' on server 'localhost'.
+2025-09-29 03:54:38.424 +07:00 [DBG] Disposed connection to database '' on server '' (0ms).
+2025-09-29 03:54:38.424 +07:00 [INF] Request finished HTTP/1.1 GET http://localhost:5207/api/user-profiles/me - 200 null application/json; charset=utf-8 17.8327ms
+2025-09-29 03:54:38.425 +07:00 [INF] Executed DbCommand (4ms) [Parameters=[], CommandType='"Text"', CommandTimeout='30']
+SELECT COUNT(*)
+FROM [submissions] AS [s]
+2025-09-29 03:54:38.425 +07:00 [DBG] Closing data reader to 'capbot_db' on server 'localhost'.
+2025-09-29 03:54:38.425 +07:00 [DBG] A data reader for 'capbot_db' on server 'localhost' is being disposed after spending 0ms reading results.
+2025-09-29 03:54:38.425 +07:00 [DBG] Closing connection to database 'capbot_db' on server 'localhost'.
+2025-09-29 03:54:38.425 +07:00 [DBG] Closed connection to database 'capbot_db' on server 'localhost' (0ms).
+2025-09-29 03:54:38.426 +07:00 [DBG] Opening connection to database 'capbot_db' on server 'localhost'.
+2025-09-29 03:54:38.426 +07:00 [DBG] Opened connection to database 'capbot_db' on server 'localhost'.
+2025-09-29 03:54:38.427 +07:00 [DBG] Creating DbCommand for 'ExecuteReader'.
+2025-09-29 03:54:38.427 +07:00 [DBG] Created DbCommand for 'ExecuteReader' (0ms).
+2025-09-29 03:54:38.427 +07:00 [DBG] Initialized DbCommand for 'ExecuteReader' (0ms).
+2025-09-29 03:54:38.427 +07:00 [DBG] Executing DbCommand [Parameters=[@__p_0='?' (DbType = Int32), @__p_1='?' (DbType = Int32)], CommandType='"Text"', CommandTimeout='30']
+SELECT [t].[Id], [t].[AdditionalNotes], [t].[AiCheckDetails], [t].[AiCheckScore], [t].[AiCheckStatus], [t].[CreatedAt], [t].[CreatedBy], [t].[DeletedAt], [t].[DocumentUrl], [t].[IsActive], [t].[LastModifiedAt], [t].[LastModifiedBy], [t].[PhaseId], [t].[Status], [t].[SubmissionRound], [t].[SubmittedAt], [t].[SubmittedBy], [t].[TopicId], [t].[TopicVersionId], [u].[Id], [u].[AccessFailedCount], [u].[ConcurrencyStamp], [u].[CreatedAt], [u].[DeletedAt], [u].[Email], [u].[EmailConfirmed], [u].[LastModifiedAt], [u].[LastModifiedBy], [u].[LockoutEnabled], [u].[LockoutEnd], [u].[NormalizedEmail], [u].[NormalizedUserName], [u].[PasswordHash], [u].[PhoneNumber], [u].[PhoneNumberConfirmed], [u].[SecurityStamp], [u].[TwoFactorEnabled], [u].[UserName], [t0].[Id], [t0].[Abbreviation], [t0].[CategoryId], [t0].[Content], [t0].[Context], [t0].[CreatedAt], [t0].[CreatedBy], [t0].[DeletedAt], [t0].[Description], [t0].[EN_Title], [t0].[IsActive], [t0].[IsApproved], [t0].[IsLegacy], [t0].[LastModifiedAt], [t0].[LastModifiedBy], [t0].[MaxStudents], [t0].[Objectives], [t0].[PotentialDuplicate], [t0].[Problem], [t0].[SemesterId], [t0].[SupervisorId], [t0].[VN_title]
+FROM (
+    SELECT [s].[Id], [s].[AdditionalNotes], [s].[AiCheckDetails], [s].[AiCheckScore], [s].[AiCheckStatus], [s].[CreatedAt], [s].[CreatedBy], [s].[DeletedAt], [s].[DocumentUrl], [s].[IsActive], [s].[LastModifiedAt], [s].[LastModifiedBy], [s].[PhaseId], [s].[Status], [s].[SubmissionRound], [s].[SubmittedAt], [s].[SubmittedBy], [s].[TopicId], [s].[TopicVersionId]
+    FROM [submissions] AS [s]
+    ORDER BY [s].[SubmittedAt] DESC
+    OFFSET @__p_0 ROWS FETCH NEXT @__p_1 ROWS ONLY
+) AS [t]
+INNER JOIN [users] AS [u] ON [t].[SubmittedBy] = [u].[Id]
+LEFT JOIN [topics] AS [t0] ON [t].[TopicId] = [t0].[Id]
+ORDER BY [t].[SubmittedAt] DESC
+2025-09-29 03:54:38.431 +07:00 [INF] Executed DbCommand (4ms) [Parameters=[@__p_0='?' (DbType = Int32), @__p_1='?' (DbType = Int32)], CommandType='"Text"', CommandTimeout='30']
+SELECT [t].[Id], [t].[AdditionalNotes], [t].[AiCheckDetails], [t].[AiCheckScore], [t].[AiCheckStatus], [t].[CreatedAt], [t].[CreatedBy], [t].[DeletedAt], [t].[DocumentUrl], [t].[IsActive], [t].[LastModifiedAt], [t].[LastModifiedBy], [t].[PhaseId], [t].[Status], [t].[SubmissionRound], [t].[SubmittedAt], [t].[SubmittedBy], [t].[TopicId], [t].[TopicVersionId], [u].[Id], [u].[AccessFailedCount], [u].[ConcurrencyStamp], [u].[CreatedAt], [u].[DeletedAt], [u].[Email], [u].[EmailConfirmed], [u].[LastModifiedAt], [u].[LastModifiedBy], [u].[LockoutEnabled], [u].[LockoutEnd], [u].[NormalizedEmail], [u].[NormalizedUserName], [u].[PasswordHash], [u].[PhoneNumber], [u].[PhoneNumberConfirmed], [u].[SecurityStamp], [u].[TwoFactorEnabled], [u].[UserName], [t0].[Id], [t0].[Abbreviation], [t0].[CategoryId], [t0].[Content], [t0].[Context], [t0].[CreatedAt], [t0].[CreatedBy], [t0].[DeletedAt], [t0].[Description], [t0].[EN_Title], [t0].[IsActive], [t0].[IsApproved], [t0].[IsLegacy], [t0].[LastModifiedAt], [t0].[LastModifiedBy], [t0].[MaxStudents], [t0].[Objectives], [t0].[PotentialDuplicate], [t0].[Problem], [t0].[SemesterId], [t0].[SupervisorId], [t0].[VN_title]
+FROM (
+    SELECT [s].[Id], [s].[AdditionalNotes], [s].[AiCheckDetails], [s].[AiCheckScore], [s].[AiCheckStatus], [s].[CreatedAt], [s].[CreatedBy], [s].[DeletedAt], [s].[DocumentUrl], [s].[IsActive], [s].[LastModifiedAt], [s].[LastModifiedBy], [s].[PhaseId], [s].[Status], [s].[SubmissionRound], [s].[SubmittedAt], [s].[SubmittedBy], [s].[TopicId], [s].[TopicVersionId]
+    FROM [submissions] AS [s]
+    ORDER BY [s].[SubmittedAt] DESC
+    OFFSET @__p_0 ROWS FETCH NEXT @__p_1 ROWS ONLY
+) AS [t]
+INNER JOIN [users] AS [u] ON [t].[SubmittedBy] = [u].[Id]
+LEFT JOIN [topics] AS [t0] ON [t].[TopicId] = [t0].[Id]
+ORDER BY [t].[SubmittedAt] DESC
+2025-09-29 03:54:38.436 +07:00 [DBG] Closing data reader to 'capbot_db' on server 'localhost'.
+2025-09-29 03:54:38.436 +07:00 [DBG] A data reader for 'capbot_db' on server 'localhost' is being disposed after spending 0ms reading results.
+2025-09-29 03:54:38.436 +07:00 [DBG] Closing connection to database 'capbot_db' on server 'localhost'.
+2025-09-29 03:54:38.436 +07:00 [DBG] Closed connection to database 'capbot_db' on server 'localhost' (0ms).
+2025-09-29 03:54:38.436 +07:00 [DBG] List of registered output formatters, in the following order: ["Microsoft.AspNetCore.OData.Formatter.ODataOutputFormatter","Microsoft.AspNetCore.OData.Formatter.ODataOutputFormatter","Microsoft.AspNetCore.OData.Formatter.ODataOutputFormatter","Microsoft.AspNetCore.Mvc.Formatters.HttpNoContentOutputFormatter","Microsoft.AspNetCore.Mvc.Formatters.StringOutputFormatter","Microsoft.AspNetCore.Mvc.Formatters.StreamOutputFormatter","Microsoft.AspNetCore.Mvc.Formatters.SystemTextJsonOutputFormatter"]
+2025-09-29 03:54:38.436 +07:00 [INF] Request starting HTTP/1.1 GET http://localhost:5207/images/entities/11111111.png - null null
+2025-09-29 03:54:38.436 +07:00 [DBG] No information found on request to perform content negotiation.
+2025-09-29 03:54:38.437 +07:00 [DBG] Attempting to select the first output formatter in the output formatters list which supports a content type from the explicitly specified content types '["application/json"]'.
+2025-09-29 03:54:38.437 +07:00 [DBG] The request path /images/entities/11111111.png does not match an existing file
+2025-09-29 03:54:38.437 +07:00 [DBG] Selected output formatter 'Microsoft.AspNetCore.Mvc.Formatters.SystemTextJsonOutputFormatter' and content type 'application/json' to write the response.
+2025-09-29 03:54:38.437 +07:00 [INF] Executing ObjectResult, writing value of type 'FS.Commons.FSResponse'.
+2025-09-29 03:54:38.437 +07:00 [DBG] The request path /images/entities/11111111.png does not match an existing file
+2025-09-29 03:54:38.437 +07:00 [DBG] No candidates found for the request path '/images/entities/11111111.png'
+2025-09-29 03:54:38.437 +07:00 [DBG] Request did not match any endpoints
+2025-09-29 03:54:38.438 +07:00 [DBG] AuthenticationScheme: Bearer was not authenticated.
+2025-09-29 03:54:38.438 +07:00 [INF] Executed action CapBot.api.Controllers.SubmissionController.List (CapBot.api) in 29.5932ms
+2025-09-29 03:54:38.439 +07:00 [DBG] Connection id "0HNFUQ4FJ9UMI" completed keep alive response.
+2025-09-29 03:54:38.440 +07:00 [INF] Request finished HTTP/1.1 GET http://localhost:5207/images/entities/11111111.png - 404 0 null 3.1986ms
+2025-09-29 03:54:38.440 +07:00 [INF] Request reached the end of the middleware pipeline without being handled by application code. Request path: GET http://localhost:5207/images/entities/11111111.png, Response status code: 404
+2025-09-29 03:54:38.439 +07:00 [INF] Executed endpoint 'CapBot.api.Controllers.SubmissionController.List (CapBot.api)'
+2025-09-29 03:54:38.440 +07:00 [DBG] Connection id "0HNFUQ4FJ9UML" completed keep alive response.
+2025-09-29 03:54:38.440 +07:00 [DBG] 'MyDbContext' disposed.
+2025-09-29 03:54:38.440 +07:00 [DBG] Disposing connection to database 'capbot_db' on server 'localhost'.
+2025-09-29 03:54:38.440 +07:00 [DBG] Disposed connection to database '' on server '' (0ms).
+2025-09-29 03:54:38.441 +07:00 [INF] Request finished HTTP/1.1 GET http://localhost:5207/api/submission/list?PageNumber=1&PageSize=10 - 200 null application/json; charset=utf-8 34.4996ms
+2025-09-29 03:54:39.752 +07:00 [INF] Request starting HTTP/1.1 GET http://localhost:5207/api/user-profiles/me - null null
+2025-09-29 03:54:39.753 +07:00 [INF] Request starting HTTP/1.1 GET http://localhost:5207/api/submission/list?PageNumber=1&PageSize=10 - null null
+2025-09-29 03:54:39.753 +07:00 [DBG] The request path /api/submission/list does not match a supported file type
+2025-09-29 03:54:39.753 +07:00 [DBG] The request path /api/user-profiles/me does not match a supported file type
+2025-09-29 03:54:39.753 +07:00 [DBG] The request path /api/submission/list does not match a supported file type
+2025-09-29 03:54:39.753 +07:00 [DBG] The request path /api/user-profiles/me does not match a supported file type
+2025-09-29 03:54:39.753 +07:00 [DBG] The request has an origin header: 'http://localhost:3000'.
+2025-09-29 03:54:39.753 +07:00 [INF] CORS policy execution successful.
+2025-09-29 03:54:39.753 +07:00 [DBG] The request has an origin header: 'http://localhost:3000'.
+2025-09-29 03:54:39.753 +07:00 [INF] CORS policy execution successful.
+2025-09-29 03:54:39.753 +07:00 [DBG] 2 candidate(s) found for the request path '/api/user-profiles/me'
+2025-09-29 03:54:39.753 +07:00 [DBG] 1 candidate(s) found for the request path '/api/submission/list'
+2025-09-29 03:54:39.753 +07:00 [DBG] Endpoint 'CapBot.api.Controllers.UserProfileController.GetMyProfile (CapBot.api)' with route pattern 'api/user-profiles/me' is valid for the request path '/api/user-profiles/me'
+2025-09-29 03:54:39.753 +07:00 [DBG] Endpoint 'CapBot.api.Controllers.UserProfileController.GetById (CapBot.api)' with route pattern 'api/user-profiles/{id}' is valid for the request path '/api/user-profiles/me'
+2025-09-29 03:54:39.754 +07:00 [DBG] Request matched endpoint 'CapBot.api.Controllers.UserProfileController.GetMyProfile (CapBot.api)'
+2025-09-29 03:54:39.754 +07:00 [DBG] Endpoint 'CapBot.api.Controllers.SubmissionController.List (CapBot.api)' with route pattern 'api/submission/list' is valid for the request path '/api/submission/list'
+2025-09-29 03:54:39.754 +07:00 [DBG] Request matched endpoint 'CapBot.api.Controllers.SubmissionController.List (CapBot.api)'
+2025-09-29 03:54:39.754 +07:00 [DBG] Successfully validated the token.
+2025-09-29 03:54:39.754 +07:00 [DBG] AuthenticationScheme: Bearer was successfully authenticated.
+2025-09-29 03:54:39.754 +07:00 [DBG] Successfully validated the token.
+2025-09-29 03:54:39.754 +07:00 [DBG] AuthenticationScheme: Bearer was successfully authenticated.
+2025-09-29 03:54:39.754 +07:00 [DBG] Authorization was successful.
+2025-09-29 03:54:39.754 +07:00 [DBG] Authorization was successful.
+2025-09-29 03:54:39.754 +07:00 [INF] Executing endpoint 'CapBot.api.Controllers.UserProfileController.GetMyProfile (CapBot.api)'
+2025-09-29 03:54:39.754 +07:00 [INF] Executing endpoint 'CapBot.api.Controllers.SubmissionController.List (CapBot.api)'
+2025-09-29 03:54:39.754 +07:00 [INF] Route matched with {action = "List", controller = "Submission"}. Executing controller action with signature System.Threading.Tasks.Task`1[Microsoft.AspNetCore.Mvc.IActionResult] List(App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO) on controller CapBot.api.Controllers.SubmissionController (CapBot.api).
+2025-09-29 03:54:39.754 +07:00 [INF] Route matched with {action = "GetMyProfile", controller = "UserProfile"}. Executing controller action with signature System.Threading.Tasks.Task`1[Microsoft.AspNetCore.Mvc.IActionResult] GetMyProfile() on controller CapBot.api.Controllers.UserProfileController (CapBot.api).
+2025-09-29 03:54:39.754 +07:00 [DBG] Execution plan of authorization filters (in the following order): ["None"]
+2025-09-29 03:54:39.754 +07:00 [DBG] Execution plan of authorization filters (in the following order): ["None"]
+2025-09-29 03:54:39.754 +07:00 [DBG] Execution plan of resource filters (in the following order): ["None"]
+2025-09-29 03:54:39.754 +07:00 [DBG] Execution plan of resource filters (in the following order): ["None"]
+2025-09-29 03:54:39.754 +07:00 [DBG] Execution plan of action filters (in the following order): ["Microsoft.AspNetCore.Mvc.ModelBinding.UnsupportedContentTypeFilter (Order: -3000)"]
+2025-09-29 03:54:39.754 +07:00 [DBG] Execution plan of action filters (in the following order): ["Microsoft.AspNetCore.Mvc.ModelBinding.UnsupportedContentTypeFilter (Order: -3000)"]
+2025-09-29 03:54:39.754 +07:00 [DBG] Execution plan of exception filters (in the following order): ["None"]
+2025-09-29 03:54:39.754 +07:00 [DBG] Execution plan of exception filters (in the following order): ["None"]
+2025-09-29 03:54:39.754 +07:00 [DBG] Execution plan of result filters (in the following order): ["Microsoft.AspNetCore.Mvc.Infrastructure.ClientErrorResultFilter (Order: -2000)","Microsoft.AspNetCore.Mvc.ProducesAttribute (Order: 0)"]
+2025-09-29 03:54:39.754 +07:00 [DBG] Execution plan of result filters (in the following order): ["Microsoft.AspNetCore.Mvc.Infrastructure.ClientErrorResultFilter (Order: -2000)"]
+2025-09-29 03:54:39.754 +07:00 [DBG] Executing controller factory for controller CapBot.api.Controllers.SubmissionController (CapBot.api)
+2025-09-29 03:54:39.754 +07:00 [DBG] Executing controller factory for controller CapBot.api.Controllers.UserProfileController (CapBot.api)
+2025-09-29 03:54:39.754 +07:00 [DBG] Executed controller factory for controller CapBot.api.Controllers.UserProfileController (CapBot.api)
+2025-09-29 03:54:39.754 +07:00 [DBG] Executed controller factory for controller CapBot.api.Controllers.SubmissionController (CapBot.api)
+2025-09-29 03:54:39.754 +07:00 [DBG] Attempting to bind parameter 'query' of type 'App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO' ...
+2025-09-29 03:54:39.755 +07:00 [DBG] Attempting to bind parameter 'query' of type 'App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO' using the name '' in request data ...
+2025-09-29 03:54:39.755 +07:00 [DBG] Entity Framework Core 8.0.16 initialized 'MyDbContext' using provider 'Microsoft.EntityFrameworkCore.SqlServer:8.0.13' with options: MigrationsAssembly=App.DAL 
+2025-09-29 03:54:39.756 +07:00 [DBG] Attempting to bind property 'App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO.TopicVersionId' of type 'System.Nullable`1[System.Int32]' using the name 'TopicVersionId' in request data ...
+2025-09-29 03:54:39.756 +07:00 [DBG] Could not find a value in the request with name 'TopicVersionId' for binding property 'App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO.TopicVersionId' of type 'System.Nullable`1[System.Int32]'.
+2025-09-29 03:54:39.756 +07:00 [DBG] Done attempting to bind property 'App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO.TopicVersionId' of type 'System.Nullable`1[System.Int32]'.
+2025-09-29 03:54:39.756 +07:00 [DBG] Attempting to bind property 'App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO.PhaseId' of type 'System.Nullable`1[System.Int32]' using the name 'PhaseId' in request data ...
+2025-09-29 03:54:39.756 +07:00 [DBG] Creating DbConnection.
+2025-09-29 03:54:39.760 +07:00 [DBG] Could not find a value in the request with name 'PhaseId' for binding property 'App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO.PhaseId' of type 'System.Nullable`1[System.Int32]'.
+2025-09-29 03:54:39.761 +07:00 [DBG] Done attempting to bind property 'App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO.PhaseId' of type 'System.Nullable`1[System.Int32]'.
+2025-09-29 03:54:39.761 +07:00 [DBG] Attempting to bind property 'App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO.SemesterId' of type 'System.Nullable`1[System.Int32]' using the name 'SemesterId' in request data ...
+2025-09-29 03:54:39.761 +07:00 [DBG] Created DbConnection. (4ms).
+2025-09-29 03:54:39.761 +07:00 [DBG] Could not find a value in the request with name 'SemesterId' for binding property 'App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO.SemesterId' of type 'System.Nullable`1[System.Int32]'.
+2025-09-29 03:54:39.761 +07:00 [DBG] Done attempting to bind property 'App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO.SemesterId' of type 'System.Nullable`1[System.Int32]'.
+2025-09-29 03:54:39.761 +07:00 [DBG] Opening connection to database 'capbot_db' on server 'localhost'.
+2025-09-29 03:54:39.763 +07:00 [DBG] Attempting to bind property 'App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO.Status' of type 'System.Nullable`1[App.Entities.Enums.SubmissionStatus]' using the name 'Status' in request data ...
+2025-09-29 03:54:39.763 +07:00 [DBG] Could not find a value in the request with name 'Status' for binding property 'App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO.Status' of type 'System.Nullable`1[App.Entities.Enums.SubmissionStatus]'.
+2025-09-29 03:54:39.763 +07:00 [DBG] Opened connection to database 'capbot_db' on server 'localhost'.
+2025-09-29 03:54:39.763 +07:00 [DBG] Done attempting to bind property 'App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO.Status' of type 'System.Nullable`1[App.Entities.Enums.SubmissionStatus]'.
+2025-09-29 03:54:39.763 +07:00 [DBG] Creating DbCommand for 'ExecuteReader'.
+2025-09-29 03:54:39.763 +07:00 [DBG] Attempting to bind property 'App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO.PageNumber' of type 'System.Int32' using the name 'PageNumber' in request data ...
+2025-09-29 03:54:39.763 +07:00 [DBG] Created DbCommand for 'ExecuteReader' (0ms).
+2025-09-29 03:54:39.763 +07:00 [DBG] Done attempting to bind property 'App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO.PageNumber' of type 'System.Int32'.
+2025-09-29 03:54:39.763 +07:00 [DBG] Initialized DbCommand for 'ExecuteReader' (0ms).
+2025-09-29 03:54:39.763 +07:00 [DBG] Attempting to bind property 'App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO.PageSize' of type 'System.Int32' using the name 'PageSize' in request data ...
+2025-09-29 03:54:39.763 +07:00 [DBG] Done attempting to bind property 'App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO.PageSize' of type 'System.Int32'.
+2025-09-29 03:54:39.763 +07:00 [DBG] Executing DbCommand [Parameters=[@__targetUserId_0='?' (DbType = Int32)], CommandType='"Text"', CommandTimeout='30']
+SELECT TOP(1) [p].[Id], [p].[Address], [p].[Avatar], [p].[CoverImage], [p].[CreatedAt], [p].[CreatedBy], [p].[DeletedAt], [p].[FullName], [p].[IsActive], [p].[LastModifiedAt], [p].[LastModifiedBy], [p].[UserId]
+FROM [profiles] AS [p]
+WHERE [p].[UserId] = @__targetUserId_0 AND [p].[IsActive] = CAST(1 AS bit) AND [p].[DeletedAt] IS NULL AND [p].[DeletedAt] IS NULL
+2025-09-29 03:54:39.763 +07:00 [DBG] Attempting to bind property 'App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO.Keyword' of type 'System.String' using the name 'Keyword' in request data ...
+2025-09-29 03:54:39.764 +07:00 [DBG] Could not find a value in the request with name 'Keyword' for binding property 'App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO.Keyword' of type 'System.String'.
+2025-09-29 03:54:39.764 +07:00 [DBG] Done attempting to bind property 'App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO.Keyword' of type 'System.String'.
+2025-09-29 03:54:39.764 +07:00 [DBG] Attempting to bind property 'App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO.TotalRecord' of type 'System.Int32' using the name 'TotalRecord' in request data ...
+2025-09-29 03:54:39.764 +07:00 [DBG] Could not find a value in the request with name 'TotalRecord' for binding property 'App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO.TotalRecord' of type 'System.Int32'.
+2025-09-29 03:54:39.764 +07:00 [DBG] Done attempting to bind property 'App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO.TotalRecord' of type 'System.Int32'.
+2025-09-29 03:54:39.766 +07:00 [INF] Executed DbCommand (2ms) [Parameters=[@__targetUserId_0='?' (DbType = Int32)], CommandType='"Text"', CommandTimeout='30']
+SELECT TOP(1) [p].[Id], [p].[Address], [p].[Avatar], [p].[CoverImage], [p].[CreatedAt], [p].[CreatedBy], [p].[DeletedAt], [p].[FullName], [p].[IsActive], [p].[LastModifiedAt], [p].[LastModifiedBy], [p].[UserId]
+FROM [profiles] AS [p]
+WHERE [p].[UserId] = @__targetUserId_0 AND [p].[IsActive] = CAST(1 AS bit) AND [p].[DeletedAt] IS NULL AND [p].[DeletedAt] IS NULL
+2025-09-29 03:54:39.767 +07:00 [DBG] Done attempting to bind parameter 'query' of type 'App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO'.
+2025-09-29 03:54:39.767 +07:00 [DBG] Done attempting to bind parameter 'query' of type 'App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO'.
+2025-09-29 03:54:39.767 +07:00 [DBG] Closing data reader to 'capbot_db' on server 'localhost'.
+2025-09-29 03:54:39.767 +07:00 [DBG] Attempting to validate the bound parameter 'query' of type 'App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO' ...
+2025-09-29 03:54:39.767 +07:00 [DBG] A data reader for 'capbot_db' on server 'localhost' is being disposed after spending 0ms reading results.
+2025-09-29 03:54:39.767 +07:00 [DBG] Done attempting to validate the bound parameter 'query' of type 'App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO'.
+2025-09-29 03:54:39.767 +07:00 [DBG] Closing connection to database 'capbot_db' on server 'localhost'.
+2025-09-29 03:54:39.768 +07:00 [DBG] Closed connection to database 'capbot_db' on server 'localhost' (0ms).
+2025-09-29 03:54:39.768 +07:00 [DBG] List of registered output formatters, in the following order: ["Microsoft.AspNetCore.OData.Formatter.ODataOutputFormatter","Microsoft.AspNetCore.OData.Formatter.ODataOutputFormatter","Microsoft.AspNetCore.OData.Formatter.ODataOutputFormatter","Microsoft.AspNetCore.Mvc.Formatters.HttpNoContentOutputFormatter","Microsoft.AspNetCore.Mvc.Formatters.StringOutputFormatter","Microsoft.AspNetCore.Mvc.Formatters.StreamOutputFormatter","Microsoft.AspNetCore.Mvc.Formatters.SystemTextJsonOutputFormatter"]
+2025-09-29 03:54:39.768 +07:00 [DBG] No information found on request to perform content negotiation.
+2025-09-29 03:54:39.768 +07:00 [DBG] Attempting to select an output formatter without using a content type as no explicit content types were specified for the response.
+2025-09-29 03:54:39.768 +07:00 [DBG] Entity Framework Core 8.0.16 initialized 'MyDbContext' using provider 'Microsoft.EntityFrameworkCore.SqlServer:8.0.13' with options: MigrationsAssembly=App.DAL 
+2025-09-29 03:54:39.768 +07:00 [DBG] Attempting to select the first formatter in the output formatters list which can write the result.
+2025-09-29 03:54:39.768 +07:00 [DBG] Selected output formatter 'Microsoft.AspNetCore.Mvc.Formatters.SystemTextJsonOutputFormatter' and content type 'application/json' to write the response.
+2025-09-29 03:54:39.768 +07:00 [INF] Executing ObjectResult, writing value of type 'FS.Commons.FSResponse'.
+2025-09-29 03:54:39.768 +07:00 [DBG] Creating DbConnection.
+2025-09-29 03:54:39.768 +07:00 [DBG] Created DbConnection. (0ms).
+2025-09-29 03:54:39.768 +07:00 [DBG] Opening connection to database 'capbot_db' on server 'localhost'.
+2025-09-29 03:54:39.768 +07:00 [INF] Executed action CapBot.api.Controllers.UserProfileController.GetMyProfile (CapBot.api) in 14.1369ms
+2025-09-29 03:54:39.768 +07:00 [DBG] Opened connection to database 'capbot_db' on server 'localhost'.
+2025-09-29 03:54:39.768 +07:00 [INF] Executed endpoint 'CapBot.api.Controllers.UserProfileController.GetMyProfile (CapBot.api)'
+2025-09-29 03:54:39.769 +07:00 [DBG] Creating DbCommand for 'ExecuteReader'.
+2025-09-29 03:54:39.769 +07:00 [DBG] Connection id "0HNFUQ4FJ9UML" completed keep alive response.
+2025-09-29 03:54:39.769 +07:00 [DBG] Created DbCommand for 'ExecuteReader' (0ms).
+2025-09-29 03:54:39.769 +07:00 [DBG] 'MyDbContext' disposed.
+2025-09-29 03:54:39.769 +07:00 [DBG] Initialized DbCommand for 'ExecuteReader' (0ms).
+2025-09-29 03:54:39.769 +07:00 [DBG] Disposing connection to database 'capbot_db' on server 'localhost'.
+2025-09-29 03:54:39.769 +07:00 [DBG] Executing DbCommand [Parameters=[], CommandType='"Text"', CommandTimeout='30']
+SELECT COUNT(*)
+FROM [submissions] AS [s]
+2025-09-29 03:54:39.769 +07:00 [DBG] Disposed connection to database '' on server '' (0ms).
+2025-09-29 03:54:39.769 +07:00 [INF] Request finished HTTP/1.1 GET http://localhost:5207/api/user-profiles/me - 200 null application/json; charset=utf-8 16.4132ms
+2025-09-29 03:54:39.769 +07:00 [INF] Executed DbCommand (1ms) [Parameters=[], CommandType='"Text"', CommandTimeout='30']
+SELECT COUNT(*)
+FROM [submissions] AS [s]
+2025-09-29 03:54:39.769 +07:00 [DBG] Closing data reader to 'capbot_db' on server 'localhost'.
+2025-09-29 03:54:39.770 +07:00 [DBG] A data reader for 'capbot_db' on server 'localhost' is being disposed after spending 0ms reading results.
+2025-09-29 03:54:39.770 +07:00 [DBG] Closing connection to database 'capbot_db' on server 'localhost'.
+2025-09-29 03:54:39.770 +07:00 [DBG] Closed connection to database 'capbot_db' on server 'localhost' (0ms).
+2025-09-29 03:54:39.770 +07:00 [DBG] Opening connection to database 'capbot_db' on server 'localhost'.
+2025-09-29 03:54:39.770 +07:00 [DBG] Opened connection to database 'capbot_db' on server 'localhost'.
+2025-09-29 03:54:39.770 +07:00 [DBG] Creating DbCommand for 'ExecuteReader'.
+2025-09-29 03:54:39.770 +07:00 [DBG] Created DbCommand for 'ExecuteReader' (0ms).
+2025-09-29 03:54:39.771 +07:00 [DBG] Initialized DbCommand for 'ExecuteReader' (0ms).
+2025-09-29 03:54:39.771 +07:00 [DBG] Executing DbCommand [Parameters=[@__p_0='?' (DbType = Int32), @__p_1='?' (DbType = Int32)], CommandType='"Text"', CommandTimeout='30']
+SELECT [t].[Id], [t].[AdditionalNotes], [t].[AiCheckDetails], [t].[AiCheckScore], [t].[AiCheckStatus], [t].[CreatedAt], [t].[CreatedBy], [t].[DeletedAt], [t].[DocumentUrl], [t].[IsActive], [t].[LastModifiedAt], [t].[LastModifiedBy], [t].[PhaseId], [t].[Status], [t].[SubmissionRound], [t].[SubmittedAt], [t].[SubmittedBy], [t].[TopicId], [t].[TopicVersionId], [u].[Id], [u].[AccessFailedCount], [u].[ConcurrencyStamp], [u].[CreatedAt], [u].[DeletedAt], [u].[Email], [u].[EmailConfirmed], [u].[LastModifiedAt], [u].[LastModifiedBy], [u].[LockoutEnabled], [u].[LockoutEnd], [u].[NormalizedEmail], [u].[NormalizedUserName], [u].[PasswordHash], [u].[PhoneNumber], [u].[PhoneNumberConfirmed], [u].[SecurityStamp], [u].[TwoFactorEnabled], [u].[UserName], [t0].[Id], [t0].[Abbreviation], [t0].[CategoryId], [t0].[Content], [t0].[Context], [t0].[CreatedAt], [t0].[CreatedBy], [t0].[DeletedAt], [t0].[Description], [t0].[EN_Title], [t0].[IsActive], [t0].[IsApproved], [t0].[IsLegacy], [t0].[LastModifiedAt], [t0].[LastModifiedBy], [t0].[MaxStudents], [t0].[Objectives], [t0].[PotentialDuplicate], [t0].[Problem], [t0].[SemesterId], [t0].[SupervisorId], [t0].[VN_title]
+FROM (
+    SELECT [s].[Id], [s].[AdditionalNotes], [s].[AiCheckDetails], [s].[AiCheckScore], [s].[AiCheckStatus], [s].[CreatedAt], [s].[CreatedBy], [s].[DeletedAt], [s].[DocumentUrl], [s].[IsActive], [s].[LastModifiedAt], [s].[LastModifiedBy], [s].[PhaseId], [s].[Status], [s].[SubmissionRound], [s].[SubmittedAt], [s].[SubmittedBy], [s].[TopicId], [s].[TopicVersionId]
+    FROM [submissions] AS [s]
+    ORDER BY [s].[SubmittedAt] DESC
+    OFFSET @__p_0 ROWS FETCH NEXT @__p_1 ROWS ONLY
+) AS [t]
+INNER JOIN [users] AS [u] ON [t].[SubmittedBy] = [u].[Id]
+LEFT JOIN [topics] AS [t0] ON [t].[TopicId] = [t0].[Id]
+ORDER BY [t].[SubmittedAt] DESC
+2025-09-29 03:54:39.777 +07:00 [INF] Executed DbCommand (6ms) [Parameters=[@__p_0='?' (DbType = Int32), @__p_1='?' (DbType = Int32)], CommandType='"Text"', CommandTimeout='30']
+SELECT [t].[Id], [t].[AdditionalNotes], [t].[AiCheckDetails], [t].[AiCheckScore], [t].[AiCheckStatus], [t].[CreatedAt], [t].[CreatedBy], [t].[DeletedAt], [t].[DocumentUrl], [t].[IsActive], [t].[LastModifiedAt], [t].[LastModifiedBy], [t].[PhaseId], [t].[Status], [t].[SubmissionRound], [t].[SubmittedAt], [t].[SubmittedBy], [t].[TopicId], [t].[TopicVersionId], [u].[Id], [u].[AccessFailedCount], [u].[ConcurrencyStamp], [u].[CreatedAt], [u].[DeletedAt], [u].[Email], [u].[EmailConfirmed], [u].[LastModifiedAt], [u].[LastModifiedBy], [u].[LockoutEnabled], [u].[LockoutEnd], [u].[NormalizedEmail], [u].[NormalizedUserName], [u].[PasswordHash], [u].[PhoneNumber], [u].[PhoneNumberConfirmed], [u].[SecurityStamp], [u].[TwoFactorEnabled], [u].[UserName], [t0].[Id], [t0].[Abbreviation], [t0].[CategoryId], [t0].[Content], [t0].[Context], [t0].[CreatedAt], [t0].[CreatedBy], [t0].[DeletedAt], [t0].[Description], [t0].[EN_Title], [t0].[IsActive], [t0].[IsApproved], [t0].[IsLegacy], [t0].[LastModifiedAt], [t0].[LastModifiedBy], [t0].[MaxStudents], [t0].[Objectives], [t0].[PotentialDuplicate], [t0].[Problem], [t0].[SemesterId], [t0].[SupervisorId], [t0].[VN_title]
+FROM (
+    SELECT [s].[Id], [s].[AdditionalNotes], [s].[AiCheckDetails], [s].[AiCheckScore], [s].[AiCheckStatus], [s].[CreatedAt], [s].[CreatedBy], [s].[DeletedAt], [s].[DocumentUrl], [s].[IsActive], [s].[LastModifiedAt], [s].[LastModifiedBy], [s].[PhaseId], [s].[Status], [s].[SubmissionRound], [s].[SubmittedAt], [s].[SubmittedBy], [s].[TopicId], [s].[TopicVersionId]
+    FROM [submissions] AS [s]
+    ORDER BY [s].[SubmittedAt] DESC
+    OFFSET @__p_0 ROWS FETCH NEXT @__p_1 ROWS ONLY
+) AS [t]
+INNER JOIN [users] AS [u] ON [t].[SubmittedBy] = [u].[Id]
+LEFT JOIN [topics] AS [t0] ON [t].[TopicId] = [t0].[Id]
+ORDER BY [t].[SubmittedAt] DESC
+2025-09-29 03:54:39.789 +07:00 [DBG] Closing data reader to 'capbot_db' on server 'localhost'.
+2025-09-29 03:54:39.789 +07:00 [DBG] A data reader for 'capbot_db' on server 'localhost' is being disposed after spending 0ms reading results.
+2025-09-29 03:54:39.789 +07:00 [DBG] Closing connection to database 'capbot_db' on server 'localhost'.
+2025-09-29 03:54:39.789 +07:00 [DBG] Closed connection to database 'capbot_db' on server 'localhost' (0ms).
+2025-09-29 03:54:39.789 +07:00 [DBG] List of registered output formatters, in the following order: ["Microsoft.AspNetCore.OData.Formatter.ODataOutputFormatter","Microsoft.AspNetCore.OData.Formatter.ODataOutputFormatter","Microsoft.AspNetCore.OData.Formatter.ODataOutputFormatter","Microsoft.AspNetCore.Mvc.Formatters.HttpNoContentOutputFormatter","Microsoft.AspNetCore.Mvc.Formatters.StringOutputFormatter","Microsoft.AspNetCore.Mvc.Formatters.StreamOutputFormatter","Microsoft.AspNetCore.Mvc.Formatters.SystemTextJsonOutputFormatter"]
+2025-09-29 03:54:39.796 +07:00 [DBG] No information found on request to perform content negotiation.
+2025-09-29 03:54:39.796 +07:00 [DBG] Attempting to select the first output formatter in the output formatters list which supports a content type from the explicitly specified content types '["application/json"]'.
+2025-09-29 03:54:39.791 +07:00 [INF] Request starting HTTP/1.1 GET http://localhost:5207/images/entities/11111111.png - null null
+2025-09-29 03:54:39.797 +07:00 [DBG] Selected output formatter 'Microsoft.AspNetCore.Mvc.Formatters.SystemTextJsonOutputFormatter' and content type 'application/json' to write the response.
+2025-09-29 03:54:39.797 +07:00 [INF] Executing ObjectResult, writing value of type 'FS.Commons.FSResponse'.
+2025-09-29 03:54:39.797 +07:00 [DBG] The request path /images/entities/11111111.png does not match an existing file
+2025-09-29 03:54:39.797 +07:00 [INF] Executed action CapBot.api.Controllers.SubmissionController.List (CapBot.api) in 42.8414ms
+2025-09-29 03:54:39.799 +07:00 [INF] Executed endpoint 'CapBot.api.Controllers.SubmissionController.List (CapBot.api)'
+2025-09-29 03:54:39.799 +07:00 [DBG] The request path /images/entities/11111111.png does not match an existing file
+2025-09-29 03:54:39.800 +07:00 [DBG] Connection id "0HNFUQ4FJ9UMK" completed keep alive response.
+2025-09-29 03:54:39.800 +07:00 [DBG] No candidates found for the request path '/images/entities/11111111.png'
+2025-09-29 03:54:39.800 +07:00 [DBG] 'MyDbContext' disposed.
+2025-09-29 03:54:39.800 +07:00 [DBG] Request did not match any endpoints
+2025-09-29 03:54:39.800 +07:00 [DBG] Disposing connection to database 'capbot_db' on server 'localhost'.
+2025-09-29 03:54:39.800 +07:00 [DBG] Disposed connection to database '' on server '' (0ms).
+2025-09-29 03:54:39.800 +07:00 [DBG] AuthenticationScheme: Bearer was not authenticated.
+2025-09-29 03:54:39.800 +07:00 [INF] Request finished HTTP/1.1 GET http://localhost:5207/api/submission/list?PageNumber=1&PageSize=10 - 200 null application/json; charset=utf-8 47.2047ms
+2025-09-29 03:54:39.800 +07:00 [DBG] Connection id "0HNFUQ4FJ9UMI" completed keep alive response.
+2025-09-29 03:54:39.803 +07:00 [INF] Request finished HTTP/1.1 GET http://localhost:5207/images/entities/11111111.png - 404 0 null 11.7269ms
+2025-09-29 03:54:39.803 +07:00 [INF] Request reached the end of the middleware pipeline without being handled by application code. Request path: GET http://localhost:5207/images/entities/11111111.png, Response status code: 404
+2025-09-29 03:54:45.601 +07:00 [INF] Request starting HTTP/1.1 OPTIONS http://localhost:5207/api/user-profiles/me - null null
+2025-09-29 03:54:45.601 +07:00 [DBG] OPTIONS requests are not supported
+2025-09-29 03:54:45.601 +07:00 [DBG] OPTIONS requests are not supported
+2025-09-29 03:54:45.601 +07:00 [DBG] The request has an origin header: 'http://localhost:3000'.
+2025-09-29 03:54:45.601 +07:00 [INF] CORS policy execution successful.
+2025-09-29 03:54:45.601 +07:00 [DBG] The request is a preflight request.
+2025-09-29 03:54:45.605 +07:00 [DBG] Connection id "0HNFUQ4FJ9UMK" completed keep alive response.
+2025-09-29 03:54:45.605 +07:00 [INF] Request finished HTTP/1.1 OPTIONS http://localhost:5207/api/user-profiles/me - 204 null null 4.4142ms
+2025-09-29 03:54:45.607 +07:00 [INF] Request starting HTTP/1.1 OPTIONS http://localhost:5207/api/submission/list?PageNumber=1&PageSize=10 - null null
+2025-09-29 03:54:45.607 +07:00 [DBG] OPTIONS requests are not supported
+2025-09-29 03:54:45.607 +07:00 [DBG] OPTIONS requests are not supported
+2025-09-29 03:54:45.608 +07:00 [DBG] The request has an origin header: 'http://localhost:3000'.
+2025-09-29 03:54:45.608 +07:00 [INF] CORS policy execution successful.
+2025-09-29 03:54:45.608 +07:00 [DBG] The request is a preflight request.
+2025-09-29 03:54:45.608 +07:00 [DBG] Connection id "0HNFUQ4FJ9UML" completed keep alive response.
+2025-09-29 03:54:45.608 +07:00 [INF] Request finished HTTP/1.1 OPTIONS http://localhost:5207/api/submission/list?PageNumber=1&PageSize=10 - 204 null null 1.7474ms
+2025-09-29 03:54:45.610 +07:00 [INF] Request starting HTTP/1.1 GET http://localhost:5207/api/user-profiles/me - null null
+2025-09-29 03:54:45.611 +07:00 [DBG] The request path /api/user-profiles/me does not match a supported file type
+2025-09-29 03:54:45.611 +07:00 [DBG] The request path /api/user-profiles/me does not match a supported file type
+2025-09-29 03:54:45.611 +07:00 [DBG] The request has an origin header: 'http://localhost:3000'.
+2025-09-29 03:54:45.611 +07:00 [INF] CORS policy execution successful.
+2025-09-29 03:54:45.611 +07:00 [DBG] 2 candidate(s) found for the request path '/api/user-profiles/me'
+2025-09-29 03:54:45.611 +07:00 [DBG] Endpoint 'CapBot.api.Controllers.UserProfileController.GetMyProfile (CapBot.api)' with route pattern 'api/user-profiles/me' is valid for the request path '/api/user-profiles/me'
+2025-09-29 03:54:45.611 +07:00 [DBG] Endpoint 'CapBot.api.Controllers.UserProfileController.GetById (CapBot.api)' with route pattern 'api/user-profiles/{id}' is valid for the request path '/api/user-profiles/me'
+2025-09-29 03:54:45.611 +07:00 [DBG] Request matched endpoint 'CapBot.api.Controllers.UserProfileController.GetMyProfile (CapBot.api)'
+2025-09-29 03:54:45.612 +07:00 [DBG] Successfully validated the token.
+2025-09-29 03:54:45.612 +07:00 [DBG] AuthenticationScheme: Bearer was successfully authenticated.
+2025-09-29 03:54:45.612 +07:00 [INF] Request starting HTTP/1.1 GET http://localhost:5207/api/submission/list?PageNumber=1&PageSize=10 - null null
+2025-09-29 03:54:45.612 +07:00 [DBG] The request path /api/submission/list does not match a supported file type
+2025-09-29 03:54:45.612 +07:00 [DBG] The request path /api/submission/list does not match a supported file type
+2025-09-29 03:54:45.612 +07:00 [DBG] The request has an origin header: 'http://localhost:3000'.
+2025-09-29 03:54:45.612 +07:00 [INF] CORS policy execution successful.
+2025-09-29 03:54:45.613 +07:00 [DBG] 1 candidate(s) found for the request path '/api/submission/list'
+2025-09-29 03:54:45.613 +07:00 [DBG] Endpoint 'CapBot.api.Controllers.SubmissionController.List (CapBot.api)' with route pattern 'api/submission/list' is valid for the request path '/api/submission/list'
+2025-09-29 03:54:45.613 +07:00 [DBG] Request matched endpoint 'CapBot.api.Controllers.SubmissionController.List (CapBot.api)'
+2025-09-29 03:54:45.613 +07:00 [DBG] Successfully validated the token.
+2025-09-29 03:54:45.613 +07:00 [DBG] AuthenticationScheme: Bearer was successfully authenticated.
+2025-09-29 03:54:45.613 +07:00 [DBG] Authorization was successful.
+2025-09-29 03:54:45.613 +07:00 [INF] Executing endpoint 'CapBot.api.Controllers.SubmissionController.List (CapBot.api)'
+2025-09-29 03:54:45.613 +07:00 [INF] Route matched with {action = "List", controller = "Submission"}. Executing controller action with signature System.Threading.Tasks.Task`1[Microsoft.AspNetCore.Mvc.IActionResult] List(App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO) on controller CapBot.api.Controllers.SubmissionController (CapBot.api).
+2025-09-29 03:54:45.613 +07:00 [DBG] Execution plan of authorization filters (in the following order): ["None"]
+2025-09-29 03:54:45.613 +07:00 [DBG] Execution plan of resource filters (in the following order): ["None"]
+2025-09-29 03:54:45.613 +07:00 [DBG] Execution plan of action filters (in the following order): ["Microsoft.AspNetCore.Mvc.ModelBinding.UnsupportedContentTypeFilter (Order: -3000)"]
+2025-09-29 03:54:45.613 +07:00 [DBG] Execution plan of exception filters (in the following order): ["None"]
+2025-09-29 03:54:45.613 +07:00 [DBG] Execution plan of result filters (in the following order): ["Microsoft.AspNetCore.Mvc.Infrastructure.ClientErrorResultFilter (Order: -2000)","Microsoft.AspNetCore.Mvc.ProducesAttribute (Order: 0)"]
+2025-09-29 03:54:45.614 +07:00 [DBG] Executing controller factory for controller CapBot.api.Controllers.SubmissionController (CapBot.api)
+2025-09-29 03:54:45.612 +07:00 [DBG] Authorization was successful.
+2025-09-29 03:54:45.614 +07:00 [INF] Executing endpoint 'CapBot.api.Controllers.UserProfileController.GetMyProfile (CapBot.api)'
+2025-09-29 03:54:45.614 +07:00 [DBG] Executed controller factory for controller CapBot.api.Controllers.SubmissionController (CapBot.api)
+2025-09-29 03:54:45.614 +07:00 [INF] Route matched with {action = "GetMyProfile", controller = "UserProfile"}. Executing controller action with signature System.Threading.Tasks.Task`1[Microsoft.AspNetCore.Mvc.IActionResult] GetMyProfile() on controller CapBot.api.Controllers.UserProfileController (CapBot.api).
+2025-09-29 03:54:45.614 +07:00 [DBG] Execution plan of authorization filters (in the following order): ["None"]
+2025-09-29 03:54:45.614 +07:00 [DBG] Attempting to bind parameter 'query' of type 'App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO' ...
+2025-09-29 03:54:45.614 +07:00 [DBG] Execution plan of resource filters (in the following order): ["None"]
+2025-09-29 03:54:45.615 +07:00 [DBG] Execution plan of action filters (in the following order): ["Microsoft.AspNetCore.Mvc.ModelBinding.UnsupportedContentTypeFilter (Order: -3000)"]
+2025-09-29 03:54:45.615 +07:00 [DBG] Execution plan of exception filters (in the following order): ["None"]
+2025-09-29 03:54:45.615 +07:00 [DBG] Execution plan of result filters (in the following order): ["Microsoft.AspNetCore.Mvc.Infrastructure.ClientErrorResultFilter (Order: -2000)"]
+2025-09-29 03:54:45.615 +07:00 [DBG] Executing controller factory for controller CapBot.api.Controllers.UserProfileController (CapBot.api)
+2025-09-29 03:54:45.614 +07:00 [DBG] Attempting to bind parameter 'query' of type 'App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO' using the name '' in request data ...
+2025-09-29 03:54:45.615 +07:00 [DBG] Attempting to bind property 'App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO.TopicVersionId' of type 'System.Nullable`1[System.Int32]' using the name 'TopicVersionId' in request data ...
+2025-09-29 03:54:45.615 +07:00 [DBG] Could not find a value in the request with name 'TopicVersionId' for binding property 'App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO.TopicVersionId' of type 'System.Nullable`1[System.Int32]'.
+2025-09-29 03:54:45.615 +07:00 [DBG] Executed controller factory for controller CapBot.api.Controllers.UserProfileController (CapBot.api)
+2025-09-29 03:54:45.616 +07:00 [DBG] Done attempting to bind property 'App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO.TopicVersionId' of type 'System.Nullable`1[System.Int32]'.
+2025-09-29 03:54:45.616 +07:00 [DBG] Attempting to bind property 'App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO.PhaseId' of type 'System.Nullable`1[System.Int32]' using the name 'PhaseId' in request data ...
+2025-09-29 03:54:45.616 +07:00 [DBG] Could not find a value in the request with name 'PhaseId' for binding property 'App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO.PhaseId' of type 'System.Nullable`1[System.Int32]'.
+2025-09-29 03:54:45.616 +07:00 [DBG] Done attempting to bind property 'App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO.PhaseId' of type 'System.Nullable`1[System.Int32]'.
+2025-09-29 03:54:45.616 +07:00 [DBG] Attempting to bind property 'App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO.SemesterId' of type 'System.Nullable`1[System.Int32]' using the name 'SemesterId' in request data ...
+2025-09-29 03:54:45.617 +07:00 [DBG] Entity Framework Core 8.0.16 initialized 'MyDbContext' using provider 'Microsoft.EntityFrameworkCore.SqlServer:8.0.13' with options: MigrationsAssembly=App.DAL 
+2025-09-29 03:54:45.618 +07:00 [DBG] Could not find a value in the request with name 'SemesterId' for binding property 'App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO.SemesterId' of type 'System.Nullable`1[System.Int32]'.
+2025-09-29 03:54:45.618 +07:00 [DBG] Done attempting to bind property 'App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO.SemesterId' of type 'System.Nullable`1[System.Int32]'.
+2025-09-29 03:54:45.618 +07:00 [DBG] Attempting to bind property 'App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO.Status' of type 'System.Nullable`1[App.Entities.Enums.SubmissionStatus]' using the name 'Status' in request data ...
+2025-09-29 03:54:45.618 +07:00 [DBG] Could not find a value in the request with name 'Status' for binding property 'App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO.Status' of type 'System.Nullable`1[App.Entities.Enums.SubmissionStatus]'.
+2025-09-29 03:54:45.618 +07:00 [DBG] Creating DbConnection.
+2025-09-29 03:54:45.621 +07:00 [DBG] Done attempting to bind property 'App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO.Status' of type 'System.Nullable`1[App.Entities.Enums.SubmissionStatus]'.
+2025-09-29 03:54:45.621 +07:00 [DBG] Created DbConnection. (2ms).
+2025-09-29 03:54:45.621 +07:00 [DBG] Attempting to bind property 'App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO.PageNumber' of type 'System.Int32' using the name 'PageNumber' in request data ...
+2025-09-29 03:54:45.621 +07:00 [DBG] Opening connection to database 'capbot_db' on server 'localhost'.
+2025-09-29 03:54:45.621 +07:00 [DBG] Done attempting to bind property 'App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO.PageNumber' of type 'System.Int32'.
+2025-09-29 03:54:45.621 +07:00 [DBG] Attempting to bind property 'App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO.PageSize' of type 'System.Int32' using the name 'PageSize' in request data ...
+2025-09-29 03:54:45.621 +07:00 [DBG] Opened connection to database 'capbot_db' on server 'localhost'.
+2025-09-29 03:54:45.621 +07:00 [DBG] Done attempting to bind property 'App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO.PageSize' of type 'System.Int32'.
+2025-09-29 03:54:45.622 +07:00 [DBG] Creating DbCommand for 'ExecuteReader'.
+2025-09-29 03:54:45.622 +07:00 [DBG] Attempting to bind property 'App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO.Keyword' of type 'System.String' using the name 'Keyword' in request data ...
+2025-09-29 03:54:45.622 +07:00 [DBG] Created DbCommand for 'ExecuteReader' (0ms).
+2025-09-29 03:54:45.622 +07:00 [DBG] Could not find a value in the request with name 'Keyword' for binding property 'App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO.Keyword' of type 'System.String'.
+2025-09-29 03:54:45.622 +07:00 [DBG] Done attempting to bind property 'App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO.Keyword' of type 'System.String'.
+2025-09-29 03:54:45.622 +07:00 [DBG] Initialized DbCommand for 'ExecuteReader' (0ms).
+2025-09-29 03:54:45.622 +07:00 [DBG] Attempting to bind property 'App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO.TotalRecord' of type 'System.Int32' using the name 'TotalRecord' in request data ...
+2025-09-29 03:54:45.622 +07:00 [DBG] Could not find a value in the request with name 'TotalRecord' for binding property 'App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO.TotalRecord' of type 'System.Int32'.
+2025-09-29 03:54:45.622 +07:00 [DBG] Executing DbCommand [Parameters=[@__targetUserId_0='?' (DbType = Int32)], CommandType='"Text"', CommandTimeout='30']
+SELECT TOP(1) [p].[Id], [p].[Address], [p].[Avatar], [p].[CoverImage], [p].[CreatedAt], [p].[CreatedBy], [p].[DeletedAt], [p].[FullName], [p].[IsActive], [p].[LastModifiedAt], [p].[LastModifiedBy], [p].[UserId]
+FROM [profiles] AS [p]
+WHERE [p].[UserId] = @__targetUserId_0 AND [p].[IsActive] = CAST(1 AS bit) AND [p].[DeletedAt] IS NULL AND [p].[DeletedAt] IS NULL
+2025-09-29 03:54:45.623 +07:00 [DBG] Done attempting to bind property 'App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO.TotalRecord' of type 'System.Int32'.
+2025-09-29 03:54:45.623 +07:00 [DBG] Done attempting to bind parameter 'query' of type 'App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO'.
+2025-09-29 03:54:45.623 +07:00 [DBG] Done attempting to bind parameter 'query' of type 'App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO'.
+2025-09-29 03:54:45.623 +07:00 [DBG] Attempting to validate the bound parameter 'query' of type 'App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO' ...
+2025-09-29 03:54:45.624 +07:00 [INF] Executed DbCommand (1ms) [Parameters=[@__targetUserId_0='?' (DbType = Int32)], CommandType='"Text"', CommandTimeout='30']
+SELECT TOP(1) [p].[Id], [p].[Address], [p].[Avatar], [p].[CoverImage], [p].[CreatedAt], [p].[CreatedBy], [p].[DeletedAt], [p].[FullName], [p].[IsActive], [p].[LastModifiedAt], [p].[LastModifiedBy], [p].[UserId]
+FROM [profiles] AS [p]
+WHERE [p].[UserId] = @__targetUserId_0 AND [p].[IsActive] = CAST(1 AS bit) AND [p].[DeletedAt] IS NULL AND [p].[DeletedAt] IS NULL
+2025-09-29 03:54:45.624 +07:00 [DBG] Done attempting to validate the bound parameter 'query' of type 'App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO'.
+2025-09-29 03:54:45.624 +07:00 [DBG] Closing data reader to 'capbot_db' on server 'localhost'.
+2025-09-29 03:54:45.624 +07:00 [DBG] A data reader for 'capbot_db' on server 'localhost' is being disposed after spending 0ms reading results.
+2025-09-29 03:54:45.624 +07:00 [DBG] Closing connection to database 'capbot_db' on server 'localhost'.
+2025-09-29 03:54:45.625 +07:00 [DBG] Entity Framework Core 8.0.16 initialized 'MyDbContext' using provider 'Microsoft.EntityFrameworkCore.SqlServer:8.0.13' with options: MigrationsAssembly=App.DAL 
+2025-09-29 03:54:45.625 +07:00 [DBG] Closed connection to database 'capbot_db' on server 'localhost' (0ms).
+2025-09-29 03:54:45.625 +07:00 [DBG] List of registered output formatters, in the following order: ["Microsoft.AspNetCore.OData.Formatter.ODataOutputFormatter","Microsoft.AspNetCore.OData.Formatter.ODataOutputFormatter","Microsoft.AspNetCore.OData.Formatter.ODataOutputFormatter","Microsoft.AspNetCore.Mvc.Formatters.HttpNoContentOutputFormatter","Microsoft.AspNetCore.Mvc.Formatters.StringOutputFormatter","Microsoft.AspNetCore.Mvc.Formatters.StreamOutputFormatter","Microsoft.AspNetCore.Mvc.Formatters.SystemTextJsonOutputFormatter"]
+2025-09-29 03:54:45.625 +07:00 [DBG] No information found on request to perform content negotiation.
+2025-09-29 03:54:45.625 +07:00 [DBG] Attempting to select an output formatter without using a content type as no explicit content types were specified for the response.
+2025-09-29 03:54:45.625 +07:00 [DBG] Creating DbConnection.
+2025-09-29 03:54:45.629 +07:00 [DBG] Attempting to select the first formatter in the output formatters list which can write the result.
+2025-09-29 03:54:45.630 +07:00 [DBG] Created DbConnection. (4ms).
+2025-09-29 03:54:45.630 +07:00 [DBG] Selected output formatter 'Microsoft.AspNetCore.Mvc.Formatters.SystemTextJsonOutputFormatter' and content type 'application/json' to write the response.
+2025-09-29 03:54:45.630 +07:00 [DBG] Opening connection to database 'capbot_db' on server 'localhost'.
+2025-09-29 03:54:45.630 +07:00 [INF] Executing ObjectResult, writing value of type 'FS.Commons.FSResponse'.
+2025-09-29 03:54:45.630 +07:00 [DBG] Opened connection to database 'capbot_db' on server 'localhost'.
+2025-09-29 03:54:45.630 +07:00 [DBG] Creating DbCommand for 'ExecuteReader'.
+2025-09-29 03:54:45.630 +07:00 [DBG] Created DbCommand for 'ExecuteReader' (0ms).
+2025-09-29 03:54:45.630 +07:00 [INF] Executed action CapBot.api.Controllers.UserProfileController.GetMyProfile (CapBot.api) in 15.2659ms
+2025-09-29 03:54:45.630 +07:00 [INF] Executed endpoint 'CapBot.api.Controllers.UserProfileController.GetMyProfile (CapBot.api)'
+2025-09-29 03:54:45.630 +07:00 [DBG] Connection id "0HNFUQ4FJ9UMK" completed keep alive response.
+2025-09-29 03:54:45.630 +07:00 [DBG] Initialized DbCommand for 'ExecuteReader' (0ms).
+2025-09-29 03:54:45.631 +07:00 [DBG] 'MyDbContext' disposed.
+2025-09-29 03:54:45.631 +07:00 [DBG] Executing DbCommand [Parameters=[], CommandType='"Text"', CommandTimeout='30']
+SELECT COUNT(*)
+FROM [submissions] AS [s]
+2025-09-29 03:54:45.631 +07:00 [DBG] Disposing connection to database 'capbot_db' on server 'localhost'.
+2025-09-29 03:54:45.631 +07:00 [DBG] Disposed connection to database '' on server '' (0ms).
+2025-09-29 03:54:45.631 +07:00 [INF] Request finished HTTP/1.1 GET http://localhost:5207/api/user-profiles/me - 200 null application/json; charset=utf-8 20.9872ms
+2025-09-29 03:54:45.633 +07:00 [INF] Executed DbCommand (2ms) [Parameters=[], CommandType='"Text"', CommandTimeout='30']
+SELECT COUNT(*)
+FROM [submissions] AS [s]
+2025-09-29 03:54:45.633 +07:00 [DBG] Closing data reader to 'capbot_db' on server 'localhost'.
+2025-09-29 03:54:45.633 +07:00 [DBG] A data reader for 'capbot_db' on server 'localhost' is being disposed after spending 0ms reading results.
+2025-09-29 03:54:45.633 +07:00 [DBG] Closing connection to database 'capbot_db' on server 'localhost'.
+2025-09-29 03:54:45.633 +07:00 [DBG] Closed connection to database 'capbot_db' on server 'localhost' (0ms).
+2025-09-29 03:54:45.636 +07:00 [DBG] Opening connection to database 'capbot_db' on server 'localhost'.
+2025-09-29 03:54:45.636 +07:00 [DBG] Opened connection to database 'capbot_db' on server 'localhost'.
+2025-09-29 03:54:45.636 +07:00 [DBG] Creating DbCommand for 'ExecuteReader'.
+2025-09-29 03:54:45.636 +07:00 [DBG] Created DbCommand for 'ExecuteReader' (0ms).
+2025-09-29 03:54:45.636 +07:00 [DBG] Initialized DbCommand for 'ExecuteReader' (0ms).
+2025-09-29 03:54:45.636 +07:00 [DBG] Executing DbCommand [Parameters=[@__p_0='?' (DbType = Int32), @__p_1='?' (DbType = Int32)], CommandType='"Text"', CommandTimeout='30']
+SELECT [t].[Id], [t].[AdditionalNotes], [t].[AiCheckDetails], [t].[AiCheckScore], [t].[AiCheckStatus], [t].[CreatedAt], [t].[CreatedBy], [t].[DeletedAt], [t].[DocumentUrl], [t].[IsActive], [t].[LastModifiedAt], [t].[LastModifiedBy], [t].[PhaseId], [t].[Status], [t].[SubmissionRound], [t].[SubmittedAt], [t].[SubmittedBy], [t].[TopicId], [t].[TopicVersionId], [u].[Id], [u].[AccessFailedCount], [u].[ConcurrencyStamp], [u].[CreatedAt], [u].[DeletedAt], [u].[Email], [u].[EmailConfirmed], [u].[LastModifiedAt], [u].[LastModifiedBy], [u].[LockoutEnabled], [u].[LockoutEnd], [u].[NormalizedEmail], [u].[NormalizedUserName], [u].[PasswordHash], [u].[PhoneNumber], [u].[PhoneNumberConfirmed], [u].[SecurityStamp], [u].[TwoFactorEnabled], [u].[UserName], [t0].[Id], [t0].[Abbreviation], [t0].[CategoryId], [t0].[Content], [t0].[Context], [t0].[CreatedAt], [t0].[CreatedBy], [t0].[DeletedAt], [t0].[Description], [t0].[EN_Title], [t0].[IsActive], [t0].[IsApproved], [t0].[IsLegacy], [t0].[LastModifiedAt], [t0].[LastModifiedBy], [t0].[MaxStudents], [t0].[Objectives], [t0].[PotentialDuplicate], [t0].[Problem], [t0].[SemesterId], [t0].[SupervisorId], [t0].[VN_title]
+FROM (
+    SELECT [s].[Id], [s].[AdditionalNotes], [s].[AiCheckDetails], [s].[AiCheckScore], [s].[AiCheckStatus], [s].[CreatedAt], [s].[CreatedBy], [s].[DeletedAt], [s].[DocumentUrl], [s].[IsActive], [s].[LastModifiedAt], [s].[LastModifiedBy], [s].[PhaseId], [s].[Status], [s].[SubmissionRound], [s].[SubmittedAt], [s].[SubmittedBy], [s].[TopicId], [s].[TopicVersionId]
+    FROM [submissions] AS [s]
+    ORDER BY [s].[SubmittedAt] DESC
+    OFFSET @__p_0 ROWS FETCH NEXT @__p_1 ROWS ONLY
+) AS [t]
+INNER JOIN [users] AS [u] ON [t].[SubmittedBy] = [u].[Id]
+LEFT JOIN [topics] AS [t0] ON [t].[TopicId] = [t0].[Id]
+ORDER BY [t].[SubmittedAt] DESC
+2025-09-29 03:54:45.640 +07:00 [INF] Executed DbCommand (4ms) [Parameters=[@__p_0='?' (DbType = Int32), @__p_1='?' (DbType = Int32)], CommandType='"Text"', CommandTimeout='30']
+SELECT [t].[Id], [t].[AdditionalNotes], [t].[AiCheckDetails], [t].[AiCheckScore], [t].[AiCheckStatus], [t].[CreatedAt], [t].[CreatedBy], [t].[DeletedAt], [t].[DocumentUrl], [t].[IsActive], [t].[LastModifiedAt], [t].[LastModifiedBy], [t].[PhaseId], [t].[Status], [t].[SubmissionRound], [t].[SubmittedAt], [t].[SubmittedBy], [t].[TopicId], [t].[TopicVersionId], [u].[Id], [u].[AccessFailedCount], [u].[ConcurrencyStamp], [u].[CreatedAt], [u].[DeletedAt], [u].[Email], [u].[EmailConfirmed], [u].[LastModifiedAt], [u].[LastModifiedBy], [u].[LockoutEnabled], [u].[LockoutEnd], [u].[NormalizedEmail], [u].[NormalizedUserName], [u].[PasswordHash], [u].[PhoneNumber], [u].[PhoneNumberConfirmed], [u].[SecurityStamp], [u].[TwoFactorEnabled], [u].[UserName], [t0].[Id], [t0].[Abbreviation], [t0].[CategoryId], [t0].[Content], [t0].[Context], [t0].[CreatedAt], [t0].[CreatedBy], [t0].[DeletedAt], [t0].[Description], [t0].[EN_Title], [t0].[IsActive], [t0].[IsApproved], [t0].[IsLegacy], [t0].[LastModifiedAt], [t0].[LastModifiedBy], [t0].[MaxStudents], [t0].[Objectives], [t0].[PotentialDuplicate], [t0].[Problem], [t0].[SemesterId], [t0].[SupervisorId], [t0].[VN_title]
+FROM (
+    SELECT [s].[Id], [s].[AdditionalNotes], [s].[AiCheckDetails], [s].[AiCheckScore], [s].[AiCheckStatus], [s].[CreatedAt], [s].[CreatedBy], [s].[DeletedAt], [s].[DocumentUrl], [s].[IsActive], [s].[LastModifiedAt], [s].[LastModifiedBy], [s].[PhaseId], [s].[Status], [s].[SubmissionRound], [s].[SubmittedAt], [s].[SubmittedBy], [s].[TopicId], [s].[TopicVersionId]
+    FROM [submissions] AS [s]
+    ORDER BY [s].[SubmittedAt] DESC
+    OFFSET @__p_0 ROWS FETCH NEXT @__p_1 ROWS ONLY
+) AS [t]
+INNER JOIN [users] AS [u] ON [t].[SubmittedBy] = [u].[Id]
+LEFT JOIN [topics] AS [t0] ON [t].[TopicId] = [t0].[Id]
+ORDER BY [t].[SubmittedAt] DESC
+2025-09-29 03:54:45.643 +07:00 [INF] Request starting HTTP/1.1 GET http://localhost:5207/images/entities/11111111.png - null null
+2025-09-29 03:54:45.644 +07:00 [DBG] The request path /images/entities/11111111.png does not match an existing file
+2025-09-29 03:54:45.644 +07:00 [DBG] Closing data reader to 'capbot_db' on server 'localhost'.
+2025-09-29 03:54:45.644 +07:00 [DBG] A data reader for 'capbot_db' on server 'localhost' is being disposed after spending 0ms reading results.
+2025-09-29 03:54:45.644 +07:00 [DBG] Closing connection to database 'capbot_db' on server 'localhost'.
+2025-09-29 03:54:45.644 +07:00 [DBG] The request path /images/entities/11111111.png does not match an existing file
+2025-09-29 03:54:45.644 +07:00 [DBG] Closed connection to database 'capbot_db' on server 'localhost' (0ms).
+2025-09-29 03:54:45.644 +07:00 [DBG] No candidates found for the request path '/images/entities/11111111.png'
+2025-09-29 03:54:45.644 +07:00 [DBG] Request did not match any endpoints
+2025-09-29 03:54:45.645 +07:00 [DBG] AuthenticationScheme: Bearer was not authenticated.
+2025-09-29 03:54:45.645 +07:00 [DBG] List of registered output formatters, in the following order: ["Microsoft.AspNetCore.OData.Formatter.ODataOutputFormatter","Microsoft.AspNetCore.OData.Formatter.ODataOutputFormatter","Microsoft.AspNetCore.OData.Formatter.ODataOutputFormatter","Microsoft.AspNetCore.Mvc.Formatters.HttpNoContentOutputFormatter","Microsoft.AspNetCore.Mvc.Formatters.StringOutputFormatter","Microsoft.AspNetCore.Mvc.Formatters.StreamOutputFormatter","Microsoft.AspNetCore.Mvc.Formatters.SystemTextJsonOutputFormatter"]
+2025-09-29 03:54:45.645 +07:00 [DBG] No information found on request to perform content negotiation.
+2025-09-29 03:54:45.645 +07:00 [DBG] Connection id "0HNFUQ4FJ9UMI" completed keep alive response.
+2025-09-29 03:54:45.645 +07:00 [DBG] Attempting to select the first output formatter in the output formatters list which supports a content type from the explicitly specified content types '["application/json"]'.
+2025-09-29 03:54:45.645 +07:00 [INF] Request finished HTTP/1.1 GET http://localhost:5207/images/entities/11111111.png - 404 0 null 2.4695ms
+2025-09-29 03:54:45.645 +07:00 [DBG] Selected output formatter 'Microsoft.AspNetCore.Mvc.Formatters.SystemTextJsonOutputFormatter' and content type 'application/json' to write the response.
+2025-09-29 03:54:45.649 +07:00 [INF] Request reached the end of the middleware pipeline without being handled by application code. Request path: GET http://localhost:5207/images/entities/11111111.png, Response status code: 404
+2025-09-29 03:54:45.649 +07:00 [INF] Executing ObjectResult, writing value of type 'FS.Commons.FSResponse'.
+2025-09-29 03:54:45.649 +07:00 [INF] Executed action CapBot.api.Controllers.SubmissionController.List (CapBot.api) in 35.7592ms
+2025-09-29 03:54:45.649 +07:00 [INF] Executed endpoint 'CapBot.api.Controllers.SubmissionController.List (CapBot.api)'
+2025-09-29 03:54:45.649 +07:00 [DBG] Connection id "0HNFUQ4FJ9UML" completed keep alive response.
+2025-09-29 03:54:45.650 +07:00 [DBG] 'MyDbContext' disposed.
+2025-09-29 03:54:45.650 +07:00 [DBG] Disposing connection to database 'capbot_db' on server 'localhost'.
+2025-09-29 03:54:45.650 +07:00 [DBG] Disposed connection to database '' on server '' (0ms).
+2025-09-29 03:54:45.650 +07:00 [INF] Request finished HTTP/1.1 GET http://localhost:5207/api/submission/list?PageNumber=1&PageSize=10 - 200 null application/json; charset=utf-8 37.4477ms
+2025-09-29 03:54:46.568 +07:00 [INF] Request starting HTTP/1.1 GET http://localhost:5207/api/user-profiles/me - null null
+2025-09-29 03:54:46.570 +07:00 [INF] Request starting HTTP/1.1 GET http://localhost:5207/api/submission/list?PageNumber=1&PageSize=10 - null null
+2025-09-29 03:54:46.570 +07:00 [DBG] The request path /api/submission/list does not match a supported file type
+2025-09-29 03:54:46.570 +07:00 [DBG] The request path /api/user-profiles/me does not match a supported file type
+2025-09-29 03:54:46.570 +07:00 [DBG] The request path /api/submission/list does not match a supported file type
+2025-09-29 03:54:46.570 +07:00 [DBG] The request path /api/user-profiles/me does not match a supported file type
+2025-09-29 03:54:46.570 +07:00 [DBG] The request has an origin header: 'http://localhost:3000'.
+2025-09-29 03:54:46.570 +07:00 [DBG] The request has an origin header: 'http://localhost:3000'.
+2025-09-29 03:54:46.570 +07:00 [INF] CORS policy execution successful.
+2025-09-29 03:54:46.570 +07:00 [INF] CORS policy execution successful.
+2025-09-29 03:54:46.570 +07:00 [DBG] 2 candidate(s) found for the request path '/api/user-profiles/me'
+2025-09-29 03:54:46.570 +07:00 [DBG] 1 candidate(s) found for the request path '/api/submission/list'
+2025-09-29 03:54:46.570 +07:00 [DBG] Endpoint 'CapBot.api.Controllers.UserProfileController.GetMyProfile (CapBot.api)' with route pattern 'api/user-profiles/me' is valid for the request path '/api/user-profiles/me'
+2025-09-29 03:54:46.570 +07:00 [DBG] Endpoint 'CapBot.api.Controllers.SubmissionController.List (CapBot.api)' with route pattern 'api/submission/list' is valid for the request path '/api/submission/list'
+2025-09-29 03:54:46.570 +07:00 [DBG] Endpoint 'CapBot.api.Controllers.UserProfileController.GetById (CapBot.api)' with route pattern 'api/user-profiles/{id}' is valid for the request path '/api/user-profiles/me'
+2025-09-29 03:54:46.570 +07:00 [DBG] Request matched endpoint 'CapBot.api.Controllers.SubmissionController.List (CapBot.api)'
+2025-09-29 03:54:46.570 +07:00 [DBG] Request matched endpoint 'CapBot.api.Controllers.UserProfileController.GetMyProfile (CapBot.api)'
+2025-09-29 03:54:46.570 +07:00 [DBG] Successfully validated the token.
+2025-09-29 03:54:46.570 +07:00 [DBG] Successfully validated the token.
+2025-09-29 03:54:46.570 +07:00 [DBG] AuthenticationScheme: Bearer was successfully authenticated.
+2025-09-29 03:54:46.570 +07:00 [DBG] AuthenticationScheme: Bearer was successfully authenticated.
+2025-09-29 03:54:46.571 +07:00 [DBG] Authorization was successful.
+2025-09-29 03:54:46.571 +07:00 [DBG] Authorization was successful.
+2025-09-29 03:54:46.571 +07:00 [INF] Executing endpoint 'CapBot.api.Controllers.SubmissionController.List (CapBot.api)'
+2025-09-29 03:54:46.571 +07:00 [INF] Executing endpoint 'CapBot.api.Controllers.UserProfileController.GetMyProfile (CapBot.api)'
+2025-09-29 03:54:46.571 +07:00 [INF] Route matched with {action = "GetMyProfile", controller = "UserProfile"}. Executing controller action with signature System.Threading.Tasks.Task`1[Microsoft.AspNetCore.Mvc.IActionResult] GetMyProfile() on controller CapBot.api.Controllers.UserProfileController (CapBot.api).
+2025-09-29 03:54:46.571 +07:00 [INF] Route matched with {action = "List", controller = "Submission"}. Executing controller action with signature System.Threading.Tasks.Task`1[Microsoft.AspNetCore.Mvc.IActionResult] List(App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO) on controller CapBot.api.Controllers.SubmissionController (CapBot.api).
+2025-09-29 03:54:46.571 +07:00 [DBG] Execution plan of authorization filters (in the following order): ["None"]
+2025-09-29 03:54:46.571 +07:00 [DBG] Execution plan of authorization filters (in the following order): ["None"]
+2025-09-29 03:54:46.571 +07:00 [DBG] Execution plan of resource filters (in the following order): ["None"]
+2025-09-29 03:54:46.571 +07:00 [DBG] Execution plan of resource filters (in the following order): ["None"]
+2025-09-29 03:54:46.571 +07:00 [DBG] Execution plan of action filters (in the following order): ["Microsoft.AspNetCore.Mvc.ModelBinding.UnsupportedContentTypeFilter (Order: -3000)"]
+2025-09-29 03:54:46.571 +07:00 [DBG] Execution plan of action filters (in the following order): ["Microsoft.AspNetCore.Mvc.ModelBinding.UnsupportedContentTypeFilter (Order: -3000)"]
+2025-09-29 03:54:46.571 +07:00 [DBG] Execution plan of exception filters (in the following order): ["None"]
+2025-09-29 03:54:46.571 +07:00 [DBG] Execution plan of exception filters (in the following order): ["None"]
+2025-09-29 03:54:46.571 +07:00 [DBG] Execution plan of result filters (in the following order): ["Microsoft.AspNetCore.Mvc.Infrastructure.ClientErrorResultFilter (Order: -2000)"]
+2025-09-29 03:54:46.571 +07:00 [DBG] Execution plan of result filters (in the following order): ["Microsoft.AspNetCore.Mvc.Infrastructure.ClientErrorResultFilter (Order: -2000)","Microsoft.AspNetCore.Mvc.ProducesAttribute (Order: 0)"]
+2025-09-29 03:54:46.571 +07:00 [DBG] Executing controller factory for controller CapBot.api.Controllers.UserProfileController (CapBot.api)
+2025-09-29 03:54:46.571 +07:00 [DBG] Executing controller factory for controller CapBot.api.Controllers.SubmissionController (CapBot.api)
+2025-09-29 03:54:46.571 +07:00 [DBG] Executed controller factory for controller CapBot.api.Controllers.UserProfileController (CapBot.api)
+2025-09-29 03:54:46.571 +07:00 [DBG] Executed controller factory for controller CapBot.api.Controllers.SubmissionController (CapBot.api)
+2025-09-29 03:54:46.571 +07:00 [DBG] Attempting to bind parameter 'query' of type 'App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO' ...
+2025-09-29 03:54:46.572 +07:00 [DBG] Entity Framework Core 8.0.16 initialized 'MyDbContext' using provider 'Microsoft.EntityFrameworkCore.SqlServer:8.0.13' with options: MigrationsAssembly=App.DAL 
+2025-09-29 03:54:46.572 +07:00 [DBG] Attempting to bind parameter 'query' of type 'App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO' using the name '' in request data ...
+2025-09-29 03:54:46.572 +07:00 [DBG] Attempting to bind property 'App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO.TopicVersionId' of type 'System.Nullable`1[System.Int32]' using the name 'TopicVersionId' in request data ...
+2025-09-29 03:54:46.572 +07:00 [DBG] Could not find a value in the request with name 'TopicVersionId' for binding property 'App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO.TopicVersionId' of type 'System.Nullable`1[System.Int32]'.
+2025-09-29 03:54:46.572 +07:00 [DBG] Done attempting to bind property 'App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO.TopicVersionId' of type 'System.Nullable`1[System.Int32]'.
+2025-09-29 03:54:46.572 +07:00 [DBG] Attempting to bind property 'App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO.PhaseId' of type 'System.Nullable`1[System.Int32]' using the name 'PhaseId' in request data ...
+2025-09-29 03:54:46.572 +07:00 [DBG] Creating DbConnection.
+2025-09-29 03:54:46.573 +07:00 [DBG] Could not find a value in the request with name 'PhaseId' for binding property 'App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO.PhaseId' of type 'System.Nullable`1[System.Int32]'.
+2025-09-29 03:54:46.573 +07:00 [DBG] Created DbConnection. (0ms).
+2025-09-29 03:54:46.573 +07:00 [DBG] Done attempting to bind property 'App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO.PhaseId' of type 'System.Nullable`1[System.Int32]'.
+2025-09-29 03:54:46.573 +07:00 [DBG] Opening connection to database 'capbot_db' on server 'localhost'.
+2025-09-29 03:54:46.573 +07:00 [DBG] Attempting to bind property 'App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO.SemesterId' of type 'System.Nullable`1[System.Int32]' using the name 'SemesterId' in request data ...
+2025-09-29 03:54:46.573 +07:00 [DBG] Could not find a value in the request with name 'SemesterId' for binding property 'App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO.SemesterId' of type 'System.Nullable`1[System.Int32]'.
+2025-09-29 03:54:46.573 +07:00 [DBG] Done attempting to bind property 'App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO.SemesterId' of type 'System.Nullable`1[System.Int32]'.
+2025-09-29 03:54:46.573 +07:00 [DBG] Opened connection to database 'capbot_db' on server 'localhost'.
+2025-09-29 03:54:46.575 +07:00 [DBG] Attempting to bind property 'App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO.Status' of type 'System.Nullable`1[App.Entities.Enums.SubmissionStatus]' using the name 'Status' in request data ...
+2025-09-29 03:54:46.575 +07:00 [DBG] Creating DbCommand for 'ExecuteReader'.
+2025-09-29 03:54:46.575 +07:00 [DBG] Could not find a value in the request with name 'Status' for binding property 'App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO.Status' of type 'System.Nullable`1[App.Entities.Enums.SubmissionStatus]'.
+2025-09-29 03:54:46.575 +07:00 [DBG] Done attempting to bind property 'App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO.Status' of type 'System.Nullable`1[App.Entities.Enums.SubmissionStatus]'.
+2025-09-29 03:54:46.575 +07:00 [DBG] Attempting to bind property 'App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO.PageNumber' of type 'System.Int32' using the name 'PageNumber' in request data ...
+2025-09-29 03:54:46.575 +07:00 [DBG] Created DbCommand for 'ExecuteReader' (0ms).
+2025-09-29 03:54:46.578 +07:00 [DBG] Done attempting to bind property 'App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO.PageNumber' of type 'System.Int32'.
+2025-09-29 03:54:46.579 +07:00 [DBG] Initialized DbCommand for 'ExecuteReader' (3ms).
+2025-09-29 03:54:46.579 +07:00 [DBG] Attempting to bind property 'App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO.PageSize' of type 'System.Int32' using the name 'PageSize' in request data ...
+2025-09-29 03:54:46.579 +07:00 [DBG] Executing DbCommand [Parameters=[@__targetUserId_0='?' (DbType = Int32)], CommandType='"Text"', CommandTimeout='30']
+SELECT TOP(1) [p].[Id], [p].[Address], [p].[Avatar], [p].[CoverImage], [p].[CreatedAt], [p].[CreatedBy], [p].[DeletedAt], [p].[FullName], [p].[IsActive], [p].[LastModifiedAt], [p].[LastModifiedBy], [p].[UserId]
+FROM [profiles] AS [p]
+WHERE [p].[UserId] = @__targetUserId_0 AND [p].[IsActive] = CAST(1 AS bit) AND [p].[DeletedAt] IS NULL AND [p].[DeletedAt] IS NULL
+2025-09-29 03:54:46.579 +07:00 [DBG] Done attempting to bind property 'App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO.PageSize' of type 'System.Int32'.
+2025-09-29 03:54:46.579 +07:00 [DBG] Attempting to bind property 'App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO.Keyword' of type 'System.String' using the name 'Keyword' in request data ...
+2025-09-29 03:54:46.579 +07:00 [DBG] Could not find a value in the request with name 'Keyword' for binding property 'App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO.Keyword' of type 'System.String'.
+2025-09-29 03:54:46.579 +07:00 [DBG] Done attempting to bind property 'App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO.Keyword' of type 'System.String'.
+2025-09-29 03:54:46.579 +07:00 [DBG] Attempting to bind property 'App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO.TotalRecord' of type 'System.Int32' using the name 'TotalRecord' in request data ...
+2025-09-29 03:54:46.579 +07:00 [DBG] Could not find a value in the request with name 'TotalRecord' for binding property 'App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO.TotalRecord' of type 'System.Int32'.
+2025-09-29 03:54:46.579 +07:00 [DBG] Done attempting to bind property 'App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO.TotalRecord' of type 'System.Int32'.
+2025-09-29 03:54:46.579 +07:00 [INF] Executed DbCommand (1ms) [Parameters=[@__targetUserId_0='?' (DbType = Int32)], CommandType='"Text"', CommandTimeout='30']
+SELECT TOP(1) [p].[Id], [p].[Address], [p].[Avatar], [p].[CoverImage], [p].[CreatedAt], [p].[CreatedBy], [p].[DeletedAt], [p].[FullName], [p].[IsActive], [p].[LastModifiedAt], [p].[LastModifiedBy], [p].[UserId]
+FROM [profiles] AS [p]
+WHERE [p].[UserId] = @__targetUserId_0 AND [p].[IsActive] = CAST(1 AS bit) AND [p].[DeletedAt] IS NULL AND [p].[DeletedAt] IS NULL
+2025-09-29 03:54:46.580 +07:00 [DBG] Done attempting to bind parameter 'query' of type 'App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO'.
+2025-09-29 03:54:46.580 +07:00 [DBG] Done attempting to bind parameter 'query' of type 'App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO'.
+2025-09-29 03:54:46.580 +07:00 [DBG] Attempting to validate the bound parameter 'query' of type 'App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO' ...
+2025-09-29 03:54:46.580 +07:00 [DBG] Closing data reader to 'capbot_db' on server 'localhost'.
+2025-09-29 03:54:46.580 +07:00 [DBG] Done attempting to validate the bound parameter 'query' of type 'App.Entities.DTOs.Submissions.GetSubmissionsQueryDTO'.
+2025-09-29 03:54:46.581 +07:00 [DBG] A data reader for 'capbot_db' on server 'localhost' is being disposed after spending 0ms reading results.
+2025-09-29 03:54:46.581 +07:00 [DBG] Closing connection to database 'capbot_db' on server 'localhost'.
+2025-09-29 03:54:46.581 +07:00 [DBG] Closed connection to database 'capbot_db' on server 'localhost' (0ms).
+2025-09-29 03:54:46.581 +07:00 [DBG] List of registered output formatters, in the following order: ["Microsoft.AspNetCore.OData.Formatter.ODataOutputFormatter","Microsoft.AspNetCore.OData.Formatter.ODataOutputFormatter","Microsoft.AspNetCore.OData.Formatter.ODataOutputFormatter","Microsoft.AspNetCore.Mvc.Formatters.HttpNoContentOutputFormatter","Microsoft.AspNetCore.Mvc.Formatters.StringOutputFormatter","Microsoft.AspNetCore.Mvc.Formatters.StreamOutputFormatter","Microsoft.AspNetCore.Mvc.Formatters.SystemTextJsonOutputFormatter"]
+2025-09-29 03:54:46.581 +07:00 [DBG] No information found on request to perform content negotiation.
+2025-09-29 03:54:46.582 +07:00 [DBG] Entity Framework Core 8.0.16 initialized 'MyDbContext' using provider 'Microsoft.EntityFrameworkCore.SqlServer:8.0.13' with options: MigrationsAssembly=App.DAL 
+2025-09-29 03:54:46.582 +07:00 [DBG] Attempting to select an output formatter without using a content type as no explicit content types were specified for the response.
+2025-09-29 03:54:46.582 +07:00 [DBG] Attempting to select the first formatter in the output formatters list which can write the result.
+2025-09-29 03:54:46.582 +07:00 [DBG] Selected output formatter 'Microsoft.AspNetCore.Mvc.Formatters.SystemTextJsonOutputFormatter' and content type 'application/json' to write the response.
+2025-09-29 03:54:46.582 +07:00 [INF] Executing ObjectResult, writing value of type 'FS.Commons.FSResponse'.
+2025-09-29 03:54:46.583 +07:00 [INF] Executed action CapBot.api.Controllers.UserProfileController.GetMyProfile (CapBot.api) in 11.9784ms
+2025-09-29 03:54:46.583 +07:00 [INF] Executed endpoint 'CapBot.api.Controllers.UserProfileController.GetMyProfile (CapBot.api)'
+2025-09-29 03:54:46.583 +07:00 [DBG] Connection id "0HNFUQ4FJ9UML" completed keep alive response.
+2025-09-29 03:54:46.583 +07:00 [DBG] Creating DbConnection.
+2025-09-29 03:54:46.586 +07:00 [DBG] 'MyDbContext' disposed.
+2025-09-29 03:54:46.586 +07:00 [DBG] Disposing connection to database 'capbot_db' on server 'localhost'.
+2025-09-29 03:54:46.586 +07:00 [DBG] Created DbConnection. (2ms).
+2025-09-29 03:54:46.586 +07:00 [DBG] Disposed connection to database '' on server '' (0ms).
+2025-09-29 03:54:46.586 +07:00 [DBG] Opening connection to database 'capbot_db' on server 'localhost'.
+2025-09-29 03:54:46.586 +07:00 [INF] Request finished HTTP/1.1 GET http://localhost:5207/api/user-profiles/me - 200 null application/json; charset=utf-8 17.9606ms
+2025-09-29 03:54:46.586 +07:00 [DBG] Opened connection to database 'capbot_db' on server 'localhost'.
+2025-09-29 03:54:46.587 +07:00 [DBG] Creating DbCommand for 'ExecuteReader'.
+2025-09-29 03:54:46.587 +07:00 [DBG] Created DbCommand for 'ExecuteReader' (0ms).
+2025-09-29 03:54:46.587 +07:00 [DBG] Initialized DbCommand for 'ExecuteReader' (0ms).
+2025-09-29 03:54:46.587 +07:00 [DBG] Executing DbCommand [Parameters=[], CommandType='"Text"', CommandTimeout='30']
+SELECT COUNT(*)
+FROM [submissions] AS [s]
+2025-09-29 03:54:46.588 +07:00 [INF] Executed DbCommand (1ms) [Parameters=[], CommandType='"Text"', CommandTimeout='30']
+SELECT COUNT(*)
+FROM [submissions] AS [s]
+2025-09-29 03:54:46.588 +07:00 [DBG] Closing data reader to 'capbot_db' on server 'localhost'.
+2025-09-29 03:54:46.588 +07:00 [DBG] A data reader for 'capbot_db' on server 'localhost' is being disposed after spending 0ms reading results.
+2025-09-29 03:54:46.588 +07:00 [DBG] Closing connection to database 'capbot_db' on server 'localhost'.
+2025-09-29 03:54:46.588 +07:00 [DBG] Closed connection to database 'capbot_db' on server 'localhost' (0ms).
+2025-09-29 03:54:46.589 +07:00 [DBG] Opening connection to database 'capbot_db' on server 'localhost'.
+2025-09-29 03:54:46.589 +07:00 [DBG] Opened connection to database 'capbot_db' on server 'localhost'.
+2025-09-29 03:54:46.589 +07:00 [DBG] Creating DbCommand for 'ExecuteReader'.
+2025-09-29 03:54:46.589 +07:00 [DBG] Created DbCommand for 'ExecuteReader' (0ms).
+2025-09-29 03:54:46.589 +07:00 [DBG] Initialized DbCommand for 'ExecuteReader' (0ms).
+2025-09-29 03:54:46.589 +07:00 [DBG] Executing DbCommand [Parameters=[@__p_0='?' (DbType = Int32), @__p_1='?' (DbType = Int32)], CommandType='"Text"', CommandTimeout='30']
+SELECT [t].[Id], [t].[AdditionalNotes], [t].[AiCheckDetails], [t].[AiCheckScore], [t].[AiCheckStatus], [t].[CreatedAt], [t].[CreatedBy], [t].[DeletedAt], [t].[DocumentUrl], [t].[IsActive], [t].[LastModifiedAt], [t].[LastModifiedBy], [t].[PhaseId], [t].[Status], [t].[SubmissionRound], [t].[SubmittedAt], [t].[SubmittedBy], [t].[TopicId], [t].[TopicVersionId], [u].[Id], [u].[AccessFailedCount], [u].[ConcurrencyStamp], [u].[CreatedAt], [u].[DeletedAt], [u].[Email], [u].[EmailConfirmed], [u].[LastModifiedAt], [u].[LastModifiedBy], [u].[LockoutEnabled], [u].[LockoutEnd], [u].[NormalizedEmail], [u].[NormalizedUserName], [u].[PasswordHash], [u].[PhoneNumber], [u].[PhoneNumberConfirmed], [u].[SecurityStamp], [u].[TwoFactorEnabled], [u].[UserName], [t0].[Id], [t0].[Abbreviation], [t0].[CategoryId], [t0].[Content], [t0].[Context], [t0].[CreatedAt], [t0].[CreatedBy], [t0].[DeletedAt], [t0].[Description], [t0].[EN_Title], [t0].[IsActive], [t0].[IsApproved], [t0].[IsLegacy], [t0].[LastModifiedAt], [t0].[LastModifiedBy], [t0].[MaxStudents], [t0].[Objectives], [t0].[PotentialDuplicate], [t0].[Problem], [t0].[SemesterId], [t0].[SupervisorId], [t0].[VN_title]
+FROM (
+    SELECT [s].[Id], [s].[AdditionalNotes], [s].[AiCheckDetails], [s].[AiCheckScore], [s].[AiCheckStatus], [s].[CreatedAt], [s].[CreatedBy], [s].[DeletedAt], [s].[DocumentUrl], [s].[IsActive], [s].[LastModifiedAt], [s].[LastModifiedBy], [s].[PhaseId], [s].[Status], [s].[SubmissionRound], [s].[SubmittedAt], [s].[SubmittedBy], [s].[TopicId], [s].[TopicVersionId]
+    FROM [submissions] AS [s]
+    ORDER BY [s].[SubmittedAt] DESC
+    OFFSET @__p_0 ROWS FETCH NEXT @__p_1 ROWS ONLY
+) AS [t]
+INNER JOIN [users] AS [u] ON [t].[SubmittedBy] = [u].[Id]
+LEFT JOIN [topics] AS [t0] ON [t].[TopicId] = [t0].[Id]
+ORDER BY [t].[SubmittedAt] DESC
+2025-09-29 03:54:46.594 +07:00 [INF] Executed DbCommand (5ms) [Parameters=[@__p_0='?' (DbType = Int32), @__p_1='?' (DbType = Int32)], CommandType='"Text"', CommandTimeout='30']
+SELECT [t].[Id], [t].[AdditionalNotes], [t].[AiCheckDetails], [t].[AiCheckScore], [t].[AiCheckStatus], [t].[CreatedAt], [t].[CreatedBy], [t].[DeletedAt], [t].[DocumentUrl], [t].[IsActive], [t].[LastModifiedAt], [t].[LastModifiedBy], [t].[PhaseId], [t].[Status], [t].[SubmissionRound], [t].[SubmittedAt], [t].[SubmittedBy], [t].[TopicId], [t].[TopicVersionId], [u].[Id], [u].[AccessFailedCount], [u].[ConcurrencyStamp], [u].[CreatedAt], [u].[DeletedAt], [u].[Email], [u].[EmailConfirmed], [u].[LastModifiedAt], [u].[LastModifiedBy], [u].[LockoutEnabled], [u].[LockoutEnd], [u].[NormalizedEmail], [u].[NormalizedUserName], [u].[PasswordHash], [u].[PhoneNumber], [u].[PhoneNumberConfirmed], [u].[SecurityStamp], [u].[TwoFactorEnabled], [u].[UserName], [t0].[Id], [t0].[Abbreviation], [t0].[CategoryId], [t0].[Content], [t0].[Context], [t0].[CreatedAt], [t0].[CreatedBy], [t0].[DeletedAt], [t0].[Description], [t0].[EN_Title], [t0].[IsActive], [t0].[IsApproved], [t0].[IsLegacy], [t0].[LastModifiedAt], [t0].[LastModifiedBy], [t0].[MaxStudents], [t0].[Objectives], [t0].[PotentialDuplicate], [t0].[Problem], [t0].[SemesterId], [t0].[SupervisorId], [t0].[VN_title]
+FROM (
+    SELECT [s].[Id], [s].[AdditionalNotes], [s].[AiCheckDetails], [s].[AiCheckScore], [s].[AiCheckStatus], [s].[CreatedAt], [s].[CreatedBy], [s].[DeletedAt], [s].[DocumentUrl], [s].[IsActive], [s].[LastModifiedAt], [s].[LastModifiedBy], [s].[PhaseId], [s].[Status], [s].[SubmissionRound], [s].[SubmittedAt], [s].[SubmittedBy], [s].[TopicId], [s].[TopicVersionId]
+    FROM [submissions] AS [s]
+    ORDER BY [s].[SubmittedAt] DESC
+    OFFSET @__p_0 ROWS FETCH NEXT @__p_1 ROWS ONLY
+) AS [t]
+INNER JOIN [users] AS [u] ON [t].[SubmittedBy] = [u].[Id]
+LEFT JOIN [topics] AS [t0] ON [t].[TopicId] = [t0].[Id]
+ORDER BY [t].[SubmittedAt] DESC
+2025-09-29 03:54:46.595 +07:00 [DBG] Closing data reader to 'capbot_db' on server 'localhost'.
+2025-09-29 03:54:46.596 +07:00 [DBG] A data reader for 'capbot_db' on server 'localhost' is being disposed after spending 0ms reading results.
+2025-09-29 03:54:46.596 +07:00 [DBG] Closing connection to database 'capbot_db' on server 'localhost'.
+2025-09-29 03:54:46.596 +07:00 [DBG] Closed connection to database 'capbot_db' on server 'localhost' (0ms).
+2025-09-29 03:54:46.596 +07:00 [DBG] List of registered output formatters, in the following order: ["Microsoft.AspNetCore.OData.Formatter.ODataOutputFormatter","Microsoft.AspNetCore.OData.Formatter.ODataOutputFormatter","Microsoft.AspNetCore.OData.Formatter.ODataOutputFormatter","Microsoft.AspNetCore.Mvc.Formatters.HttpNoContentOutputFormatter","Microsoft.AspNetCore.Mvc.Formatters.StringOutputFormatter","Microsoft.AspNetCore.Mvc.Formatters.StreamOutputFormatter","Microsoft.AspNetCore.Mvc.Formatters.SystemTextJsonOutputFormatter"]
+2025-09-29 03:54:46.598 +07:00 [DBG] No information found on request to perform content negotiation.
+2025-09-29 03:54:46.598 +07:00 [DBG] Attempting to select the first output formatter in the output formatters list which supports a content type from the explicitly specified content types '["application/json"]'.
+2025-09-29 03:54:46.599 +07:00 [DBG] Selected output formatter 'Microsoft.AspNetCore.Mvc.Formatters.SystemTextJsonOutputFormatter' and content type 'application/json' to write the response.
+2025-09-29 03:54:46.599 +07:00 [INF] Executing ObjectResult, writing value of type 'FS.Commons.FSResponse'.
+2025-09-29 03:54:46.599 +07:00 [INF] Executed action CapBot.api.Controllers.SubmissionController.List (CapBot.api) in 27.9733ms
+2025-09-29 03:54:46.599 +07:00 [INF] Executed endpoint 'CapBot.api.Controllers.SubmissionController.List (CapBot.api)'
+2025-09-29 03:54:46.599 +07:00 [DBG] Connection id "0HNFUQ4FJ9UMK" completed keep alive response.
+2025-09-29 03:54:46.599 +07:00 [DBG] 'MyDbContext' disposed.
+2025-09-29 03:54:46.599 +07:00 [DBG] Disposing connection to database 'capbot_db' on server 'localhost'.
+2025-09-29 03:54:46.599 +07:00 [DBG] Disposed connection to database '' on server '' (0ms).
+2025-09-29 03:54:46.599 +07:00 [INF] Request finished HTTP/1.1 GET http://localhost:5207/api/submission/list?PageNumber=1&PageSize=10 - 200 null application/json; charset=utf-8 29.6223ms
+2025-09-29 03:54:46.604 +07:00 [INF] Request starting HTTP/1.1 GET http://localhost:5207/images/entities/11111111.png - null null
+2025-09-29 03:54:46.604 +07:00 [DBG] The request path /images/entities/11111111.png does not match an existing file
+2025-09-29 03:54:46.605 +07:00 [DBG] The request path /images/entities/11111111.png does not match an existing file
+2025-09-29 03:54:46.605 +07:00 [DBG] No candidates found for the request path '/images/entities/11111111.png'
+2025-09-29 03:54:46.605 +07:00 [DBG] Request did not match any endpoints
+2025-09-29 03:54:46.605 +07:00 [DBG] AuthenticationScheme: Bearer was not authenticated.
+2025-09-29 03:54:46.605 +07:00 [DBG] Connection id "0HNFUQ4FJ9UMI" completed keep alive response.
+2025-09-29 03:54:46.606 +07:00 [INF] Request finished HTTP/1.1 GET http://localhost:5207/images/entities/11111111.png - 404 0 null 1.6002ms
+2025-09-29 03:54:46.606 +07:00 [INF] Request reached the end of the middleware pipeline without being handled by application code. Request path: GET http://localhost:5207/images/entities/11111111.png, Response status code: 404
+2025-09-29 03:54:57.069 +07:00 [INF] Application is shutting down...
+2025-09-29 03:54:57.072 +07:00 [DBG] Hosting stopping
+2025-09-29 03:54:57.077 +07:00 [DBG] Connection id "0HNFUQ4FJ9UMJ" disconnecting.
+2025-09-29 03:54:57.077 +07:00 [DBG] Connection id "0HNFUQ4FJ9UMI" disconnecting.
+2025-09-29 03:54:57.078 +07:00 [DBG] Connection id "0HNFUQ4FJ9UML" disconnecting.
+2025-09-29 03:54:57.079 +07:00 [DBG] Connection id "0HNFUQ4FJ9UMK" disconnecting.
+2025-09-29 03:54:57.080 +07:00 [DBG] Connection id "0HNFUQ4FJ9UML" stopped.
+2025-09-29 03:54:57.080 +07:00 [DBG] Connection id "0HNFUQ4FJ9UMK" stopped.
+2025-09-29 03:54:57.080 +07:00 [DBG] Connection id "0HNFUQ4FJ9UMI" stopped.
+2025-09-29 03:54:57.080 +07:00 [DBG] Connection id "0HNFUQ4FJ9UMJ" stopped.
+2025-09-29 03:54:57.081 +07:00 [DBG] Connection id "0HNFUQ4FJ9UMI" sending FIN because: "The Socket transport's send loop completed gracefully."
+2025-09-29 03:54:57.081 +07:00 [DBG] Connection id "0HNFUQ4FJ9UML" sending FIN because: "The Socket transport's send loop completed gracefully."
+2025-09-29 03:54:57.082 +07:00 [DBG] Connection id "0HNFUQ4FJ9UMJ" sending FIN because: "The Socket transport's send loop completed gracefully."
+2025-09-29 03:54:57.082 +07:00 [DBG] Connection id "0HNFUQ4FJ9UMK" sending FIN because: "The Socket transport's send loop completed gracefully."
+2025-09-29 03:54:57.088 +07:00 [ERR] Lỗi khi kiểm tra deadline notifications
+System.Threading.Tasks.TaskCanceledException: A task was canceled.
+   at CapBot.api.Services.DeadlineNotificationService.ExecuteAsync(CancellationToken stoppingToken) in C:\Users\Admin\Downloads\CBAI_API\capbot.api\Services\DeadlineNotificationService.cs:line 41
+2025-09-29 03:54:57.116 +07:00 [DBG] Hosting stopped


### PR DESCRIPTION
This pull request introduces stricter enforcement of reviewer assignment limits per submission and updates the logic for determining submission status, especially in cases where a submission is escalated to a moderator. These changes ensure that no more than two reviewers are assigned to a submission under normal circumstances, with a special allowance for a moderator to add an extra reviewer if needed. Additionally, the logic for updating submission status has been refined to better handle both standard and escalated review scenarios.

**Reviewer assignment limits:**

* Enforced a maximum of two reviewers per submission in both individual and bulk assignment operations, with a special exception allowing a moderator to add a third reviewer if the submission is escalated to moderator status. [[1]](diffhunk://#diff-26e0313dd9fea37043069b6c831b98b26bc09a79286c9ddbf56e8b054f861d54R195-R237) [[2]](diffhunk://#diff-26e0313dd9fea37043069b6c831b98b26bc09a79286c9ddbf56e8b054f861d54R438-R460)
* Updated the auto-assignment logic to respect the reviewer cap, preventing assignment if the submission already has two reviewers and providing appropriate warnings.

**Submission status update logic:**

* Refined the logic in `UpdateSubmissionStatusAfterSubmit` to handle escalated submissions: when escalated to moderator, the latest moderator review alone determines the final status; otherwise, the standard two-reviewer rule applies.
* Simplified the status update conditions to approve or reject a submission if there are at least two approvals or rejections, regardless of the total number of reviews, both in review and submission services. [[1]](diffhunk://#diff-2931bdb699aca5c6cf2d470458a9f1018b5bfaca9f47323241d3185f870d751aL68-R108) [[2]](diffhunk://#diff-97a37152fdf7a45d867b92181e87d1d0604065dcb9c547c815eb0c236b23cde0L201-R205)