### PR TITLE
Fix: update match with latestsubmissionstatus with status when review…

### DIFF
--- a/CapBot.api/Logs/log20251004.txt
+++ b/CapBot.api/Logs/log20251004.txt
@@ -1839,3 +1839,3863 @@ WHERE [u].[NormalizedEmail] = @__normalizedEmail_0
 System.Threading.Tasks.TaskCanceledException: A task was canceled.
    at CapBot.api.Services.DeadlineNotificationService.ExecuteAsync(CancellationToken stoppingToken) in C:\Users\acer\Downloads\CBAI_API\capbot.api\Services\DeadlineNotificationService.cs:line 41
 2025-10-04 01:43:11.765 +07:00 [DBG] Hosting stopped
+2025-10-04 02:05:01.151 +07:00 [DBG] An 'IServiceProvider' was created for internal use by Entity Framework.
+2025-10-04 02:05:01.388 +07:00 [INF] User profile is available. Using 'C:\Users\acer\AppData\Local\ASP.NET\DataProtection-Keys' as key repository and Windows DPAPI to encrypt keys at rest.
+2025-10-04 02:05:01.969 +07:00 [DBG] No relationship from 'ReviewerAssignment' to 'User' has been configured by convention because there are multiple properties on one entity type - {'AssignedByUser', 'Reviewer'} that could be matched with the properties on the other entity type - {'ReviewerAssignments'}. This message can be disregarded if explicit configuration has been specified in 'OnModelCreating'.
+2025-10-04 02:05:02.018 +07:00 [DBG] No relationship from 'SubmissionWorkflowLog' to 'WorkflowState' has been configured by convention because there are multiple properties on one entity type - {'FromState', 'ToState'} that could be matched with the properties on the other entity type - {'FromStateLogs', 'ToStateLogs'}. This message can be disregarded if explicit configuration has been specified in 'OnModelCreating'.
+2025-10-04 02:05:02.061 +07:00 [DBG] No relationship from 'User' to 'ReviewerAssignment' has been configured by convention because there are multiple properties on one entity type - {'ReviewerAssignments'} that could be matched with the properties on the other entity type - {'AssignedByUser', 'Reviewer'}. This message can be disregarded if explicit configuration has been specified in 'OnModelCreating'.
+2025-10-04 02:05:02.064 +07:00 [DBG] No relationship from 'WorkflowState' to 'SubmissionWorkflowLog' has been configured by convention because there are multiple properties on one entity type - {'FromStateLogs', 'ToStateLogs'} that could be matched with the properties on the other entity type - {'FromState', 'ToState'}. This message can be disregarded if explicit configuration has been specified in 'OnModelCreating'.
+2025-10-04 02:05:02.065 +07:00 [DBG] No relationship from 'WorkflowState' to 'WorkflowTransition' has been configured by convention because there are multiple properties on one entity type - {'FromTransitions', 'ToTransitions'} that could be matched with the properties on the other entity type - {'FromState', 'ToState'}. This message can be disregarded if explicit configuration has been specified in 'OnModelCreating'.
+2025-10-04 02:05:02.068 +07:00 [DBG] No relationship from 'WorkflowTransition' to 'WorkflowState' has been configured by convention because there are multiple properties on one entity type - {'FromState', 'ToState'} that could be matched with the properties on the other entity type - {'FromTransitions', 'ToTransitions'}. This message can be disregarded if explicit configuration has been specified in 'OnModelCreating'.
+2025-10-04 02:05:02.490 +07:00 [DBG] No relationship from 'ReviewerAssignment' to 'User' has been configured by convention because there are multiple properties on one entity type - {'AssignedByUser', 'Reviewer'} that could be matched with the properties on the other entity type - {'ReviewerAssignments'}. This message can be disregarded if explicit configuration has been specified in 'OnModelCreating'.
+2025-10-04 02:05:02.492 +07:00 [DBG] No relationship from 'User' to 'ReviewerAssignment' has been configured by convention because there are multiple properties on one entity type - {'ReviewerAssignments'} that could be matched with the properties on the other entity type - {'AssignedByUser', 'Reviewer'}. This message can be disregarded if explicit configuration has been specified in 'OnModelCreating'.
+2025-10-04 02:05:02.528 +07:00 [DBG] No relationship from 'WorkflowTransition' to 'WorkflowState' has been configured by convention because there are multiple properties on one entity type - {'FromState', 'ToState'} that could be matched with the properties on the other entity type - {'FromTransitions', 'ToTransitions'}. This message can be disregarded if explicit configuration has been specified in 'OnModelCreating'.
+2025-10-04 02:05:02.529 +07:00 [DBG] No relationship from 'WorkflowState' to 'SubmissionWorkflowLog' has been configured by convention because there are multiple properties on one entity type - {'FromStateLogs', 'ToStateLogs'} that could be matched with the properties on the other entity type - {'FromState', 'ToState'}. This message can be disregarded if explicit configuration has been specified in 'OnModelCreating'.
+2025-10-04 02:05:02.530 +07:00 [DBG] No relationship from 'WorkflowState' to 'WorkflowTransition' has been configured by convention because there are multiple properties on one entity type - {'FromTransitions', 'ToTransitions'} that could be matched with the properties on the other entity type - {'FromState', 'ToState'}. This message can be disregarded if explicit configuration has been specified in 'OnModelCreating'.
+2025-10-04 02:05:02.532 +07:00 [DBG] No relationship from 'WorkflowState' to 'SubmissionWorkflowLog' has been configured by convention because there are multiple properties on one entity type - {'FromStateLogs', 'ToStateLogs'} that could be matched with the properties on the other entity type - {'FromState', 'ToState'}. This message can be disregarded if explicit configuration has been specified in 'OnModelCreating'.
+2025-10-04 02:05:02.544 +07:00 [DBG] No relationship from 'SubmissionWorkflowLog' to 'WorkflowState' has been configured by convention because there are multiple properties on one entity type - {'FromState', 'ToState'} that could be matched with the properties on the other entity type - {'FromStateLogs', 'ToStateLogs'}. This message can be disregarded if explicit configuration has been specified in 'OnModelCreating'.
+2025-10-04 02:05:02.545 +07:00 [DBG] No relationship from 'WorkflowState' to 'SubmissionWorkflowLog' has been configured by convention because there are multiple properties on one entity type - {'FromStateLogs', 'ToStateLogs'} that could be matched with the properties on the other entity type - {'FromState', 'ToState'}. This message can be disregarded if explicit configuration has been specified in 'OnModelCreating'.
+2025-10-04 02:05:02.627 +07:00 [DBG] The index {'LecturerId'} was not created on entity type 'LecturerSkill' as the properties are already covered by the index {'LecturerId', 'SkillTag'}.
+2025-10-04 02:05:02.628 +07:00 [DBG] The index {'SemesterId'} was not created on entity type 'Phase' as the properties are already covered by the index {'SemesterId', 'PhaseTypeId'}.
+2025-10-04 02:05:02.629 +07:00 [DBG] The index {'AssignmentId'} was not created on entity type 'Review' as the properties are already covered by the index {'AssignmentId', 'Status'}.
+2025-10-04 02:05:02.629 +07:00 [DBG] The index {'ReviewId'} was not created on entity type 'ReviewComment' as the properties are already covered by the index {'ReviewId', 'SectionName'}.
+2025-10-04 02:05:02.630 +07:00 [DBG] The index {'ReviewId'} was not created on entity type 'ReviewCriteriaScore' as the properties are already covered by the index {'ReviewId', 'CriteriaId'}.
+2025-10-04 02:05:02.630 +07:00 [DBG] The index {'ReviewerId'} was not created on entity type 'ReviewerAssignment' as the properties are already covered by the index {'ReviewerId', 'Status'}.
+2025-10-04 02:05:02.631 +07:00 [DBG] The index {'SubmissionId'} was not created on entity type 'ReviewerAssignment' as the properties are already covered by the index {'SubmissionId', 'ReviewerId'}.
+2025-10-04 02:05:02.632 +07:00 [DBG] The index {'ReviewerId'} was not created on entity type 'ReviewerPerformance' as the properties are already covered by the index {'ReviewerId', 'SemesterId'}.
+2025-10-04 02:05:02.632 +07:00 [DBG] The index {'PhaseId'} was not created on entity type 'Submission' as the properties are already covered by the index {'PhaseId', 'Status'}.
+2025-10-04 02:05:02.633 +07:00 [DBG] The index {'PhaseId'} was not created on entity type 'Submission' as the properties are already covered by the index {'PhaseId', 'Status', 'SubmittedAt'}.
+2025-10-04 02:05:02.636 +07:00 [DBG] The index {'TopicId'} was not created on entity type 'Submission' as the properties are already covered by the index {'TopicId', 'PhaseId', 'SubmissionRound'}.
+2025-10-04 02:05:02.636 +07:00 [DBG] The index {'SubmissionId'} was not created on entity type 'SubmissionWorkflowLog' as the properties are already covered by the index {'SubmissionId', 'CreatedAt'}.
+2025-10-04 02:05:02.637 +07:00 [DBG] The index {'UserId'} was not created on entity type 'SystemNotification' as the properties are already covered by the index {'UserId', 'IsRead', 'CreatedAt'}.
+2025-10-04 02:05:02.637 +07:00 [DBG] The index {'SemesterId'} was not created on entity type 'Topic' as the properties are already covered by the index {'SemesterId', 'IsApproved'}.
+2025-10-04 02:05:02.637 +07:00 [DBG] The index {'SupervisorId'} was not created on entity type 'Topic' as the properties are already covered by the index {'SupervisorId', 'SemesterId'}.
+2025-10-04 02:05:02.638 +07:00 [DBG] The index {'TopicId'} was not created on entity type 'TopicVersion' as the properties are already covered by the index {'TopicId', 'Status'}.
+2025-10-04 02:05:02.638 +07:00 [DBG] The index {'TopicId'} was not created on entity type 'TopicVersion' as the properties are already covered by the index {'TopicId', 'VersionNumber'}.
+2025-10-04 02:05:02.639 +07:00 [DBG] The index {'UserId'} was not created on entity type 'UserRole' as the properties are already covered by the index {'UserId', 'RoleId'}.
+2025-10-04 02:05:02.639 +07:00 [DBG] The index {'UserId'} was not created on entity type 'UserToken' as the properties are already covered by the index {'UserId', 'LoginProvider', 'Name'}.
+2025-10-04 02:05:03.065 +07:00 [WRN] The 'ProficiencyLevels' property 'ProficiencyLevel' on entity type 'LecturerSkill' is configured with a database-generated default, but has no configured sentinel value. The database-generated default will always be used for inserts when the property has the value '0', since this is the CLR default for the 'ProficiencyLevels' type. Consider using a nullable type, using a nullable backing field, or setting the sentinel value for the property to ensure the database default is used when, and only when, appropriate. See https://aka.ms/efcore-docs-default-values for more information.
+2025-10-04 02:05:03.070 +07:00 [WRN] The 'ReviewRecommendations' property 'Recommendation' on entity type 'Review' is configured with a database-generated default, but has no configured sentinel value. The database-generated default will always be used for inserts when the property has the value '0', since this is the CLR default for the 'ReviewRecommendations' type. Consider using a nullable type, using a nullable backing field, or setting the sentinel value for the property to ensure the database default is used when, and only when, appropriate. See https://aka.ms/efcore-docs-default-values for more information.
+2025-10-04 02:05:03.072 +07:00 [WRN] The 'ReviewStatus' property 'Status' on entity type 'Review' is configured with a database-generated default, but has no configured sentinel value. The database-generated default will always be used for inserts when the property has the value '0', since this is the CLR default for the 'ReviewStatus' type. Consider using a nullable type, using a nullable backing field, or setting the sentinel value for the property to ensure the database default is used when, and only when, appropriate. See https://aka.ms/efcore-docs-default-values for more information.
+2025-10-04 02:05:03.073 +07:00 [WRN] The 'CommentTypes' property 'CommentType' on entity type 'ReviewComment' is configured with a database-generated default, but has no configured sentinel value. The database-generated default will always be used for inserts when the property has the value '0', since this is the CLR default for the 'CommentTypes' type. Consider using a nullable type, using a nullable backing field, or setting the sentinel value for the property to ensure the database default is used when, and only when, appropriate. See https://aka.ms/efcore-docs-default-values for more information.
+2025-10-04 02:05:03.075 +07:00 [WRN] The 'PriorityLevels' property 'Priority' on entity type 'ReviewComment' is configured with a database-generated default, but has no configured sentinel value. The database-generated default will always be used for inserts when the property has the value '0', since this is the CLR default for the 'PriorityLevels' type. Consider using a nullable type, using a nullable backing field, or setting the sentinel value for the property to ensure the database default is used when, and only when, appropriate. See https://aka.ms/efcore-docs-default-values for more information.
+2025-10-04 02:05:03.076 +07:00 [WRN] The 'AssignmentTypes' property 'AssignmentType' on entity type 'ReviewerAssignment' is configured with a database-generated default, but has no configured sentinel value. The database-generated default will always be used for inserts when the property has the value '0', since this is the CLR default for the 'AssignmentTypes' type. Consider using a nullable type, using a nullable backing field, or setting the sentinel value for the property to ensure the database default is used when, and only when, appropriate. See https://aka.ms/efcore-docs-default-values for more information.
+2025-10-04 02:05:03.077 +07:00 [WRN] The 'AssignmentStatus' property 'Status' on entity type 'ReviewerAssignment' is configured with a database-generated default, but has no configured sentinel value. The database-generated default will always be used for inserts when the property has the value '0', since this is the CLR default for the 'AssignmentStatus' type. Consider using a nullable type, using a nullable backing field, or setting the sentinel value for the property to ensure the database default is used when, and only when, appropriate. See https://aka.ms/efcore-docs-default-values for more information.
+2025-10-04 02:05:03.078 +07:00 [WRN] The 'AiCheckStatus' property 'AiCheckStatus' on entity type 'Submission' is configured with a database-generated default, but has no configured sentinel value. The database-generated default will always be used for inserts when the property has the value '0', since this is the CLR default for the 'AiCheckStatus' type. Consider using a nullable type, using a nullable backing field, or setting the sentinel value for the property to ensure the database default is used when, and only when, appropriate. See https://aka.ms/efcore-docs-default-values for more information.
+2025-10-04 02:05:03.080 +07:00 [WRN] The 'SubmissionStatus' property 'Status' on entity type 'Submission' is configured with a database-generated default, but has no configured sentinel value. The database-generated default will always be used for inserts when the property has the value '0', since this is the CLR default for the 'SubmissionStatus' type. Consider using a nullable type, using a nullable backing field, or setting the sentinel value for the property to ensure the database default is used when, and only when, appropriate. See https://aka.ms/efcore-docs-default-values for more information.
+2025-10-04 02:05:03.081 +07:00 [WRN] The 'NotificationTypes' property 'Type' on entity type 'SystemNotification' is configured with a database-generated default, but has no configured sentinel value. The database-generated default will always be used for inserts when the property has the value '0', since this is the CLR default for the 'NotificationTypes' type. Consider using a nullable type, using a nullable backing field, or setting the sentinel value for the property to ensure the database default is used when, and only when, appropriate. See https://aka.ms/efcore-docs-default-values for more information.
+2025-10-04 02:05:03.082 +07:00 [WRN] The 'TopicStatus' property 'Status' on entity type 'TopicVersion' is configured with a database-generated default, but has no configured sentinel value. The database-generated default will always be used for inserts when the property has the value '0', since this is the CLR default for the 'TopicStatus' type. Consider using a nullable type, using a nullable backing field, or setting the sentinel value for the property to ensure the database default is used when, and only when, appropriate. See https://aka.ms/efcore-docs-default-values for more information.
+2025-10-04 02:05:03.452 +07:00 [DBG] Entity Framework Core 8.0.16 initialized 'MyDbContext' using provider 'Microsoft.EntityFrameworkCore.SqlServer:8.0.13' with options: MigrationsAssembly=App.DAL 
+2025-10-04 02:05:03.611 +07:00 [DBG] Compiling query expression: 
+'DbSet<Role>()
+    .FirstOrDefault(r => r.NormalizedName == __normalizedName_0)'
+2025-10-04 02:05:04.031 +07:00 [DBG] Generated query execution expression: 
+'queryContext => ShapedQueryCompilingExpressionVisitor.SingleOrDefaultAsync<Role>(
+    asyncEnumerable: new SingleQueryingEnumerable<Role>(
+        (RelationalQueryContext)queryContext, 
+        RelationalCommandCache.QueryExpression(
+            Projection Mapping:
+                EmptyProjectionMember -> Dictionary<IProperty, int> { [Property: Role.Id (int) Required PK AfterSave:Throw ValueGenerated.OnAdd, 0], [Property: Role.ConcurrencyStamp (string), 1], [Property: Role.IsAdmin (bool) Required, 2], [Property: Role.Name (string), 3], [Property: Role.NormalizedName (string), 4] }
+            SELECT TOP(1) r.Id, r.ConcurrencyStamp, r.IsAdmin, r.Name, r.NormalizedName
+            FROM roles AS r
+            WHERE r.NormalizedName == @__normalizedName_0), 
+        null, 
+        Func<QueryContext, DbDataReader, ResultContext, SingleQueryResultCoordinator, Role>, 
+        App.DAL.Context.MyDbContext, 
+        False, 
+        False, 
+        True
+    ), 
+    cancellationToken: queryContext.CancellationToken)'
+2025-10-04 02:05:04.161 +07:00 [DBG] Creating DbConnection.
+2025-10-04 02:05:04.253 +07:00 [DBG] Created DbConnection. (82ms).
+2025-10-04 02:05:04.267 +07:00 [DBG] Opening connection to database 'capbot_db' on server 'localhost'.
+2025-10-04 02:05:04.906 +07:00 [DBG] Opened connection to database 'capbot_db' on server 'localhost'.
+2025-10-04 02:05:04.914 +07:00 [DBG] Creating DbCommand for 'ExecuteReader'.
+2025-10-04 02:05:04.927 +07:00 [DBG] Created DbCommand for 'ExecuteReader' (9ms).
+2025-10-04 02:05:04.943 +07:00 [DBG] Initialized DbCommand for 'ExecuteReader' (30ms).
+2025-10-04 02:05:04.958 +07:00 [DBG] Executing DbCommand [Parameters=[@__normalizedName_0='?' (Size = 4000)], CommandType='"Text"', CommandTimeout='30']
+SELECT TOP(1) [r].[Id], [r].[ConcurrencyStamp], [r].[IsAdmin], [r].[Name], [r].[NormalizedName]
+FROM [roles] AS [r]
+WHERE [r].[NormalizedName] = @__normalizedName_0
+2025-10-04 02:05:05.104 +07:00 [INF] Executed DbCommand (133ms) [Parameters=[@__normalizedName_0='?' (Size = 4000)], CommandType='"Text"', CommandTimeout='30']
+SELECT TOP(1) [r].[Id], [r].[ConcurrencyStamp], [r].[IsAdmin], [r].[Name], [r].[NormalizedName]
+FROM [roles] AS [r]
+WHERE [r].[NormalizedName] = @__normalizedName_0
+2025-10-04 02:05:05.230 +07:00 [DBG] Context 'MyDbContext' started tracking 'Role' entity. Consider using 'DbContextOptionsBuilder.EnableSensitiveDataLogging' to see key values.
+2025-10-04 02:05:05.308 +07:00 [DBG] Closing data reader to 'capbot_db' on server 'localhost'.
+2025-10-04 02:05:05.326 +07:00 [DBG] A data reader for 'capbot_db' on server 'localhost' is being disposed after spending 205ms reading results.
+2025-10-04 02:05:05.334 +07:00 [DBG] Closing connection to database 'capbot_db' on server 'localhost'.
+2025-10-04 02:05:05.344 +07:00 [DBG] Closed connection to database 'capbot_db' on server 'localhost' (12ms).
+2025-10-04 02:05:05.355 +07:00 [DBG] Opening connection to database 'capbot_db' on server 'localhost'.
+2025-10-04 02:05:05.357 +07:00 [DBG] Opened connection to database 'capbot_db' on server 'localhost'.
+2025-10-04 02:05:05.357 +07:00 [DBG] Creating DbCommand for 'ExecuteReader'.
+2025-10-04 02:05:05.358 +07:00 [DBG] Created DbCommand for 'ExecuteReader' (0ms).
+2025-10-04 02:05:05.360 +07:00 [DBG] Initialized DbCommand for 'ExecuteReader' (2ms).
+2025-10-04 02:05:05.361 +07:00 [DBG] Executing DbCommand [Parameters=[@__normalizedName_0='?' (Size = 4000)], CommandType='"Text"', CommandTimeout='30']
+SELECT TOP(1) [r].[Id], [r].[ConcurrencyStamp], [r].[IsAdmin], [r].[Name], [r].[NormalizedName]
+FROM [roles] AS [r]
+WHERE [r].[NormalizedName] = @__normalizedName_0
+2025-10-04 02:05:05.379 +07:00 [INF] Executed DbCommand (19ms) [Parameters=[@__normalizedName_0='?' (Size = 4000)], CommandType='"Text"', CommandTimeout='30']
+SELECT TOP(1) [r].[Id], [r].[ConcurrencyStamp], [r].[IsAdmin], [r].[Name], [r].[NormalizedName]
+FROM [roles] AS [r]
+WHERE [r].[NormalizedName] = @__normalizedName_0
+2025-10-04 02:05:05.382 +07:00 [DBG] Context 'MyDbContext' started tracking 'Role' entity. Consider using 'DbContextOptionsBuilder.EnableSensitiveDataLogging' to see key values.
+2025-10-04 02:05:05.388 +07:00 [DBG] Closing data reader to 'capbot_db' on server 'localhost'.
+2025-10-04 02:05:05.388 +07:00 [DBG] A data reader for 'capbot_db' on server 'localhost' is being disposed after spending 8ms reading results.
+2025-10-04 02:05:05.389 +07:00 [DBG] Closing connection to database 'capbot_db' on server 'localhost'.
+2025-10-04 02:05:05.390 +07:00 [DBG] Closed connection to database 'capbot_db' on server 'localhost' (0ms).
+2025-10-04 02:05:05.392 +07:00 [DBG] Opening connection to database 'capbot_db' on server 'localhost'.
+2025-10-04 02:05:05.395 +07:00 [DBG] Opened connection to database 'capbot_db' on server 'localhost'.
+2025-10-04 02:05:05.395 +07:00 [DBG] Creating DbCommand for 'ExecuteReader'.
+2025-10-04 02:05:05.395 +07:00 [DBG] Created DbCommand for 'ExecuteReader' (0ms).
+2025-10-04 02:05:05.396 +07:00 [DBG] Initialized DbCommand for 'ExecuteReader' (0ms).
+2025-10-04 02:05:05.396 +07:00 [DBG] Executing DbCommand [Parameters=[@__normalizedName_0='?' (Size = 4000)], CommandType='"Text"', CommandTimeout='30']
+SELECT TOP(1) [r].[Id], [r].[ConcurrencyStamp], [r].[IsAdmin], [r].[Name], [r].[NormalizedName]
+FROM [roles] AS [r]
+WHERE [r].[NormalizedName] = @__normalizedName_0
+2025-10-04 02:05:05.398 +07:00 [INF] Executed DbCommand (2ms) [Parameters=[@__normalizedName_0='?' (Size = 4000)], CommandType='"Text"', CommandTimeout='30']
+SELECT TOP(1) [r].[Id], [r].[ConcurrencyStamp], [r].[IsAdmin], [r].[Name], [r].[NormalizedName]
+FROM [roles] AS [r]
+WHERE [r].[NormalizedName] = @__normalizedName_0
+2025-10-04 02:05:05.404 +07:00 [DBG] Context 'MyDbContext' started tracking 'Role' entity. Consider using 'DbContextOptionsBuilder.EnableSensitiveDataLogging' to see key values.
+2025-10-04 02:05:05.405 +07:00 [DBG] Closing data reader to 'capbot_db' on server 'localhost'.
+2025-10-04 02:05:05.406 +07:00 [DBG] A data reader for 'capbot_db' on server 'localhost' is being disposed after spending 2ms reading results.
+2025-10-04 02:05:05.407 +07:00 [DBG] Closing connection to database 'capbot_db' on server 'localhost'.
+2025-10-04 02:05:05.407 +07:00 [DBG] Closed connection to database 'capbot_db' on server 'localhost' (0ms).
+2025-10-04 02:05:05.409 +07:00 [DBG] Opening connection to database 'capbot_db' on server 'localhost'.
+2025-10-04 02:05:05.410 +07:00 [DBG] Opened connection to database 'capbot_db' on server 'localhost'.
+2025-10-04 02:05:05.411 +07:00 [DBG] Creating DbCommand for 'ExecuteReader'.
+2025-10-04 02:05:05.411 +07:00 [DBG] Created DbCommand for 'ExecuteReader' (0ms).
+2025-10-04 02:05:05.412 +07:00 [DBG] Initialized DbCommand for 'ExecuteReader' (1ms).
+2025-10-04 02:05:05.413 +07:00 [DBG] Executing DbCommand [Parameters=[@__normalizedName_0='?' (Size = 4000)], CommandType='"Text"', CommandTimeout='30']
+SELECT TOP(1) [r].[Id], [r].[ConcurrencyStamp], [r].[IsAdmin], [r].[Name], [r].[NormalizedName]
+FROM [roles] AS [r]
+WHERE [r].[NormalizedName] = @__normalizedName_0
+2025-10-04 02:05:05.414 +07:00 [INF] Executed DbCommand (2ms) [Parameters=[@__normalizedName_0='?' (Size = 4000)], CommandType='"Text"', CommandTimeout='30']
+SELECT TOP(1) [r].[Id], [r].[ConcurrencyStamp], [r].[IsAdmin], [r].[Name], [r].[NormalizedName]
+FROM [roles] AS [r]
+WHERE [r].[NormalizedName] = @__normalizedName_0
+2025-10-04 02:05:05.421 +07:00 [DBG] Context 'MyDbContext' started tracking 'Role' entity. Consider using 'DbContextOptionsBuilder.EnableSensitiveDataLogging' to see key values.
+2025-10-04 02:05:05.423 +07:00 [DBG] Closing data reader to 'capbot_db' on server 'localhost'.
+2025-10-04 02:05:05.423 +07:00 [DBG] A data reader for 'capbot_db' on server 'localhost' is being disposed after spending 2ms reading results.
+2025-10-04 02:05:05.426 +07:00 [DBG] Closing connection to database 'capbot_db' on server 'localhost'.
+2025-10-04 02:05:05.427 +07:00 [DBG] Closed connection to database 'capbot_db' on server 'localhost' (0ms).
+2025-10-04 02:05:05.455 +07:00 [DBG] Compiling query expression: 
+'DbSet<User>()
+    .SingleOrDefault(u => u.NormalizedEmail == __normalizedEmail_0)'
+2025-10-04 02:05:05.486 +07:00 [DBG] Generated query execution expression: 
+'queryContext => ShapedQueryCompilingExpressionVisitor.SingleOrDefaultAsync<User>(
+    asyncEnumerable: new SingleQueryingEnumerable<User>(
+        (RelationalQueryContext)queryContext, 
+        RelationalCommandCache.QueryExpression(
+            Projection Mapping:
+                EmptyProjectionMember -> Dictionary<IProperty, int> { [Property: User.Id (int) Required PK AfterSave:Throw ValueGenerated.OnAdd, 0], [Property: User.AccessFailedCount (int) Required, 1], [Property: User.ConcurrencyStamp (string), 2], [Property: User.CreatedAt (DateTime) Required, 3], [Property: User.DeletedAt (DateTime?), 4], [Property: User.Email (string), 5], [Property: User.EmailConfirmed (bool) Required, 6], [Property: User.LastModifiedAt (DateTime) Required, 7], [Property: User.LastModifiedBy (string), 8], [Property: User.LockoutEnabled (bool) Required, 9], [Property: User.LockoutEnd (DateTimeOffset?), 10], [Property: User.NormalizedEmail (string), 11], [Property: User.NormalizedUserName (string), 12], [Property: User.PasswordHash (string), 13], [Property: User.PhoneNumber (string), 14], [Property: User.PhoneNumberConfirmed (bool) Required, 15], [Property: User.SecurityStamp (string), 16], [Property: User.TwoFactorEnabled (bool) Required, 17], [Property: User.UserName (string), 18] }
+            SELECT TOP(2) u.Id, u.AccessFailedCount, u.ConcurrencyStamp, u.CreatedAt, u.DeletedAt, u.Email, u.EmailConfirmed, u.LastModifiedAt, u.LastModifiedBy, u.LockoutEnabled, u.LockoutEnd, u.NormalizedEmail, u.NormalizedUserName, u.PasswordHash, u.PhoneNumber, u.PhoneNumberConfirmed, u.SecurityStamp, u.TwoFactorEnabled, u.UserName
+            FROM users AS u
+            WHERE u.NormalizedEmail == @__normalizedEmail_0), 
+        null, 
+        Func<QueryContext, DbDataReader, ResultContext, SingleQueryResultCoordinator, User>, 
+        App.DAL.Context.MyDbContext, 
+        False, 
+        False, 
+        True
+    ), 
+    cancellationToken: queryContext.CancellationToken)'
+2025-10-04 02:05:05.495 +07:00 [DBG] Opening connection to database 'capbot_db' on server 'localhost'.
+2025-10-04 02:05:05.496 +07:00 [DBG] Opened connection to database 'capbot_db' on server 'localhost'.
+2025-10-04 02:05:05.497 +07:00 [DBG] Creating DbCommand for 'ExecuteReader'.
+2025-10-04 02:05:05.498 +07:00 [DBG] Created DbCommand for 'ExecuteReader' (0ms).
+2025-10-04 02:05:05.502 +07:00 [DBG] Initialized DbCommand for 'ExecuteReader' (5ms).
+2025-10-04 02:05:05.503 +07:00 [DBG] Executing DbCommand [Parameters=[@__normalizedEmail_0='?' (Size = 4000)], CommandType='"Text"', CommandTimeout='30']
+SELECT TOP(2) [u].[Id], [u].[AccessFailedCount], [u].[ConcurrencyStamp], [u].[CreatedAt], [u].[DeletedAt], [u].[Email], [u].[EmailConfirmed], [u].[LastModifiedAt], [u].[LastModifiedBy], [u].[LockoutEnabled], [u].[LockoutEnd], [u].[NormalizedEmail], [u].[NormalizedUserName], [u].[PasswordHash], [u].[PhoneNumber], [u].[PhoneNumberConfirmed], [u].[SecurityStamp], [u].[TwoFactorEnabled], [u].[UserName]
+FROM [users] AS [u]
+WHERE [u].[NormalizedEmail] = @__normalizedEmail_0
+2025-10-04 02:05:05.513 +07:00 [INF] Executed DbCommand (9ms) [Parameters=[@__normalizedEmail_0='?' (Size = 4000)], CommandType='"Text"', CommandTimeout='30']
+SELECT TOP(2) [u].[Id], [u].[AccessFailedCount], [u].[ConcurrencyStamp], [u].[CreatedAt], [u].[DeletedAt], [u].[Email], [u].[EmailConfirmed], [u].[LastModifiedAt], [u].[LastModifiedBy], [u].[LockoutEnabled], [u].[LockoutEnd], [u].[NormalizedEmail], [u].[NormalizedUserName], [u].[PasswordHash], [u].[PhoneNumber], [u].[PhoneNumberConfirmed], [u].[SecurityStamp], [u].[TwoFactorEnabled], [u].[UserName]
+FROM [users] AS [u]
+WHERE [u].[NormalizedEmail] = @__normalizedEmail_0
+2025-10-04 02:05:05.586 +07:00 [DBG] Context 'MyDbContext' started tracking 'User' entity. Consider using 'DbContextOptionsBuilder.EnableSensitiveDataLogging' to see key values.
+2025-10-04 02:05:05.676 +07:00 [DBG] Closing data reader to 'capbot_db' on server 'localhost'.
+2025-10-04 02:05:05.677 +07:00 [DBG] A data reader for 'capbot_db' on server 'localhost' is being disposed after spending 156ms reading results.
+2025-10-04 02:05:05.677 +07:00 [DBG] Closing connection to database 'capbot_db' on server 'localhost'.
+2025-10-04 02:05:05.677 +07:00 [DBG] Closed connection to database 'capbot_db' on server 'localhost' (0ms).
+2025-10-04 02:05:05.688 +07:00 [INF] Admin user 'admin.capbot@gmail.com' already exists
+2025-10-04 02:05:05.694 +07:00 [DBG] Opening connection to database 'capbot_db' on server 'localhost'.
+2025-10-04 02:05:05.695 +07:00 [DBG] Opened connection to database 'capbot_db' on server 'localhost'.
+2025-10-04 02:05:05.695 +07:00 [DBG] Creating DbCommand for 'ExecuteReader'.
+2025-10-04 02:05:05.695 +07:00 [DBG] Created DbCommand for 'ExecuteReader' (0ms).
+2025-10-04 02:05:05.696 +07:00 [DBG] Initialized DbCommand for 'ExecuteReader' (0ms).
+2025-10-04 02:05:05.696 +07:00 [DBG] Executing DbCommand [Parameters=[@__normalizedEmail_0='?' (Size = 4000)], CommandType='"Text"', CommandTimeout='30']
+SELECT TOP(2) [u].[Id], [u].[AccessFailedCount], [u].[ConcurrencyStamp], [u].[CreatedAt], [u].[DeletedAt], [u].[Email], [u].[EmailConfirmed], [u].[LastModifiedAt], [u].[LastModifiedBy], [u].[LockoutEnabled], [u].[LockoutEnd], [u].[NormalizedEmail], [u].[NormalizedUserName], [u].[PasswordHash], [u].[PhoneNumber], [u].[PhoneNumberConfirmed], [u].[SecurityStamp], [u].[TwoFactorEnabled], [u].[UserName]
+FROM [users] AS [u]
+WHERE [u].[NormalizedEmail] = @__normalizedEmail_0
+2025-10-04 02:05:05.709 +07:00 [INF] Executed DbCommand (13ms) [Parameters=[@__normalizedEmail_0='?' (Size = 4000)], CommandType='"Text"', CommandTimeout='30']
+SELECT TOP(2) [u].[Id], [u].[AccessFailedCount], [u].[ConcurrencyStamp], [u].[CreatedAt], [u].[DeletedAt], [u].[Email], [u].[EmailConfirmed], [u].[LastModifiedAt], [u].[LastModifiedBy], [u].[LockoutEnabled], [u].[LockoutEnd], [u].[NormalizedEmail], [u].[NormalizedUserName], [u].[PasswordHash], [u].[PhoneNumber], [u].[PhoneNumberConfirmed], [u].[SecurityStamp], [u].[TwoFactorEnabled], [u].[UserName]
+FROM [users] AS [u]
+WHERE [u].[NormalizedEmail] = @__normalizedEmail_0
+2025-10-04 02:05:05.711 +07:00 [DBG] Context 'MyDbContext' started tracking 'User' entity. Consider using 'DbContextOptionsBuilder.EnableSensitiveDataLogging' to see key values.
+2025-10-04 02:05:05.713 +07:00 [DBG] Closing data reader to 'capbot_db' on server 'localhost'.
+2025-10-04 02:05:05.713 +07:00 [DBG] A data reader for 'capbot_db' on server 'localhost' is being disposed after spending 2ms reading results.
+2025-10-04 02:05:05.714 +07:00 [DBG] Closing connection to database 'capbot_db' on server 'localhost'.
+2025-10-04 02:05:05.714 +07:00 [DBG] Closed connection to database 'capbot_db' on server 'localhost' (0ms).
+2025-10-04 02:05:05.721 +07:00 [INF] Sample moderator 'moderator@example.com' already exists
+2025-10-04 02:05:05.723 +07:00 [DBG] Opening connection to database 'capbot_db' on server 'localhost'.
+2025-10-04 02:05:05.724 +07:00 [DBG] Opened connection to database 'capbot_db' on server 'localhost'.
+2025-10-04 02:05:05.725 +07:00 [DBG] Creating DbCommand for 'ExecuteReader'.
+2025-10-04 02:05:05.725 +07:00 [DBG] Created DbCommand for 'ExecuteReader' (0ms).
+2025-10-04 02:05:05.726 +07:00 [DBG] Initialized DbCommand for 'ExecuteReader' (1ms).
+2025-10-04 02:05:05.726 +07:00 [DBG] Executing DbCommand [Parameters=[@__normalizedEmail_0='?' (Size = 4000)], CommandType='"Text"', CommandTimeout='30']
+SELECT TOP(2) [u].[Id], [u].[AccessFailedCount], [u].[ConcurrencyStamp], [u].[CreatedAt], [u].[DeletedAt], [u].[Email], [u].[EmailConfirmed], [u].[LastModifiedAt], [u].[LastModifiedBy], [u].[LockoutEnabled], [u].[LockoutEnd], [u].[NormalizedEmail], [u].[NormalizedUserName], [u].[PasswordHash], [u].[PhoneNumber], [u].[PhoneNumberConfirmed], [u].[SecurityStamp], [u].[TwoFactorEnabled], [u].[UserName]
+FROM [users] AS [u]
+WHERE [u].[NormalizedEmail] = @__normalizedEmail_0
+2025-10-04 02:05:05.745 +07:00 [INF] Executed DbCommand (18ms) [Parameters=[@__normalizedEmail_0='?' (Size = 4000)], CommandType='"Text"', CommandTimeout='30']
+SELECT TOP(2) [u].[Id], [u].[AccessFailedCount], [u].[ConcurrencyStamp], [u].[CreatedAt], [u].[DeletedAt], [u].[Email], [u].[EmailConfirmed], [u].[LastModifiedAt], [u].[LastModifiedBy], [u].[LockoutEnabled], [u].[LockoutEnd], [u].[NormalizedEmail], [u].[NormalizedUserName], [u].[PasswordHash], [u].[PhoneNumber], [u].[PhoneNumberConfirmed], [u].[SecurityStamp], [u].[TwoFactorEnabled], [u].[UserName]
+FROM [users] AS [u]
+WHERE [u].[NormalizedEmail] = @__normalizedEmail_0
+2025-10-04 02:05:05.747 +07:00 [DBG] Context 'MyDbContext' started tracking 'User' entity. Consider using 'DbContextOptionsBuilder.EnableSensitiveDataLogging' to see key values.
+2025-10-04 02:05:05.748 +07:00 [DBG] Closing data reader to 'capbot_db' on server 'localhost'.
+2025-10-04 02:05:05.755 +07:00 [DBG] A data reader for 'capbot_db' on server 'localhost' is being disposed after spending 8ms reading results.
+2025-10-04 02:05:05.756 +07:00 [DBG] Closing connection to database 'capbot_db' on server 'localhost'.
+2025-10-04 02:05:05.757 +07:00 [DBG] Closed connection to database 'capbot_db' on server 'localhost' (1ms).
+2025-10-04 02:05:05.759 +07:00 [DBG] Opening connection to database 'capbot_db' on server 'localhost'.
+2025-10-04 02:05:05.760 +07:00 [DBG] Opened connection to database 'capbot_db' on server 'localhost'.
+2025-10-04 02:05:05.761 +07:00 [DBG] Creating DbCommand for 'ExecuteReader'.
+2025-10-04 02:05:05.762 +07:00 [DBG] Created DbCommand for 'ExecuteReader' (0ms).
+2025-10-04 02:05:05.762 +07:00 [DBG] Initialized DbCommand for 'ExecuteReader' (1ms).
+2025-10-04 02:05:05.763 +07:00 [DBG] Executing DbCommand [Parameters=[@__normalizedEmail_0='?' (Size = 4000)], CommandType='"Text"', CommandTimeout='30']
+SELECT TOP(2) [u].[Id], [u].[AccessFailedCount], [u].[ConcurrencyStamp], [u].[CreatedAt], [u].[DeletedAt], [u].[Email], [u].[EmailConfirmed], [u].[LastModifiedAt], [u].[LastModifiedBy], [u].[LockoutEnabled], [u].[LockoutEnd], [u].[NormalizedEmail], [u].[NormalizedUserName], [u].[PasswordHash], [u].[PhoneNumber], [u].[PhoneNumberConfirmed], [u].[SecurityStamp], [u].[TwoFactorEnabled], [u].[UserName]
+FROM [users] AS [u]
+WHERE [u].[NormalizedEmail] = @__normalizedEmail_0
+2025-10-04 02:05:05.779 +07:00 [INF] Executed DbCommand (16ms) [Parameters=[@__normalizedEmail_0='?' (Size = 4000)], CommandType='"Text"', CommandTimeout='30']
+SELECT TOP(2) [u].[Id], [u].[AccessFailedCount], [u].[ConcurrencyStamp], [u].[CreatedAt], [u].[DeletedAt], [u].[Email], [u].[EmailConfirmed], [u].[LastModifiedAt], [u].[LastModifiedBy], [u].[LockoutEnabled], [u].[LockoutEnd], [u].[NormalizedEmail], [u].[NormalizedUserName], [u].[PasswordHash], [u].[PhoneNumber], [u].[PhoneNumberConfirmed], [u].[SecurityStamp], [u].[TwoFactorEnabled], [u].[UserName]
+FROM [users] AS [u]
+WHERE [u].[NormalizedEmail] = @__normalizedEmail_0
+2025-10-04 02:05:05.786 +07:00 [DBG] Context 'MyDbContext' started tracking 'User' entity. Consider using 'DbContextOptionsBuilder.EnableSensitiveDataLogging' to see key values.
+2025-10-04 02:05:05.787 +07:00 [DBG] Closing data reader to 'capbot_db' on server 'localhost'.
+2025-10-04 02:05:05.788 +07:00 [DBG] A data reader for 'capbot_db' on server 'localhost' is being disposed after spending 2ms reading results.
+2025-10-04 02:05:05.789 +07:00 [DBG] Closing connection to database 'capbot_db' on server 'localhost'.
+2025-10-04 02:05:05.789 +07:00 [DBG] Closed connection to database 'capbot_db' on server 'localhost' (0ms).
+2025-10-04 02:05:05.790 +07:00 [INF] Data seeding completed successfully
+2025-10-04 02:05:05.793 +07:00 [DBG] 'MyDbContext' disposed.
+2025-10-04 02:05:05.798 +07:00 [DBG] Disposing connection to database 'capbot_db' on server 'localhost'.
+2025-10-04 02:05:05.804 +07:00 [DBG] Disposed connection to database '' on server '' (5ms).
+2025-10-04 02:05:05.852 +07:00 [DBG] Registered SignalR Protocol: json, implemented by Microsoft.AspNetCore.SignalR.Protocol.JsonHubProtocol.
+2025-10-04 02:05:06.337 +07:00 [DBG] Registered model binder providers, in the following order: ["Microsoft.AspNetCore.Mvc.ModelBinding.Binders.BinderTypeModelBinderProvider","Microsoft.AspNetCore.Mvc.ModelBinding.Binders.ServicesModelBinderProvider","Microsoft.AspNetCore.Mvc.ModelBinding.Binders.BodyModelBinderProvider","Microsoft.AspNetCore.Mvc.ModelBinding.Binders.HeaderModelBinderProvider","Microsoft.AspNetCore.Mvc.ModelBinding.Binders.FloatingPointTypeModelBinderProvider","Microsoft.AspNetCore.Mvc.ModelBinding.Binders.EnumTypeModelBinderProvider","Microsoft.AspNetCore.Mvc.ModelBinding.Binders.DateTimeModelBinderProvider","Microsoft.AspNetCore.Mvc.ModelBinding.Binders.SimpleTypeModelBinderProvider","Microsoft.AspNetCore.Mvc.ModelBinding.Binders.TryParseModelBinderProvider","Microsoft.AspNetCore.Mvc.ModelBinding.Binders.CancellationTokenModelBinderProvider"]
+2025-10-04 02:05:06.722 +07:00 [DBG] Hosting starting
+2025-10-04 02:05:06.754 +07:00 [DBG] Reading data from file 'C:\Users\acer\AppData\Local\ASP.NET\DataProtection-Keys\key-30a711c8-7ddc-4a0d-8c07-4439effde9db.xml'.
+2025-10-04 02:05:06.760 +07:00 [DBG] Reading data from file 'C:\Users\acer\AppData\Local\ASP.NET\DataProtection-Keys\key-732ee668-a56c-4fc9-b9d2-4188dc372919.xml'.
+2025-10-04 02:05:06.763 +07:00 [DBG] Reading data from file 'C:\Users\acer\AppData\Local\ASP.NET\DataProtection-Keys\key-ad0e504d-5eaf-4fbc-adde-d8f26319af02.xml'.
+2025-10-04 02:05:06.777 +07:00 [DBG] Found key {30a711c8-7ddc-4a0d-8c07-4439effde9db}.
+2025-10-04 02:05:06.792 +07:00 [DBG] Found key {732ee668-a56c-4fc9-b9d2-4188dc372919}.
+2025-10-04 02:05:06.794 +07:00 [DBG] Found key {ad0e504d-5eaf-4fbc-adde-d8f26319af02}.
+2025-10-04 02:05:06.808 +07:00 [DBG] Considering key {30a711c8-7ddc-4a0d-8c07-4439effde9db} with expiration date 2025-11-11 18:32:26Z as default key.
+2025-10-04 02:05:06.819 +07:00 [DBG] Forwarded activator type request from Microsoft.AspNetCore.DataProtection.XmlEncryption.DpapiXmlDecryptor, Microsoft.AspNetCore.DataProtection, Version=8.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60 to Microsoft.AspNetCore.DataProtection.XmlEncryption.DpapiXmlDecryptor, Microsoft.AspNetCore.DataProtection, Culture=neutral, PublicKeyToken=adb9793829ddae60
+2025-10-04 02:05:06.823 +07:00 [DBG] Decrypting secret element using Windows DPAPI.
+2025-10-04 02:05:06.826 +07:00 [DBG] Forwarded activator type request from Microsoft.AspNetCore.DataProtection.AuthenticatedEncryption.ConfigurationModel.AuthenticatedEncryptorDescriptorDeserializer, Microsoft.AspNetCore.DataProtection, Version=8.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60 to Microsoft.AspNetCore.DataProtection.AuthenticatedEncryption.ConfigurationModel.AuthenticatedEncryptorDescriptorDeserializer, Microsoft.AspNetCore.DataProtection, Culture=neutral, PublicKeyToken=adb9793829ddae60
+2025-10-04 02:05:06.829 +07:00 [DBG] Opening CNG algorithm 'AES' from provider 'null' with chaining mode CBC.
+2025-10-04 02:05:06.836 +07:00 [DBG] Opening CNG algorithm 'SHA256' from provider 'null' with HMAC.
+2025-10-04 02:05:06.843 +07:00 [DBG] Using key {30a711c8-7ddc-4a0d-8c07-4439effde9db} as the default key.
+2025-10-04 02:05:06.845 +07:00 [DBG] Key ring with default key {30a711c8-7ddc-4a0d-8c07-4439effde9db} was loaded during application startup.
+2025-10-04 02:05:07.004 +07:00 [INF] Now listening on: http://localhost:5207
+2025-10-04 02:05:07.005 +07:00 [DBG] Loaded hosting startup assembly CapBot.api
+2025-10-04 02:05:07.006 +07:00 [INF] Application started. Press Ctrl+C to shut down.
+2025-10-04 02:05:07.006 +07:00 [INF] Hosting environment: Development
+2025-10-04 02:05:07.006 +07:00 [INF] Content root path: c:\Users\acer\Downloads\CBAI_API\CapBot.api
+2025-10-04 02:05:07.010 +07:00 [DBG] Hosting started
+2025-10-04 02:06:35.110 +07:00 [INF] Application is shutting down...
+2025-10-04 02:06:35.113 +07:00 [DBG] Hosting stopping
+2025-10-04 02:06:35.123 +07:00 [ERR] Lỗi khi kiểm tra deadline notifications
+System.Threading.Tasks.TaskCanceledException: A task was canceled.
+   at CapBot.api.Services.DeadlineNotificationService.ExecuteAsync(CancellationToken stoppingToken) in c:\Users\acer\Downloads\CBAI_API\CapBot.api\Services\DeadlineNotificationService.cs:line 41
+2025-10-04 02:06:35.157 +07:00 [DBG] Hosting stopped
+2025-10-04 02:19:48.511 +07:00 [DBG] An 'IServiceProvider' was created for internal use by Entity Framework.
+2025-10-04 02:19:48.697 +07:00 [INF] User profile is available. Using 'C:\Users\acer\AppData\Local\ASP.NET\DataProtection-Keys' as key repository and Windows DPAPI to encrypt keys at rest.
+2025-10-04 02:19:49.266 +07:00 [DBG] No relationship from 'ReviewerAssignment' to 'User' has been configured by convention because there are multiple properties on one entity type - {'AssignedByUser', 'Reviewer'} that could be matched with the properties on the other entity type - {'ReviewerAssignments'}. This message can be disregarded if explicit configuration has been specified in 'OnModelCreating'.
+2025-10-04 02:19:49.313 +07:00 [DBG] No relationship from 'SubmissionWorkflowLog' to 'WorkflowState' has been configured by convention because there are multiple properties on one entity type - {'FromState', 'ToState'} that could be matched with the properties on the other entity type - {'FromStateLogs', 'ToStateLogs'}. This message can be disregarded if explicit configuration has been specified in 'OnModelCreating'.
+2025-10-04 02:19:49.349 +07:00 [DBG] No relationship from 'User' to 'ReviewerAssignment' has been configured by convention because there are multiple properties on one entity type - {'ReviewerAssignments'} that could be matched with the properties on the other entity type - {'AssignedByUser', 'Reviewer'}. This message can be disregarded if explicit configuration has been specified in 'OnModelCreating'.
+2025-10-04 02:19:49.353 +07:00 [DBG] No relationship from 'WorkflowState' to 'SubmissionWorkflowLog' has been configured by convention because there are multiple properties on one entity type - {'FromStateLogs', 'ToStateLogs'} that could be matched with the properties on the other entity type - {'FromState', 'ToState'}. This message can be disregarded if explicit configuration has been specified in 'OnModelCreating'.
+2025-10-04 02:19:49.354 +07:00 [DBG] No relationship from 'WorkflowState' to 'WorkflowTransition' has been configured by convention because there are multiple properties on one entity type - {'FromTransitions', 'ToTransitions'} that could be matched with the properties on the other entity type - {'FromState', 'ToState'}. This message can be disregarded if explicit configuration has been specified in 'OnModelCreating'.
+2025-10-04 02:19:49.357 +07:00 [DBG] No relationship from 'WorkflowTransition' to 'WorkflowState' has been configured by convention because there are multiple properties on one entity type - {'FromState', 'ToState'} that could be matched with the properties on the other entity type - {'FromTransitions', 'ToTransitions'}. This message can be disregarded if explicit configuration has been specified in 'OnModelCreating'.
+2025-10-04 02:19:50.252 +07:00 [DBG] No relationship from 'ReviewerAssignment' to 'User' has been configured by convention because there are multiple properties on one entity type - {'AssignedByUser', 'Reviewer'} that could be matched with the properties on the other entity type - {'ReviewerAssignments'}. This message can be disregarded if explicit configuration has been specified in 'OnModelCreating'.
+2025-10-04 02:19:50.254 +07:00 [DBG] No relationship from 'User' to 'ReviewerAssignment' has been configured by convention because there are multiple properties on one entity type - {'ReviewerAssignments'} that could be matched with the properties on the other entity type - {'AssignedByUser', 'Reviewer'}. This message can be disregarded if explicit configuration has been specified in 'OnModelCreating'.
+2025-10-04 02:19:50.312 +07:00 [DBG] No relationship from 'WorkflowTransition' to 'WorkflowState' has been configured by convention because there are multiple properties on one entity type - {'FromState', 'ToState'} that could be matched with the properties on the other entity type - {'FromTransitions', 'ToTransitions'}. This message can be disregarded if explicit configuration has been specified in 'OnModelCreating'.
+2025-10-04 02:19:50.314 +07:00 [DBG] No relationship from 'WorkflowState' to 'SubmissionWorkflowLog' has been configured by convention because there are multiple properties on one entity type - {'FromStateLogs', 'ToStateLogs'} that could be matched with the properties on the other entity type - {'FromState', 'ToState'}. This message can be disregarded if explicit configuration has been specified in 'OnModelCreating'.
+2025-10-04 02:19:50.314 +07:00 [DBG] No relationship from 'WorkflowState' to 'WorkflowTransition' has been configured by convention because there are multiple properties on one entity type - {'FromTransitions', 'ToTransitions'} that could be matched with the properties on the other entity type - {'FromState', 'ToState'}. This message can be disregarded if explicit configuration has been specified in 'OnModelCreating'.
+2025-10-04 02:19:50.318 +07:00 [DBG] No relationship from 'WorkflowState' to 'SubmissionWorkflowLog' has been configured by convention because there are multiple properties on one entity type - {'FromStateLogs', 'ToStateLogs'} that could be matched with the properties on the other entity type - {'FromState', 'ToState'}. This message can be disregarded if explicit configuration has been specified in 'OnModelCreating'.
+2025-10-04 02:19:50.349 +07:00 [DBG] No relationship from 'SubmissionWorkflowLog' to 'WorkflowState' has been configured by convention because there are multiple properties on one entity type - {'FromState', 'ToState'} that could be matched with the properties on the other entity type - {'FromStateLogs', 'ToStateLogs'}. This message can be disregarded if explicit configuration has been specified in 'OnModelCreating'.
+2025-10-04 02:19:50.351 +07:00 [DBG] No relationship from 'WorkflowState' to 'SubmissionWorkflowLog' has been configured by convention because there are multiple properties on one entity type - {'FromStateLogs', 'ToStateLogs'} that could be matched with the properties on the other entity type - {'FromState', 'ToState'}. This message can be disregarded if explicit configuration has been specified in 'OnModelCreating'.
+2025-10-04 02:19:50.588 +07:00 [DBG] The index {'LecturerId'} was not created on entity type 'LecturerSkill' as the properties are already covered by the index {'LecturerId', 'SkillTag'}.
+2025-10-04 02:19:50.589 +07:00 [DBG] The index {'SemesterId'} was not created on entity type 'Phase' as the properties are already covered by the index {'SemesterId', 'PhaseTypeId'}.
+2025-10-04 02:19:50.590 +07:00 [DBG] The index {'AssignmentId'} was not created on entity type 'Review' as the properties are already covered by the index {'AssignmentId', 'Status'}.
+2025-10-04 02:19:50.591 +07:00 [DBG] The index {'ReviewId'} was not created on entity type 'ReviewComment' as the properties are already covered by the index {'ReviewId', 'SectionName'}.
+2025-10-04 02:19:50.591 +07:00 [DBG] The index {'ReviewId'} was not created on entity type 'ReviewCriteriaScore' as the properties are already covered by the index {'ReviewId', 'CriteriaId'}.
+2025-10-04 02:19:50.594 +07:00 [DBG] The index {'ReviewerId'} was not created on entity type 'ReviewerAssignment' as the properties are already covered by the index {'ReviewerId', 'Status'}.
+2025-10-04 02:19:50.595 +07:00 [DBG] The index {'SubmissionId'} was not created on entity type 'ReviewerAssignment' as the properties are already covered by the index {'SubmissionId', 'ReviewerId'}.
+2025-10-04 02:19:50.595 +07:00 [DBG] The index {'ReviewerId'} was not created on entity type 'ReviewerPerformance' as the properties are already covered by the index {'ReviewerId', 'SemesterId'}.
+2025-10-04 02:19:50.596 +07:00 [DBG] The index {'PhaseId'} was not created on entity type 'Submission' as the properties are already covered by the index {'PhaseId', 'Status'}.
+2025-10-04 02:19:50.596 +07:00 [DBG] The index {'PhaseId'} was not created on entity type 'Submission' as the properties are already covered by the index {'PhaseId', 'Status', 'SubmittedAt'}.
+2025-10-04 02:19:50.596 +07:00 [DBG] The index {'TopicId'} was not created on entity type 'Submission' as the properties are already covered by the index {'TopicId', 'PhaseId', 'SubmissionRound'}.
+2025-10-04 02:19:50.596 +07:00 [DBG] The index {'SubmissionId'} was not created on entity type 'SubmissionWorkflowLog' as the properties are already covered by the index {'SubmissionId', 'CreatedAt'}.
+2025-10-04 02:19:50.597 +07:00 [DBG] The index {'UserId'} was not created on entity type 'SystemNotification' as the properties are already covered by the index {'UserId', 'IsRead', 'CreatedAt'}.
+2025-10-04 02:19:50.597 +07:00 [DBG] The index {'SemesterId'} was not created on entity type 'Topic' as the properties are already covered by the index {'SemesterId', 'IsApproved'}.
+2025-10-04 02:19:50.597 +07:00 [DBG] The index {'SupervisorId'} was not created on entity type 'Topic' as the properties are already covered by the index {'SupervisorId', 'SemesterId'}.
+2025-10-04 02:19:50.597 +07:00 [DBG] The index {'TopicId'} was not created on entity type 'TopicVersion' as the properties are already covered by the index {'TopicId', 'Status'}.
+2025-10-04 02:19:50.597 +07:00 [DBG] The index {'TopicId'} was not created on entity type 'TopicVersion' as the properties are already covered by the index {'TopicId', 'VersionNumber'}.
+2025-10-04 02:19:50.598 +07:00 [DBG] The index {'UserId'} was not created on entity type 'UserRole' as the properties are already covered by the index {'UserId', 'RoleId'}.
+2025-10-04 02:19:50.598 +07:00 [DBG] The index {'UserId'} was not created on entity type 'UserToken' as the properties are already covered by the index {'UserId', 'LoginProvider', 'Name'}.
+2025-10-04 02:19:51.160 +07:00 [WRN] The 'ProficiencyLevels' property 'ProficiencyLevel' on entity type 'LecturerSkill' is configured with a database-generated default, but has no configured sentinel value. The database-generated default will always be used for inserts when the property has the value '0', since this is the CLR default for the 'ProficiencyLevels' type. Consider using a nullable type, using a nullable backing field, or setting the sentinel value for the property to ensure the database default is used when, and only when, appropriate. See https://aka.ms/efcore-docs-default-values for more information.
+2025-10-04 02:19:51.161 +07:00 [WRN] The 'ReviewRecommendations' property 'Recommendation' on entity type 'Review' is configured with a database-generated default, but has no configured sentinel value. The database-generated default will always be used for inserts when the property has the value '0', since this is the CLR default for the 'ReviewRecommendations' type. Consider using a nullable type, using a nullable backing field, or setting the sentinel value for the property to ensure the database default is used when, and only when, appropriate. See https://aka.ms/efcore-docs-default-values for more information.
+2025-10-04 02:19:51.161 +07:00 [WRN] The 'ReviewStatus' property 'Status' on entity type 'Review' is configured with a database-generated default, but has no configured sentinel value. The database-generated default will always be used for inserts when the property has the value '0', since this is the CLR default for the 'ReviewStatus' type. Consider using a nullable type, using a nullable backing field, or setting the sentinel value for the property to ensure the database default is used when, and only when, appropriate. See https://aka.ms/efcore-docs-default-values for more information.
+2025-10-04 02:19:51.161 +07:00 [WRN] The 'CommentTypes' property 'CommentType' on entity type 'ReviewComment' is configured with a database-generated default, but has no configured sentinel value. The database-generated default will always be used for inserts when the property has the value '0', since this is the CLR default for the 'CommentTypes' type. Consider using a nullable type, using a nullable backing field, or setting the sentinel value for the property to ensure the database default is used when, and only when, appropriate. See https://aka.ms/efcore-docs-default-values for more information.
+2025-10-04 02:19:51.162 +07:00 [WRN] The 'PriorityLevels' property 'Priority' on entity type 'ReviewComment' is configured with a database-generated default, but has no configured sentinel value. The database-generated default will always be used for inserts when the property has the value '0', since this is the CLR default for the 'PriorityLevels' type. Consider using a nullable type, using a nullable backing field, or setting the sentinel value for the property to ensure the database default is used when, and only when, appropriate. See https://aka.ms/efcore-docs-default-values for more information.
+2025-10-04 02:19:51.162 +07:00 [WRN] The 'AssignmentTypes' property 'AssignmentType' on entity type 'ReviewerAssignment' is configured with a database-generated default, but has no configured sentinel value. The database-generated default will always be used for inserts when the property has the value '0', since this is the CLR default for the 'AssignmentTypes' type. Consider using a nullable type, using a nullable backing field, or setting the sentinel value for the property to ensure the database default is used when, and only when, appropriate. See https://aka.ms/efcore-docs-default-values for more information.
+2025-10-04 02:19:51.162 +07:00 [WRN] The 'AssignmentStatus' property 'Status' on entity type 'ReviewerAssignment' is configured with a database-generated default, but has no configured sentinel value. The database-generated default will always be used for inserts when the property has the value '0', since this is the CLR default for the 'AssignmentStatus' type. Consider using a nullable type, using a nullable backing field, or setting the sentinel value for the property to ensure the database default is used when, and only when, appropriate. See https://aka.ms/efcore-docs-default-values for more information.
+2025-10-04 02:19:51.163 +07:00 [WRN] The 'AiCheckStatus' property 'AiCheckStatus' on entity type 'Submission' is configured with a database-generated default, but has no configured sentinel value. The database-generated default will always be used for inserts when the property has the value '0', since this is the CLR default for the 'AiCheckStatus' type. Consider using a nullable type, using a nullable backing field, or setting the sentinel value for the property to ensure the database default is used when, and only when, appropriate. See https://aka.ms/efcore-docs-default-values for more information.
+2025-10-04 02:19:51.163 +07:00 [WRN] The 'SubmissionStatus' property 'Status' on entity type 'Submission' is configured with a database-generated default, but has no configured sentinel value. The database-generated default will always be used for inserts when the property has the value '0', since this is the CLR default for the 'SubmissionStatus' type. Consider using a nullable type, using a nullable backing field, or setting the sentinel value for the property to ensure the database default is used when, and only when, appropriate. See https://aka.ms/efcore-docs-default-values for more information.
+2025-10-04 02:19:51.164 +07:00 [WRN] The 'NotificationTypes' property 'Type' on entity type 'SystemNotification' is configured with a database-generated default, but has no configured sentinel value. The database-generated default will always be used for inserts when the property has the value '0', since this is the CLR default for the 'NotificationTypes' type. Consider using a nullable type, using a nullable backing field, or setting the sentinel value for the property to ensure the database default is used when, and only when, appropriate. See https://aka.ms/efcore-docs-default-values for more information.
+2025-10-04 02:19:51.164 +07:00 [WRN] The 'TopicStatus' property 'Status' on entity type 'TopicVersion' is configured with a database-generated default, but has no configured sentinel value. The database-generated default will always be used for inserts when the property has the value '0', since this is the CLR default for the 'TopicStatus' type. Consider using a nullable type, using a nullable backing field, or setting the sentinel value for the property to ensure the database default is used when, and only when, appropriate. See https://aka.ms/efcore-docs-default-values for more information.
+2025-10-04 02:19:51.651 +07:00 [DBG] Entity Framework Core 8.0.16 initialized 'MyDbContext' using provider 'Microsoft.EntityFrameworkCore.SqlServer:8.0.13' with options: MigrationsAssembly=App.DAL 
+2025-10-04 02:19:51.816 +07:00 [DBG] Compiling query expression: 
+'DbSet<Role>()
+    .FirstOrDefault(r => r.NormalizedName == __normalizedName_0)'
+2025-10-04 02:19:52.593 +07:00 [DBG] Generated query execution expression: 
+'queryContext => ShapedQueryCompilingExpressionVisitor.SingleOrDefaultAsync<Role>(
+    asyncEnumerable: new SingleQueryingEnumerable<Role>(
+        (RelationalQueryContext)queryContext, 
+        RelationalCommandCache.QueryExpression(
+            Projection Mapping:
+                EmptyProjectionMember -> Dictionary<IProperty, int> { [Property: Role.Id (int) Required PK AfterSave:Throw ValueGenerated.OnAdd, 0], [Property: Role.ConcurrencyStamp (string), 1], [Property: Role.IsAdmin (bool) Required, 2], [Property: Role.Name (string), 3], [Property: Role.NormalizedName (string), 4] }
+            SELECT TOP(1) r.Id, r.ConcurrencyStamp, r.IsAdmin, r.Name, r.NormalizedName
+            FROM roles AS r
+            WHERE r.NormalizedName == @__normalizedName_0), 
+        null, 
+        Func<QueryContext, DbDataReader, ResultContext, SingleQueryResultCoordinator, Role>, 
+        App.DAL.Context.MyDbContext, 
+        False, 
+        False, 
+        True
+    ), 
+    cancellationToken: queryContext.CancellationToken)'
+2025-10-04 02:19:52.756 +07:00 [DBG] Creating DbConnection.
+2025-10-04 02:19:52.818 +07:00 [DBG] Created DbConnection. (57ms).
+2025-10-04 02:19:52.831 +07:00 [DBG] Opening connection to database 'capbot_db' on server 'localhost'.
+2025-10-04 02:19:53.227 +07:00 [DBG] Opened connection to database 'capbot_db' on server 'localhost'.
+2025-10-04 02:19:53.231 +07:00 [DBG] Creating DbCommand for 'ExecuteReader'.
+2025-10-04 02:19:53.239 +07:00 [DBG] Created DbCommand for 'ExecuteReader' (4ms).
+2025-10-04 02:19:53.249 +07:00 [DBG] Initialized DbCommand for 'ExecuteReader' (18ms).
+2025-10-04 02:19:53.260 +07:00 [DBG] Executing DbCommand [Parameters=[@__normalizedName_0='?' (Size = 4000)], CommandType='"Text"', CommandTimeout='30']
+SELECT TOP(1) [r].[Id], [r].[ConcurrencyStamp], [r].[IsAdmin], [r].[Name], [r].[NormalizedName]
+FROM [roles] AS [r]
+WHERE [r].[NormalizedName] = @__normalizedName_0
+2025-10-04 02:19:53.383 +07:00 [INF] Executed DbCommand (121ms) [Parameters=[@__normalizedName_0='?' (Size = 4000)], CommandType='"Text"', CommandTimeout='30']
+SELECT TOP(1) [r].[Id], [r].[ConcurrencyStamp], [r].[IsAdmin], [r].[Name], [r].[NormalizedName]
+FROM [roles] AS [r]
+WHERE [r].[NormalizedName] = @__normalizedName_0
+2025-10-04 02:19:53.458 +07:00 [DBG] Context 'MyDbContext' started tracking 'Role' entity. Consider using 'DbContextOptionsBuilder.EnableSensitiveDataLogging' to see key values.
+2025-10-04 02:19:53.484 +07:00 [DBG] Closing data reader to 'capbot_db' on server 'localhost'.
+2025-10-04 02:19:53.493 +07:00 [DBG] A data reader for 'capbot_db' on server 'localhost' is being disposed after spending 103ms reading results.
+2025-10-04 02:19:53.498 +07:00 [DBG] Closing connection to database 'capbot_db' on server 'localhost'.
+2025-10-04 02:19:53.503 +07:00 [DBG] Closed connection to database 'capbot_db' on server 'localhost' (5ms).
+2025-10-04 02:19:53.509 +07:00 [DBG] Opening connection to database 'capbot_db' on server 'localhost'.
+2025-10-04 02:19:53.510 +07:00 [DBG] Opened connection to database 'capbot_db' on server 'localhost'.
+2025-10-04 02:19:53.511 +07:00 [DBG] Creating DbCommand for 'ExecuteReader'.
+2025-10-04 02:19:53.511 +07:00 [DBG] Created DbCommand for 'ExecuteReader' (0ms).
+2025-10-04 02:19:53.511 +07:00 [DBG] Initialized DbCommand for 'ExecuteReader' (0ms).
+2025-10-04 02:19:53.511 +07:00 [DBG] Executing DbCommand [Parameters=[@__normalizedName_0='?' (Size = 4000)], CommandType='"Text"', CommandTimeout='30']
+SELECT TOP(1) [r].[Id], [r].[ConcurrencyStamp], [r].[IsAdmin], [r].[Name], [r].[NormalizedName]
+FROM [roles] AS [r]
+WHERE [r].[NormalizedName] = @__normalizedName_0
+2025-10-04 02:19:53.525 +07:00 [INF] Executed DbCommand (14ms) [Parameters=[@__normalizedName_0='?' (Size = 4000)], CommandType='"Text"', CommandTimeout='30']
+SELECT TOP(1) [r].[Id], [r].[ConcurrencyStamp], [r].[IsAdmin], [r].[Name], [r].[NormalizedName]
+FROM [roles] AS [r]
+WHERE [r].[NormalizedName] = @__normalizedName_0
+2025-10-04 02:19:53.525 +07:00 [DBG] Context 'MyDbContext' started tracking 'Role' entity. Consider using 'DbContextOptionsBuilder.EnableSensitiveDataLogging' to see key values.
+2025-10-04 02:19:53.526 +07:00 [DBG] Closing data reader to 'capbot_db' on server 'localhost'.
+2025-10-04 02:19:53.526 +07:00 [DBG] A data reader for 'capbot_db' on server 'localhost' is being disposed after spending 1ms reading results.
+2025-10-04 02:19:53.526 +07:00 [DBG] Closing connection to database 'capbot_db' on server 'localhost'.
+2025-10-04 02:19:53.527 +07:00 [DBG] Closed connection to database 'capbot_db' on server 'localhost' (0ms).
+2025-10-04 02:19:53.527 +07:00 [DBG] Opening connection to database 'capbot_db' on server 'localhost'.
+2025-10-04 02:19:53.527 +07:00 [DBG] Opened connection to database 'capbot_db' on server 'localhost'.
+2025-10-04 02:19:53.527 +07:00 [DBG] Creating DbCommand for 'ExecuteReader'.
+2025-10-04 02:19:53.527 +07:00 [DBG] Created DbCommand for 'ExecuteReader' (0ms).
+2025-10-04 02:19:53.528 +07:00 [DBG] Initialized DbCommand for 'ExecuteReader' (0ms).
+2025-10-04 02:19:53.528 +07:00 [DBG] Executing DbCommand [Parameters=[@__normalizedName_0='?' (Size = 4000)], CommandType='"Text"', CommandTimeout='30']
+SELECT TOP(1) [r].[Id], [r].[ConcurrencyStamp], [r].[IsAdmin], [r].[Name], [r].[NormalizedName]
+FROM [roles] AS [r]
+WHERE [r].[NormalizedName] = @__normalizedName_0
+2025-10-04 02:19:53.529 +07:00 [INF] Executed DbCommand (1ms) [Parameters=[@__normalizedName_0='?' (Size = 4000)], CommandType='"Text"', CommandTimeout='30']
+SELECT TOP(1) [r].[Id], [r].[ConcurrencyStamp], [r].[IsAdmin], [r].[Name], [r].[NormalizedName]
+FROM [roles] AS [r]
+WHERE [r].[NormalizedName] = @__normalizedName_0
+2025-10-04 02:19:53.529 +07:00 [DBG] Context 'MyDbContext' started tracking 'Role' entity. Consider using 'DbContextOptionsBuilder.EnableSensitiveDataLogging' to see key values.
+2025-10-04 02:19:53.530 +07:00 [DBG] Closing data reader to 'capbot_db' on server 'localhost'.
+2025-10-04 02:19:53.530 +07:00 [DBG] A data reader for 'capbot_db' on server 'localhost' is being disposed after spending 0ms reading results.
+2025-10-04 02:19:53.530 +07:00 [DBG] Closing connection to database 'capbot_db' on server 'localhost'.
+2025-10-04 02:19:53.530 +07:00 [DBG] Closed connection to database 'capbot_db' on server 'localhost' (0ms).
+2025-10-04 02:19:53.531 +07:00 [DBG] Opening connection to database 'capbot_db' on server 'localhost'.
+2025-10-04 02:19:53.531 +07:00 [DBG] Opened connection to database 'capbot_db' on server 'localhost'.
+2025-10-04 02:19:53.531 +07:00 [DBG] Creating DbCommand for 'ExecuteReader'.
+2025-10-04 02:19:53.531 +07:00 [DBG] Created DbCommand for 'ExecuteReader' (0ms).
+2025-10-04 02:19:53.531 +07:00 [DBG] Initialized DbCommand for 'ExecuteReader' (0ms).
+2025-10-04 02:19:53.531 +07:00 [DBG] Executing DbCommand [Parameters=[@__normalizedName_0='?' (Size = 4000)], CommandType='"Text"', CommandTimeout='30']
+SELECT TOP(1) [r].[Id], [r].[ConcurrencyStamp], [r].[IsAdmin], [r].[Name], [r].[NormalizedName]
+FROM [roles] AS [r]
+WHERE [r].[NormalizedName] = @__normalizedName_0
+2025-10-04 02:19:53.533 +07:00 [INF] Executed DbCommand (1ms) [Parameters=[@__normalizedName_0='?' (Size = 4000)], CommandType='"Text"', CommandTimeout='30']
+SELECT TOP(1) [r].[Id], [r].[ConcurrencyStamp], [r].[IsAdmin], [r].[Name], [r].[NormalizedName]
+FROM [roles] AS [r]
+WHERE [r].[NormalizedName] = @__normalizedName_0
+2025-10-04 02:19:53.533 +07:00 [DBG] Context 'MyDbContext' started tracking 'Role' entity. Consider using 'DbContextOptionsBuilder.EnableSensitiveDataLogging' to see key values.
+2025-10-04 02:19:53.533 +07:00 [DBG] Closing data reader to 'capbot_db' on server 'localhost'.
+2025-10-04 02:19:53.533 +07:00 [DBG] A data reader for 'capbot_db' on server 'localhost' is being disposed after spending 0ms reading results.
+2025-10-04 02:19:53.533 +07:00 [DBG] Closing connection to database 'capbot_db' on server 'localhost'.
+2025-10-04 02:19:53.533 +07:00 [DBG] Closed connection to database 'capbot_db' on server 'localhost' (0ms).
+2025-10-04 02:19:53.545 +07:00 [DBG] Compiling query expression: 
+'DbSet<User>()
+    .SingleOrDefault(u => u.NormalizedEmail == __normalizedEmail_0)'
+2025-10-04 02:19:53.559 +07:00 [DBG] Generated query execution expression: 
+'queryContext => ShapedQueryCompilingExpressionVisitor.SingleOrDefaultAsync<User>(
+    asyncEnumerable: new SingleQueryingEnumerable<User>(
+        (RelationalQueryContext)queryContext, 
+        RelationalCommandCache.QueryExpression(
+            Projection Mapping:
+                EmptyProjectionMember -> Dictionary<IProperty, int> { [Property: User.Id (int) Required PK AfterSave:Throw ValueGenerated.OnAdd, 0], [Property: User.AccessFailedCount (int) Required, 1], [Property: User.ConcurrencyStamp (string), 2], [Property: User.CreatedAt (DateTime) Required, 3], [Property: User.DeletedAt (DateTime?), 4], [Property: User.Email (string), 5], [Property: User.EmailConfirmed (bool) Required, 6], [Property: User.LastModifiedAt (DateTime) Required, 7], [Property: User.LastModifiedBy (string), 8], [Property: User.LockoutEnabled (bool) Required, 9], [Property: User.LockoutEnd (DateTimeOffset?), 10], [Property: User.NormalizedEmail (string), 11], [Property: User.NormalizedUserName (string), 12], [Property: User.PasswordHash (string), 13], [Property: User.PhoneNumber (string), 14], [Property: User.PhoneNumberConfirmed (bool) Required, 15], [Property: User.SecurityStamp (string), 16], [Property: User.TwoFactorEnabled (bool) Required, 17], [Property: User.UserName (string), 18] }
+            SELECT TOP(2) u.Id, u.AccessFailedCount, u.ConcurrencyStamp, u.CreatedAt, u.DeletedAt, u.Email, u.EmailConfirmed, u.LastModifiedAt, u.LastModifiedBy, u.LockoutEnabled, u.LockoutEnd, u.NormalizedEmail, u.NormalizedUserName, u.PasswordHash, u.PhoneNumber, u.PhoneNumberConfirmed, u.SecurityStamp, u.TwoFactorEnabled, u.UserName
+            FROM users AS u
+            WHERE u.NormalizedEmail == @__normalizedEmail_0), 
+        null, 
+        Func<QueryContext, DbDataReader, ResultContext, SingleQueryResultCoordinator, User>, 
+        App.DAL.Context.MyDbContext, 
+        False, 
+        False, 
+        True
+    ), 
+    cancellationToken: queryContext.CancellationToken)'
+2025-10-04 02:19:53.561 +07:00 [DBG] Opening connection to database 'capbot_db' on server 'localhost'.
+2025-10-04 02:19:53.561 +07:00 [DBG] Opened connection to database 'capbot_db' on server 'localhost'.
+2025-10-04 02:19:53.561 +07:00 [DBG] Creating DbCommand for 'ExecuteReader'.
+2025-10-04 02:19:53.561 +07:00 [DBG] Created DbCommand for 'ExecuteReader' (0ms).
+2025-10-04 02:19:53.561 +07:00 [DBG] Initialized DbCommand for 'ExecuteReader' (0ms).
+2025-10-04 02:19:53.562 +07:00 [DBG] Executing DbCommand [Parameters=[@__normalizedEmail_0='?' (Size = 4000)], CommandType='"Text"', CommandTimeout='30']
+SELECT TOP(2) [u].[Id], [u].[AccessFailedCount], [u].[ConcurrencyStamp], [u].[CreatedAt], [u].[DeletedAt], [u].[Email], [u].[EmailConfirmed], [u].[LastModifiedAt], [u].[LastModifiedBy], [u].[LockoutEnabled], [u].[LockoutEnd], [u].[NormalizedEmail], [u].[NormalizedUserName], [u].[PasswordHash], [u].[PhoneNumber], [u].[PhoneNumberConfirmed], [u].[SecurityStamp], [u].[TwoFactorEnabled], [u].[UserName]
+FROM [users] AS [u]
+WHERE [u].[NormalizedEmail] = @__normalizedEmail_0
+2025-10-04 02:19:53.581 +07:00 [INF] Executed DbCommand (19ms) [Parameters=[@__normalizedEmail_0='?' (Size = 4000)], CommandType='"Text"', CommandTimeout='30']
+SELECT TOP(2) [u].[Id], [u].[AccessFailedCount], [u].[ConcurrencyStamp], [u].[CreatedAt], [u].[DeletedAt], [u].[Email], [u].[EmailConfirmed], [u].[LastModifiedAt], [u].[LastModifiedBy], [u].[LockoutEnabled], [u].[LockoutEnd], [u].[NormalizedEmail], [u].[NormalizedUserName], [u].[PasswordHash], [u].[PhoneNumber], [u].[PhoneNumberConfirmed], [u].[SecurityStamp], [u].[TwoFactorEnabled], [u].[UserName]
+FROM [users] AS [u]
+WHERE [u].[NormalizedEmail] = @__normalizedEmail_0
+2025-10-04 02:19:53.630 +07:00 [DBG] Context 'MyDbContext' started tracking 'User' entity. Consider using 'DbContextOptionsBuilder.EnableSensitiveDataLogging' to see key values.
+2025-10-04 02:19:53.682 +07:00 [DBG] Closing data reader to 'capbot_db' on server 'localhost'.
+2025-10-04 02:19:53.683 +07:00 [DBG] A data reader for 'capbot_db' on server 'localhost' is being disposed after spending 101ms reading results.
+2025-10-04 02:19:53.683 +07:00 [DBG] Closing connection to database 'capbot_db' on server 'localhost'.
+2025-10-04 02:19:53.683 +07:00 [DBG] Closed connection to database 'capbot_db' on server 'localhost' (0ms).
+2025-10-04 02:19:53.690 +07:00 [INF] Admin user 'admin.capbot@gmail.com' already exists
+2025-10-04 02:19:53.695 +07:00 [DBG] Opening connection to database 'capbot_db' on server 'localhost'.
+2025-10-04 02:19:53.695 +07:00 [DBG] Opened connection to database 'capbot_db' on server 'localhost'.
+2025-10-04 02:19:53.695 +07:00 [DBG] Creating DbCommand for 'ExecuteReader'.
+2025-10-04 02:19:53.696 +07:00 [DBG] Created DbCommand for 'ExecuteReader' (0ms).
+2025-10-04 02:19:53.696 +07:00 [DBG] Initialized DbCommand for 'ExecuteReader' (0ms).
+2025-10-04 02:19:53.696 +07:00 [DBG] Executing DbCommand [Parameters=[@__normalizedEmail_0='?' (Size = 4000)], CommandType='"Text"', CommandTimeout='30']
+SELECT TOP(2) [u].[Id], [u].[AccessFailedCount], [u].[ConcurrencyStamp], [u].[CreatedAt], [u].[DeletedAt], [u].[Email], [u].[EmailConfirmed], [u].[LastModifiedAt], [u].[LastModifiedBy], [u].[LockoutEnabled], [u].[LockoutEnd], [u].[NormalizedEmail], [u].[NormalizedUserName], [u].[PasswordHash], [u].[PhoneNumber], [u].[PhoneNumberConfirmed], [u].[SecurityStamp], [u].[TwoFactorEnabled], [u].[UserName]
+FROM [users] AS [u]
+WHERE [u].[NormalizedEmail] = @__normalizedEmail_0
+2025-10-04 02:19:53.712 +07:00 [INF] Executed DbCommand (16ms) [Parameters=[@__normalizedEmail_0='?' (Size = 4000)], CommandType='"Text"', CommandTimeout='30']
+SELECT TOP(2) [u].[Id], [u].[AccessFailedCount], [u].[ConcurrencyStamp], [u].[CreatedAt], [u].[DeletedAt], [u].[Email], [u].[EmailConfirmed], [u].[LastModifiedAt], [u].[LastModifiedBy], [u].[LockoutEnabled], [u].[LockoutEnd], [u].[NormalizedEmail], [u].[NormalizedUserName], [u].[PasswordHash], [u].[PhoneNumber], [u].[PhoneNumberConfirmed], [u].[SecurityStamp], [u].[TwoFactorEnabled], [u].[UserName]
+FROM [users] AS [u]
+WHERE [u].[NormalizedEmail] = @__normalizedEmail_0
+2025-10-04 02:19:53.712 +07:00 [DBG] Context 'MyDbContext' started tracking 'User' entity. Consider using 'DbContextOptionsBuilder.EnableSensitiveDataLogging' to see key values.
+2025-10-04 02:19:53.713 +07:00 [DBG] Closing data reader to 'capbot_db' on server 'localhost'.
+2025-10-04 02:19:53.713 +07:00 [DBG] A data reader for 'capbot_db' on server 'localhost' is being disposed after spending 1ms reading results.
+2025-10-04 02:19:53.713 +07:00 [DBG] Closing connection to database 'capbot_db' on server 'localhost'.
+2025-10-04 02:19:53.714 +07:00 [DBG] Closed connection to database 'capbot_db' on server 'localhost' (0ms).
+2025-10-04 02:19:53.714 +07:00 [INF] Sample moderator 'moderator@example.com' already exists
+2025-10-04 02:19:53.715 +07:00 [DBG] Opening connection to database 'capbot_db' on server 'localhost'.
+2025-10-04 02:19:53.715 +07:00 [DBG] Opened connection to database 'capbot_db' on server 'localhost'.
+2025-10-04 02:19:53.715 +07:00 [DBG] Creating DbCommand for 'ExecuteReader'.
+2025-10-04 02:19:53.715 +07:00 [DBG] Created DbCommand for 'ExecuteReader' (0ms).
+2025-10-04 02:19:53.715 +07:00 [DBG] Initialized DbCommand for 'ExecuteReader' (0ms).
+2025-10-04 02:19:53.715 +07:00 [DBG] Executing DbCommand [Parameters=[@__normalizedEmail_0='?' (Size = 4000)], CommandType='"Text"', CommandTimeout='30']
+SELECT TOP(2) [u].[Id], [u].[AccessFailedCount], [u].[ConcurrencyStamp], [u].[CreatedAt], [u].[DeletedAt], [u].[Email], [u].[EmailConfirmed], [u].[LastModifiedAt], [u].[LastModifiedBy], [u].[LockoutEnabled], [u].[LockoutEnd], [u].[NormalizedEmail], [u].[NormalizedUserName], [u].[PasswordHash], [u].[PhoneNumber], [u].[PhoneNumberConfirmed], [u].[SecurityStamp], [u].[TwoFactorEnabled], [u].[UserName]
+FROM [users] AS [u]
+WHERE [u].[NormalizedEmail] = @__normalizedEmail_0
+2025-10-04 02:19:53.717 +07:00 [INF] Executed DbCommand (1ms) [Parameters=[@__normalizedEmail_0='?' (Size = 4000)], CommandType='"Text"', CommandTimeout='30']
+SELECT TOP(2) [u].[Id], [u].[AccessFailedCount], [u].[ConcurrencyStamp], [u].[CreatedAt], [u].[DeletedAt], [u].[Email], [u].[EmailConfirmed], [u].[LastModifiedAt], [u].[LastModifiedBy], [u].[LockoutEnabled], [u].[LockoutEnd], [u].[NormalizedEmail], [u].[NormalizedUserName], [u].[PasswordHash], [u].[PhoneNumber], [u].[PhoneNumberConfirmed], [u].[SecurityStamp], [u].[TwoFactorEnabled], [u].[UserName]
+FROM [users] AS [u]
+WHERE [u].[NormalizedEmail] = @__normalizedEmail_0
+2025-10-04 02:19:53.717 +07:00 [DBG] Context 'MyDbContext' started tracking 'User' entity. Consider using 'DbContextOptionsBuilder.EnableSensitiveDataLogging' to see key values.
+2025-10-04 02:19:53.717 +07:00 [DBG] Closing data reader to 'capbot_db' on server 'localhost'.
+2025-10-04 02:19:53.717 +07:00 [DBG] A data reader for 'capbot_db' on server 'localhost' is being disposed after spending 0ms reading results.
+2025-10-04 02:19:53.717 +07:00 [DBG] Closing connection to database 'capbot_db' on server 'localhost'.
+2025-10-04 02:19:53.718 +07:00 [DBG] Closed connection to database 'capbot_db' on server 'localhost' (0ms).
+2025-10-04 02:19:53.718 +07:00 [DBG] Opening connection to database 'capbot_db' on server 'localhost'.
+2025-10-04 02:19:53.719 +07:00 [DBG] Opened connection to database 'capbot_db' on server 'localhost'.
+2025-10-04 02:19:53.719 +07:00 [DBG] Creating DbCommand for 'ExecuteReader'.
+2025-10-04 02:19:53.720 +07:00 [DBG] Created DbCommand for 'ExecuteReader' (1ms).
+2025-10-04 02:19:53.720 +07:00 [DBG] Initialized DbCommand for 'ExecuteReader' (1ms).
+2025-10-04 02:19:53.721 +07:00 [DBG] Executing DbCommand [Parameters=[@__normalizedEmail_0='?' (Size = 4000)], CommandType='"Text"', CommandTimeout='30']
+SELECT TOP(2) [u].[Id], [u].[AccessFailedCount], [u].[ConcurrencyStamp], [u].[CreatedAt], [u].[DeletedAt], [u].[Email], [u].[EmailConfirmed], [u].[LastModifiedAt], [u].[LastModifiedBy], [u].[LockoutEnabled], [u].[LockoutEnd], [u].[NormalizedEmail], [u].[NormalizedUserName], [u].[PasswordHash], [u].[PhoneNumber], [u].[PhoneNumberConfirmed], [u].[SecurityStamp], [u].[TwoFactorEnabled], [u].[UserName]
+FROM [users] AS [u]
+WHERE [u].[NormalizedEmail] = @__normalizedEmail_0
+2025-10-04 02:19:53.723 +07:00 [INF] Executed DbCommand (2ms) [Parameters=[@__normalizedEmail_0='?' (Size = 4000)], CommandType='"Text"', CommandTimeout='30']
+SELECT TOP(2) [u].[Id], [u].[AccessFailedCount], [u].[ConcurrencyStamp], [u].[CreatedAt], [u].[DeletedAt], [u].[Email], [u].[EmailConfirmed], [u].[LastModifiedAt], [u].[LastModifiedBy], [u].[LockoutEnabled], [u].[LockoutEnd], [u].[NormalizedEmail], [u].[NormalizedUserName], [u].[PasswordHash], [u].[PhoneNumber], [u].[PhoneNumberConfirmed], [u].[SecurityStamp], [u].[TwoFactorEnabled], [u].[UserName]
+FROM [users] AS [u]
+WHERE [u].[NormalizedEmail] = @__normalizedEmail_0
+2025-10-04 02:19:53.724 +07:00 [DBG] Context 'MyDbContext' started tracking 'User' entity. Consider using 'DbContextOptionsBuilder.EnableSensitiveDataLogging' to see key values.
+2025-10-04 02:19:53.725 +07:00 [DBG] Closing data reader to 'capbot_db' on server 'localhost'.
+2025-10-04 02:19:53.725 +07:00 [DBG] A data reader for 'capbot_db' on server 'localhost' is being disposed after spending 1ms reading results.
+2025-10-04 02:19:53.726 +07:00 [DBG] Closing connection to database 'capbot_db' on server 'localhost'.
+2025-10-04 02:19:53.726 +07:00 [DBG] Closed connection to database 'capbot_db' on server 'localhost' (0ms).
+2025-10-04 02:19:53.726 +07:00 [INF] Data seeding completed successfully
+2025-10-04 02:19:53.728 +07:00 [DBG] 'MyDbContext' disposed.
+2025-10-04 02:19:53.732 +07:00 [DBG] Disposing connection to database 'capbot_db' on server 'localhost'.
+2025-10-04 02:19:53.733 +07:00 [DBG] Disposed connection to database '' on server '' (1ms).
+2025-10-04 02:19:53.768 +07:00 [DBG] Registered SignalR Protocol: json, implemented by Microsoft.AspNetCore.SignalR.Protocol.JsonHubProtocol.
+2025-10-04 02:19:54.229 +07:00 [DBG] Registered model binder providers, in the following order: ["Microsoft.AspNetCore.Mvc.ModelBinding.Binders.BinderTypeModelBinderProvider","Microsoft.AspNetCore.Mvc.ModelBinding.Binders.ServicesModelBinderProvider","Microsoft.AspNetCore.Mvc.ModelBinding.Binders.BodyModelBinderProvider","Microsoft.AspNetCore.Mvc.ModelBinding.Binders.HeaderModelBinderProvider","Microsoft.AspNetCore.Mvc.ModelBinding.Binders.FloatingPointTypeModelBinderProvider","Microsoft.AspNetCore.Mvc.ModelBinding.Binders.EnumTypeModelBinderProvider","Microsoft.AspNetCore.Mvc.ModelBinding.Binders.DateTimeModelBinderProvider","Microsoft.AspNetCore.Mvc.ModelBinding.Binders.SimpleTypeModelBinderProvider","Microsoft.AspNetCore.Mvc.ModelBinding.Binders.TryParseModelBinderProvider","Microsoft.AspNetCore.Mvc.ModelBinding.Binders.CancellationTokenModelBinderProvider"]
+2025-10-04 02:19:54.427 +07:00 [DBG] Hosting starting
+2025-10-04 02:19:54.446 +07:00 [DBG] Reading data from file 'C:\Users\acer\AppData\Local\ASP.NET\DataProtection-Keys\key-30a711c8-7ddc-4a0d-8c07-4439effde9db.xml'.
+2025-10-04 02:19:54.450 +07:00 [DBG] Reading data from file 'C:\Users\acer\AppData\Local\ASP.NET\DataProtection-Keys\key-732ee668-a56c-4fc9-b9d2-4188dc372919.xml'.
+2025-10-04 02:19:54.451 +07:00 [DBG] Reading data from file 'C:\Users\acer\AppData\Local\ASP.NET\DataProtection-Keys\key-ad0e504d-5eaf-4fbc-adde-d8f26319af02.xml'.
+2025-10-04 02:19:54.461 +07:00 [DBG] Found key {30a711c8-7ddc-4a0d-8c07-4439effde9db}.
+2025-10-04 02:19:54.469 +07:00 [DBG] Found key {732ee668-a56c-4fc9-b9d2-4188dc372919}.
+2025-10-04 02:19:54.470 +07:00 [DBG] Found key {ad0e504d-5eaf-4fbc-adde-d8f26319af02}.
+2025-10-04 02:19:54.481 +07:00 [DBG] Considering key {30a711c8-7ddc-4a0d-8c07-4439effde9db} with expiration date 2025-11-11 18:32:26Z as default key.
+2025-10-04 02:19:54.486 +07:00 [DBG] Forwarded activator type request from Microsoft.AspNetCore.DataProtection.XmlEncryption.DpapiXmlDecryptor, Microsoft.AspNetCore.DataProtection, Version=8.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60 to Microsoft.AspNetCore.DataProtection.XmlEncryption.DpapiXmlDecryptor, Microsoft.AspNetCore.DataProtection, Culture=neutral, PublicKeyToken=adb9793829ddae60
+2025-10-04 02:19:54.488 +07:00 [DBG] Decrypting secret element using Windows DPAPI.
+2025-10-04 02:19:54.493 +07:00 [DBG] Forwarded activator type request from Microsoft.AspNetCore.DataProtection.AuthenticatedEncryption.ConfigurationModel.AuthenticatedEncryptorDescriptorDeserializer, Microsoft.AspNetCore.DataProtection, Version=8.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60 to Microsoft.AspNetCore.DataProtection.AuthenticatedEncryption.ConfigurationModel.AuthenticatedEncryptorDescriptorDeserializer, Microsoft.AspNetCore.DataProtection, Culture=neutral, PublicKeyToken=adb9793829ddae60
+2025-10-04 02:19:54.494 +07:00 [DBG] Opening CNG algorithm 'AES' from provider 'null' with chaining mode CBC.
+2025-10-04 02:19:54.500 +07:00 [DBG] Opening CNG algorithm 'SHA256' from provider 'null' with HMAC.
+2025-10-04 02:19:54.509 +07:00 [DBG] Using key {30a711c8-7ddc-4a0d-8c07-4439effde9db} as the default key.
+2025-10-04 02:19:54.510 +07:00 [DBG] Key ring with default key {30a711c8-7ddc-4a0d-8c07-4439effde9db} was loaded during application startup.
+2025-10-04 02:19:54.595 +07:00 [INF] Now listening on: http://localhost:5207
+2025-10-04 02:19:54.595 +07:00 [DBG] Loaded hosting startup assembly CapBot.api
+2025-10-04 02:19:54.595 +07:00 [DBG] Loaded hosting startup assembly Microsoft.AspNetCore.Watch.BrowserRefresh
+2025-10-04 02:19:54.596 +07:00 [INF] Application started. Press Ctrl+C to shut down.
+2025-10-04 02:19:54.596 +07:00 [INF] Hosting environment: Development
+2025-10-04 02:19:54.596 +07:00 [INF] Content root path: C:\Users\acer\Downloads\CBAI_API\capbot.api
+2025-10-04 02:19:54.598 +07:00 [DBG] Hosting started
+2025-10-04 02:19:55.063 +07:00 [DBG] Connection id "0HNG2M7AQS91V" accepted.
+2025-10-04 02:19:55.064 +07:00 [DBG] Connection id "0HNG2M7AQS91V" started.
+2025-10-04 02:19:55.617 +07:00 [DBG] Connection id "0HNG2M7AQS920" accepted.
+2025-10-04 02:19:55.618 +07:00 [DBG] Connection id "0HNG2M7AQS920" started.
+2025-10-04 02:19:55.626 +07:00 [INF] Request starting HTTP/1.1 GET http://localhost:5207/index.html - null null
+2025-10-04 02:19:55.652 +07:00 [DBG] Wildcard detected, all requests with hosts will be allowed.
+2025-10-04 02:19:56.004 +07:00 [DBG] Response markup is scheduled to include browser refresh script injection.
+2025-10-04 02:19:56.037 +07:00 [DBG] Response markup was updated to include browser refresh script injection.
+2025-10-04 02:19:56.038 +07:00 [DBG] Connection id "0HNG2M7AQS91V" completed keep alive response.
+2025-10-04 02:19:56.052 +07:00 [INF] Request finished HTTP/1.1 GET http://localhost:5207/index.html - 200 null text/html;charset=utf-8 431.6588ms
+2025-10-04 02:19:56.101 +07:00 [INF] Request starting HTTP/1.1 GET http://localhost:5207/_framework/aspnetcore-browser-refresh.js - null null
+2025-10-04 02:19:56.107 +07:00 [DBG] Connection id "0HNG2M7AQS91V" completed keep alive response.
+2025-10-04 02:19:56.109 +07:00 [INF] Request finished HTTP/1.1 GET http://localhost:5207/_framework/aspnetcore-browser-refresh.js - 200 13732 application/javascript; charset=utf-8 7.2733ms
+2025-10-04 02:19:56.363 +07:00 [INF] Request starting HTTP/1.1 GET http://localhost:5207/swagger/v1/swagger.json - null null
+2025-10-04 02:19:56.979 +07:00 [DBG] Connection id "0HNG2M7AQS91V" completed keep alive response.
+2025-10-04 02:19:56.981 +07:00 [INF] Request finished HTTP/1.1 GET http://localhost:5207/swagger/v1/swagger.json - 200 null application/json;charset=utf-8 617.608ms
+2025-10-04 02:20:03.001 +07:00 [DBG] Connection id "0HNG2M7AQS920" received FIN.
+2025-10-04 02:20:03.001 +07:00 [DBG] Connection id "0HNG2M7AQS91V" received FIN.
+2025-10-04 02:20:03.004 +07:00 [DBG] Connection id "0HNG2M7AQS920" sending FIN because: "The Socket transport's send loop completed gracefully."
+2025-10-04 02:20:03.004 +07:00 [DBG] Connection id "0HNG2M7AQS91V" sending FIN because: "The Socket transport's send loop completed gracefully."
+2025-10-04 02:20:03.005 +07:00 [DBG] Connection id "0HNG2M7AQS91V" disconnecting.
+2025-10-04 02:20:03.005 +07:00 [DBG] Connection id "0HNG2M7AQS920" disconnecting.
+2025-10-04 02:20:03.007 +07:00 [DBG] Connection id "0HNG2M7AQS91V" stopped.
+2025-10-04 02:20:03.007 +07:00 [DBG] Connection id "0HNG2M7AQS920" stopped.
+2025-10-04 02:20:32.819 +07:00 [DBG] Connection id "0HNG2M7AQS921" accepted.
+2025-10-04 02:20:32.819 +07:00 [DBG] Connection id "0HNG2M7AQS921" started.
+2025-10-04 02:20:32.820 +07:00 [INF] Request starting HTTP/1.1 GET http://localhost:5207/api/topic/detail/104 - null null
+2025-10-04 02:20:32.842 +07:00 [DBG] The request path /api/topic/detail/104 does not match a supported file type
+2025-10-04 02:20:32.846 +07:00 [WRN] Failed to determine the https port for redirect.
+2025-10-04 02:20:32.849 +07:00 [DBG] The request path /api/topic/detail/104 does not match a supported file type
+2025-10-04 02:20:32.904 +07:00 [DBG] 1 candidate(s) found for the request path '/api/topic/detail/104'
+2025-10-04 02:20:32.905 +07:00 [DBG] Endpoint 'CapBot.api.Controllers.TopicController.GetDetail (CapBot.api)' with route pattern 'api/topic/detail/{topicId}' is valid for the request path '/api/topic/detail/104'
+2025-10-04 02:20:32.906 +07:00 [DBG] Request matched endpoint 'CapBot.api.Controllers.TopicController.GetDetail (CapBot.api)'
+2025-10-04 02:20:33.023 +07:00 [DBG] Successfully validated the token.
+2025-10-04 02:20:33.024 +07:00 [DBG] AuthenticationScheme: Bearer was successfully authenticated.
+2025-10-04 02:20:33.036 +07:00 [INF] Executing endpoint 'CapBot.api.Controllers.TopicController.GetDetail (CapBot.api)'
+2025-10-04 02:20:33.066 +07:00 [INF] Route matched with {action = "GetDetail", controller = "Topic"}. Executing controller action with signature System.Threading.Tasks.Task`1[Microsoft.AspNetCore.Mvc.IActionResult] GetDetail(Int32) on controller CapBot.api.Controllers.TopicController (CapBot.api).
+2025-10-04 02:20:33.068 +07:00 [DBG] Execution plan of authorization filters (in the following order): ["None"]
+2025-10-04 02:20:33.069 +07:00 [DBG] Execution plan of resource filters (in the following order): ["Microsoft.AspNetCore.Mvc.ConsumesAttribute"]
+2025-10-04 02:20:33.070 +07:00 [DBG] Execution plan of action filters (in the following order): ["Microsoft.AspNetCore.Mvc.ModelBinding.UnsupportedContentTypeFilter (Order: -3000)"]
+2025-10-04 02:20:33.070 +07:00 [DBG] Execution plan of exception filters (in the following order): ["None"]
+2025-10-04 02:20:33.070 +07:00 [DBG] Execution plan of result filters (in the following order): ["Microsoft.AspNetCore.Mvc.Infrastructure.ClientErrorResultFilter (Order: -2000)","Microsoft.AspNetCore.Mvc.ProducesAttribute (Order: 0)"]
+2025-10-04 02:20:33.074 +07:00 [DBG] Executing controller factory for controller CapBot.api.Controllers.TopicController (CapBot.api)
+2025-10-04 02:20:33.094 +07:00 [DBG] Executed controller factory for controller CapBot.api.Controllers.TopicController (CapBot.api)
+2025-10-04 02:20:33.101 +07:00 [DBG] Attempting to bind parameter 'topicId' of type 'System.Int32' ...
+2025-10-04 02:20:33.102 +07:00 [DBG] Attempting to bind parameter 'topicId' of type 'System.Int32' using the name 'topicId' in request data ...
+2025-10-04 02:20:33.104 +07:00 [DBG] Done attempting to bind parameter 'topicId' of type 'System.Int32'.
+2025-10-04 02:20:33.104 +07:00 [DBG] Done attempting to bind parameter 'topicId' of type 'System.Int32'.
+2025-10-04 02:20:33.104 +07:00 [DBG] Attempting to validate the bound parameter 'topicId' of type 'System.Int32' ...
+2025-10-04 02:20:33.106 +07:00 [DBG] Done attempting to validate the bound parameter 'topicId' of type 'System.Int32'.
+2025-10-04 02:20:33.180 +07:00 [DBG] Entity Framework Core 8.0.16 initialized 'MyDbContext' using provider 'Microsoft.EntityFrameworkCore.SqlServer:8.0.13' with options: MigrationsAssembly=App.DAL 
+2025-10-04 02:20:33.196 +07:00 [DBG] Compiling query expression: 
+'DbSet<Topic>()
+    .AsNoTracking()
+    .Include(x => x.Supervisor)
+    .Include(x => x.Category)
+    .Include(x => x.Semester)
+    .Include(x => x.TopicVersions)
+    .Where(x => x.Id == __topicId_0 && x.IsActive && x.DeletedAt == null)
+    .FirstOrDefault()'
+2025-10-04 02:20:33.211 +07:00 [DBG] Including navigation: 'Topic.Supervisor'.
+2025-10-04 02:20:33.214 +07:00 [DBG] Including navigation: 'Topic.Category'.
+2025-10-04 02:20:33.217 +07:00 [DBG] Including navigation: 'Topic.Semester'.
+2025-10-04 02:20:33.218 +07:00 [DBG] Including navigation: 'Topic.TopicVersions'.
+2025-10-04 02:20:33.340 +07:00 [DBG] Generated query execution expression: 
+'queryContext => ShapedQueryCompilingExpressionVisitor.SingleOrDefaultAsync<Topic>(
+    asyncEnumerable: new SingleQueryingEnumerable<Topic>(
+        (RelationalQueryContext)queryContext, 
+        RelationalCommandCache.QueryExpression(
+            Client Projections:
+                0 -> Dictionary<IProperty, int> { [Property: Topic.Id (int) Required PK AfterSave:Throw ValueGenerated.OnAdd, 0], [Property: Topic.Abbreviation (string), 1], [Property: Topic.CategoryId (int?) FK Index, 2], [Property: Topic.Content (string), 3], [Property: Topic.Context (string), 4], [Property: Topic.CreatedAt (DateTime) Required ValueGenerated.OnAdd, 5], [Property: Topic.CreatedBy (string), 6], [Property: Topic.DeletedAt (DateTime?), 7], [Property: Topic.Description (string), 8], [Property: Topic.EN_Title (string) Required MaxLength(500), 9], [Property: Topic.IsActive (bool) Required, 10], [Property: Topic.IsApproved (bool) Required Index Sentinel:True ValueGenerated.OnAdd, 11], [Property: Topic.IsLegacy (bool) Required Index ValueGenerated.OnAdd, 12], [Property: Topic.LastModifiedAt (DateTime?), 13], [Property: Topic.LastModifiedBy (string), 14], [Property: Topic.MaxStudents (int) Required ValueGenerated.OnAdd, 15], [Property: Topic.Objectives (string), 16], [Property: Topic.PotentialDuplicate (string), 17], [Property: Topic.Problem (string), 18], [Property: Topic.SemesterId (int) Required FK Index, 19], [Property: Topic.SupervisorId (int) Required FK Index, 20], [Property: Topic.VN_title (string), 21] }
+                1 -> Dictionary<IProperty, int> { [Property: User.Id (int) Required PK AfterSave:Throw ValueGenerated.OnAdd, 22], [Property: User.AccessFailedCount (int) Required, 23], [Property: User.ConcurrencyStamp (string), 24], [Property: User.CreatedAt (DateTime) Required, 25], [Property: User.DeletedAt (DateTime?), 26], [Property: User.Email (string), 27], [Property: User.EmailConfirmed (bool) Required, 28], [Property: User.LastModifiedAt (DateTime) Required, 29], [Property: User.LastModifiedBy (string), 30], [Property: User.LockoutEnabled (bool) Required, 31], [Property: User.LockoutEnd (DateTimeOffset?), 32], [Property: User.NormalizedEmail (string), 33], [Property: User.NormalizedUserName (string), 34], [Property: User.PasswordHash (string), 35], [Property: User.PhoneNumber (string), 36], [Property: User.PhoneNumberConfirmed (bool) Required, 37], [Property: User.SecurityStamp (string), 38], [Property: User.TwoFactorEnabled (bool) Required, 39], [Property: User.UserName (string), 40] }
+                2 -> Dictionary<IProperty, int> { [Property: TopicCategory.Id (int) Required PK AfterSave:Throw ValueGenerated.OnAdd, 41], [Property: TopicCategory.CreatedAt (DateTime) Required ValueGenerated.OnAdd, 42], [Property: TopicCategory.CreatedBy (string), 43], [Property: TopicCategory.DeletedAt (DateTime?), 44], [Property: TopicCategory.Description (string), 45], [Property: TopicCategory.IsActive (bool) Required, 46], [Property: TopicCategory.LastModifiedAt (DateTime?), 47], [Property: TopicCategory.LastModifiedBy (string), 48], [Property: TopicCategory.Name (string) Required MaxLength(100), 49] }
+                3 -> Dictionary<IProperty, int> { [Property: Semester.Id (int) Required PK AfterSave:Throw ValueGenerated.OnAdd, 50], [Property: Semester.CreatedAt (DateTime) Required, 51], [Property: Semester.CreatedBy (string), 52], [Property: Semester.DeletedAt (DateTime?), 53], [Property: Semester.Description (string), 54], [Property: Semester.EndDate (DateTime) Required, 55], [Property: Semester.IsActive (bool) Required, 56], [Property: Semester.LastModifiedAt (DateTime?), 57], [Property: Semester.LastModifiedBy (string), 58], [Property: Semester.Name (string) Required Index MaxLength(50), 59], [Property: Semester.StartDate (DateTime) Required, 60] }
+                4 -> 0
+                5 -> 22
+                6 -> 41
+                7 -> 50
+                8 -> Dictionary<IProperty, int> { [Property: TopicVersion.Id (int) Required PK AfterSave:Throw ValueGenerated.OnAdd, 61], [Property: TopicVersion.Content (string), 62], [Property: TopicVersion.Context (string), 63], [Property: TopicVersion.CreatedAt (DateTime) Required ValueGenerated.OnAdd, 64], [Property: TopicVersion.CreatedBy (string), 65], [Property: TopicVersion.DeletedAt (DateTime?), 66], [Property: TopicVersion.Description (string), 67], [Property: TopicVersion.DocumentUrl (string) MaxLength(500), 68], [Property: TopicVersion.EN_Title (string) Required MaxLength(500), 69], [Property: TopicVersion.ExpectedOutcomes (string), 70], [Property: TopicVersion.IsActive (bool) Required, 71], [Property: TopicVersion.LastModifiedAt (DateTime?), 72], [Property: TopicVersion.LastModifiedBy (string), 73], [Property: TopicVersion.Methodology (string), 74], [Property: TopicVersion.Objectives (string), 75], [Property: TopicVersion.PotentialDuplicate (string), 76], [Property: TopicVersion.Problem (string), 77], [Property: TopicVersion.Requirements (string), 78], [Property: TopicVersion.Status (TopicStatus) Required Index ValueGenerated.OnAdd, 79], [Property: TopicVersion.SubmittedAt (DateTime?), 80], [Property: TopicVersion.SubmittedBy (int?) FK Index, 81], [Property: TopicVersion.TopicId (int) Required FK Index, 82], [Property: TopicVersion.VN_title (string), 83], [Property: TopicVersion.VersionNumber (int) Required Index, 84] }
+                9 -> 61
+            SELECT t1.Id, t1.Abbreviation, t1.CategoryId, t1.Content, t1.Context, t1.CreatedAt, t1.CreatedBy, t1.DeletedAt, t1.Description, t1.EN_Title, t1.IsActive, t1.IsApproved, t1.IsLegacy, t1.LastModifiedAt, t1.LastModifiedBy, t1.MaxStudents, t1.Objectives, t1.PotentialDuplicate, t1.Problem, t1.SemesterId, t1.SupervisorId, t1.VN_title, t1.Id0, t1.AccessFailedCount, t1.ConcurrencyStamp, t1.CreatedAt0, t1.DeletedAt0, t1.Email, t1.EmailConfirmed, t1.LastModifiedAt0, t1.LastModifiedBy0, t1.LockoutEnabled, t1.LockoutEnd, t1.NormalizedEmail, t1.NormalizedUserName, t1.PasswordHash, t1.PhoneNumber, t1.PhoneNumberConfirmed, t1.SecurityStamp, t1.TwoFactorEnabled, t1.UserName, t1.Id1, t1.CreatedAt1, t1.CreatedBy0, t1.DeletedAt1, t1.Description0, t1.IsActive0, t1.LastModifiedAt1, t1.LastModifiedBy1, t1.Name, t1.Id2, t1.CreatedAt2, t1.CreatedBy1, t1.DeletedAt2, t1.Description1, t1.EndDate, t1.IsActive1, t1.LastModifiedAt2, t1.LastModifiedBy2, t1.Name0, t1.StartDate, t2.Id, t2.Content, t2.Context, t2.CreatedAt, t2.CreatedBy, t2.DeletedAt, t2.Description, t2.DocumentUrl, t2.EN_Title, t2.ExpectedOutcomes, t2.IsActive, t2.LastModifiedAt, t2.LastModifiedBy, t2.Methodology, t2.Objectives, t2.PotentialDuplicate, t2.Problem, t2.Requirements, t2.Status, t2.SubmittedAt, t2.SubmittedBy, t2.TopicId, t2.VN_title, t2.VersionNumber
+            FROM 
+            (
+                SELECT TOP(1) t.Id, t.Abbreviation, t.CategoryId, t.Content, t.Context, t.CreatedAt, t.CreatedBy, t.DeletedAt, t.Description, t.EN_Title, t.IsActive, t.IsApproved, t.IsLegacy, t.LastModifiedAt, t.LastModifiedBy, t.MaxStudents, t.Objectives, t.PotentialDuplicate, t.Problem, t.SemesterId, t.SupervisorId, t.VN_title, u.Id AS Id0, u.AccessFailedCount, u.ConcurrencyStamp, u.CreatedAt AS CreatedAt0, u.DeletedAt AS DeletedAt0, u.Email, u.EmailConfirmed, u.LastModifiedAt AS LastModifiedAt0, u.LastModifiedBy AS LastModifiedBy0, u.LockoutEnabled, u.LockoutEnd, u.NormalizedEmail, u.NormalizedUserName, u.PasswordHash, u.PhoneNumber, u.PhoneNumberConfirmed, u.SecurityStamp, u.TwoFactorEnabled, u.UserName, t0.Id AS Id1, t0.CreatedAt AS CreatedAt1, t0.CreatedBy AS CreatedBy0, t0.DeletedAt AS DeletedAt1, t0.Description AS Description0, t0.IsActive AS IsActive0, t0.LastModifiedAt AS LastModifiedAt1, t0.LastModifiedBy AS LastModifiedBy1, t0.Name, s.Id AS Id2, s.CreatedAt AS CreatedAt2, s.CreatedBy AS CreatedBy1, s.DeletedAt AS DeletedAt2, s.Description AS Description1, s.EndDate, s.IsActive AS IsActive1, s.LastModifiedAt AS LastModifiedAt2, s.LastModifiedBy AS LastModifiedBy2, s.Name AS Name0, s.StartDate
+                FROM topics AS t
+                INNER JOIN users AS u ON t.SupervisorId == u.Id
+                LEFT JOIN topic_categories AS t0 ON t.CategoryId == t0.Id
+                INNER JOIN semesters AS s ON t.SemesterId == s.Id
+                WHERE ((t.Id == @__topicId_0) && t.IsActive) && (t.DeletedAt == NULL)
+            ) AS t1
+            LEFT JOIN topic_versions AS t2 ON t1.Id == t2.TopicId
+            ORDER BY t1.Id ASC, t1.Id0 ASC, t1.Id1 ASC, t1.Id2 ASC), 
+        null, 
+        Func<QueryContext, DbDataReader, ResultContext, SingleQueryResultCoordinator, Topic>, 
+        App.DAL.Context.MyDbContext, 
+        False, 
+        False, 
+        True
+    ), 
+    cancellationToken: queryContext.CancellationToken)'
+2025-10-04 02:20:33.354 +07:00 [DBG] Creating DbConnection.
+2025-10-04 02:20:33.355 +07:00 [DBG] Created DbConnection. (0ms).
+2025-10-04 02:20:33.355 +07:00 [DBG] Opening connection to database 'capbot_db' on server 'localhost'.
+2025-10-04 02:20:33.356 +07:00 [DBG] Opened connection to database 'capbot_db' on server 'localhost'.
+2025-10-04 02:20:33.356 +07:00 [DBG] Creating DbCommand for 'ExecuteReader'.
+2025-10-04 02:20:33.356 +07:00 [DBG] Created DbCommand for 'ExecuteReader' (0ms).
+2025-10-04 02:20:33.357 +07:00 [DBG] Initialized DbCommand for 'ExecuteReader' (0ms).
+2025-10-04 02:20:33.358 +07:00 [DBG] Executing DbCommand [Parameters=[@__topicId_0='?' (DbType = Int32)], CommandType='"Text"', CommandTimeout='30']
+SELECT [t1].[Id], [t1].[Abbreviation], [t1].[CategoryId], [t1].[Content], [t1].[Context], [t1].[CreatedAt], [t1].[CreatedBy], [t1].[DeletedAt], [t1].[Description], [t1].[EN_Title], [t1].[IsActive], [t1].[IsApproved], [t1].[IsLegacy], [t1].[LastModifiedAt], [t1].[LastModifiedBy], [t1].[MaxStudents], [t1].[Objectives], [t1].[PotentialDuplicate], [t1].[Problem], [t1].[SemesterId], [t1].[SupervisorId], [t1].[VN_title], [t1].[Id0], [t1].[AccessFailedCount], [t1].[ConcurrencyStamp], [t1].[CreatedAt0], [t1].[DeletedAt0], [t1].[Email], [t1].[EmailConfirmed], [t1].[LastModifiedAt0], [t1].[LastModifiedBy0], [t1].[LockoutEnabled], [t1].[LockoutEnd], [t1].[NormalizedEmail], [t1].[NormalizedUserName], [t1].[PasswordHash], [t1].[PhoneNumber], [t1].[PhoneNumberConfirmed], [t1].[SecurityStamp], [t1].[TwoFactorEnabled], [t1].[UserName], [t1].[Id1], [t1].[CreatedAt1], [t1].[CreatedBy0], [t1].[DeletedAt1], [t1].[Description0], [t1].[IsActive0], [t1].[LastModifiedAt1], [t1].[LastModifiedBy1], [t1].[Name], [t1].[Id2], [t1].[CreatedAt2], [t1].[CreatedBy1], [t1].[DeletedAt2], [t1].[Description1], [t1].[EndDate], [t1].[IsActive1], [t1].[LastModifiedAt2], [t1].[LastModifiedBy2], [t1].[Name0], [t1].[StartDate], [t2].[Id], [t2].[Content], [t2].[Context], [t2].[CreatedAt], [t2].[CreatedBy], [t2].[DeletedAt], [t2].[Description], [t2].[DocumentUrl], [t2].[EN_Title], [t2].[ExpectedOutcomes], [t2].[IsActive], [t2].[LastModifiedAt], [t2].[LastModifiedBy], [t2].[Methodology], [t2].[Objectives], [t2].[PotentialDuplicate], [t2].[Problem], [t2].[Requirements], [t2].[Status], [t2].[SubmittedAt], [t2].[SubmittedBy], [t2].[TopicId], [t2].[VN_title], [t2].[VersionNumber]
+FROM (
+    SELECT TOP(1) [t].[Id], [t].[Abbreviation], [t].[CategoryId], [t].[Content], [t].[Context], [t].[CreatedAt], [t].[CreatedBy], [t].[DeletedAt], [t].[Description], [t].[EN_Title], [t].[IsActive], [t].[IsApproved], [t].[IsLegacy], [t].[LastModifiedAt], [t].[LastModifiedBy], [t].[MaxStudents], [t].[Objectives], [t].[PotentialDuplicate], [t].[Problem], [t].[SemesterId], [t].[SupervisorId], [t].[VN_title], [u].[Id] AS [Id0], [u].[AccessFailedCount], [u].[ConcurrencyStamp], [u].[CreatedAt] AS [CreatedAt0], [u].[DeletedAt] AS [DeletedAt0], [u].[Email], [u].[EmailConfirmed], [u].[LastModifiedAt] AS [LastModifiedAt0], [u].[LastModifiedBy] AS [LastModifiedBy0], [u].[LockoutEnabled], [u].[LockoutEnd], [u].[NormalizedEmail], [u].[NormalizedUserName], [u].[PasswordHash], [u].[PhoneNumber], [u].[PhoneNumberConfirmed], [u].[SecurityStamp], [u].[TwoFactorEnabled], [u].[UserName], [t0].[Id] AS [Id1], [t0].[CreatedAt] AS [CreatedAt1], [t0].[CreatedBy] AS [CreatedBy0], [t0].[DeletedAt] AS [DeletedAt1], [t0].[Description] AS [Description0], [t0].[IsActive] AS [IsActive0], [t0].[LastModifiedAt] AS [LastModifiedAt1], [t0].[LastModifiedBy] AS [LastModifiedBy1], [t0].[Name], [s].[Id] AS [Id2], [s].[CreatedAt] AS [CreatedAt2], [s].[CreatedBy] AS [CreatedBy1], [s].[DeletedAt] AS [DeletedAt2], [s].[Description] AS [Description1], [s].[EndDate], [s].[IsActive] AS [IsActive1], [s].[LastModifiedAt] AS [LastModifiedAt2], [s].[LastModifiedBy] AS [LastModifiedBy2], [s].[Name] AS [Name0], [s].[StartDate]
+    FROM [topics] AS [t]
+    INNER JOIN [users] AS [u] ON [t].[SupervisorId] = [u].[Id]
+    LEFT JOIN [topic_categories] AS [t0] ON [t].[CategoryId] = [t0].[Id]
+    INNER JOIN [semesters] AS [s] ON [t].[SemesterId] = [s].[Id]
+    WHERE [t].[Id] = @__topicId_0 AND [t].[IsActive] = CAST(1 AS bit) AND [t].[DeletedAt] IS NULL
+) AS [t1]
+LEFT JOIN [topic_versions] AS [t2] ON [t1].[Id] = [t2].[TopicId]
+ORDER BY [t1].[Id], [t1].[Id0], [t1].[Id1], [t1].[Id2]
+2025-10-04 02:20:33.493 +07:00 [INF] Executed DbCommand (136ms) [Parameters=[@__topicId_0='?' (DbType = Int32)], CommandType='"Text"', CommandTimeout='30']
+SELECT [t1].[Id], [t1].[Abbreviation], [t1].[CategoryId], [t1].[Content], [t1].[Context], [t1].[CreatedAt], [t1].[CreatedBy], [t1].[DeletedAt], [t1].[Description], [t1].[EN_Title], [t1].[IsActive], [t1].[IsApproved], [t1].[IsLegacy], [t1].[LastModifiedAt], [t1].[LastModifiedBy], [t1].[MaxStudents], [t1].[Objectives], [t1].[PotentialDuplicate], [t1].[Problem], [t1].[SemesterId], [t1].[SupervisorId], [t1].[VN_title], [t1].[Id0], [t1].[AccessFailedCount], [t1].[ConcurrencyStamp], [t1].[CreatedAt0], [t1].[DeletedAt0], [t1].[Email], [t1].[EmailConfirmed], [t1].[LastModifiedAt0], [t1].[LastModifiedBy0], [t1].[LockoutEnabled], [t1].[LockoutEnd], [t1].[NormalizedEmail], [t1].[NormalizedUserName], [t1].[PasswordHash], [t1].[PhoneNumber], [t1].[PhoneNumberConfirmed], [t1].[SecurityStamp], [t1].[TwoFactorEnabled], [t1].[UserName], [t1].[Id1], [t1].[CreatedAt1], [t1].[CreatedBy0], [t1].[DeletedAt1], [t1].[Description0], [t1].[IsActive0], [t1].[LastModifiedAt1], [t1].[LastModifiedBy1], [t1].[Name], [t1].[Id2], [t1].[CreatedAt2], [t1].[CreatedBy1], [t1].[DeletedAt2], [t1].[Description1], [t1].[EndDate], [t1].[IsActive1], [t1].[LastModifiedAt2], [t1].[LastModifiedBy2], [t1].[Name0], [t1].[StartDate], [t2].[Id], [t2].[Content], [t2].[Context], [t2].[CreatedAt], [t2].[CreatedBy], [t2].[DeletedAt], [t2].[Description], [t2].[DocumentUrl], [t2].[EN_Title], [t2].[ExpectedOutcomes], [t2].[IsActive], [t2].[LastModifiedAt], [t2].[LastModifiedBy], [t2].[Methodology], [t2].[Objectives], [t2].[PotentialDuplicate], [t2].[Problem], [t2].[Requirements], [t2].[Status], [t2].[SubmittedAt], [t2].[SubmittedBy], [t2].[TopicId], [t2].[VN_title], [t2].[VersionNumber]
+FROM (
+    SELECT TOP(1) [t].[Id], [t].[Abbreviation], [t].[CategoryId], [t].[Content], [t].[Context], [t].[CreatedAt], [t].[CreatedBy], [t].[DeletedAt], [t].[Description], [t].[EN_Title], [t].[IsActive], [t].[IsApproved], [t].[IsLegacy], [t].[LastModifiedAt], [t].[LastModifiedBy], [t].[MaxStudents], [t].[Objectives], [t].[PotentialDuplicate], [t].[Problem], [t].[SemesterId], [t].[SupervisorId], [t].[VN_title], [u].[Id] AS [Id0], [u].[AccessFailedCount], [u].[ConcurrencyStamp], [u].[CreatedAt] AS [CreatedAt0], [u].[DeletedAt] AS [DeletedAt0], [u].[Email], [u].[EmailConfirmed], [u].[LastModifiedAt] AS [LastModifiedAt0], [u].[LastModifiedBy] AS [LastModifiedBy0], [u].[LockoutEnabled], [u].[LockoutEnd], [u].[NormalizedEmail], [u].[NormalizedUserName], [u].[PasswordHash], [u].[PhoneNumber], [u].[PhoneNumberConfirmed], [u].[SecurityStamp], [u].[TwoFactorEnabled], [u].[UserName], [t0].[Id] AS [Id1], [t0].[CreatedAt] AS [CreatedAt1], [t0].[CreatedBy] AS [CreatedBy0], [t0].[DeletedAt] AS [DeletedAt1], [t0].[Description] AS [Description0], [t0].[IsActive] AS [IsActive0], [t0].[LastModifiedAt] AS [LastModifiedAt1], [t0].[LastModifiedBy] AS [LastModifiedBy1], [t0].[Name], [s].[Id] AS [Id2], [s].[CreatedAt] AS [CreatedAt2], [s].[CreatedBy] AS [CreatedBy1], [s].[DeletedAt] AS [DeletedAt2], [s].[Description] AS [Description1], [s].[EndDate], [s].[IsActive] AS [IsActive1], [s].[LastModifiedAt] AS [LastModifiedAt2], [s].[LastModifiedBy] AS [LastModifiedBy2], [s].[Name] AS [Name0], [s].[StartDate]
+    FROM [topics] AS [t]
+    INNER JOIN [users] AS [u] ON [t].[SupervisorId] = [u].[Id]
+    LEFT JOIN [topic_categories] AS [t0] ON [t].[CategoryId] = [t0].[Id]
+    INNER JOIN [semesters] AS [s] ON [t].[SemesterId] = [s].[Id]
+    WHERE [t].[Id] = @__topicId_0 AND [t].[IsActive] = CAST(1 AS bit) AND [t].[DeletedAt] IS NULL
+) AS [t1]
+LEFT JOIN [topic_versions] AS [t2] ON [t1].[Id] = [t2].[TopicId]
+ORDER BY [t1].[Id], [t1].[Id0], [t1].[Id1], [t1].[Id2]
+2025-10-04 02:20:33.507 +07:00 [DBG] Closing data reader to 'capbot_db' on server 'localhost'.
+2025-10-04 02:20:33.507 +07:00 [DBG] A data reader for 'capbot_db' on server 'localhost' is being disposed after spending 13ms reading results.
+2025-10-04 02:20:33.507 +07:00 [DBG] Closing connection to database 'capbot_db' on server 'localhost'.
+2025-10-04 02:20:33.507 +07:00 [DBG] Closed connection to database 'capbot_db' on server 'localhost' (0ms).
+2025-10-04 02:20:33.518 +07:00 [DBG] Compiling query expression: 
+'DbSet<Submission>()
+    .AsNoTracking()
+    .Include(s => s.Phase)
+    .Include(s => s.SubmittedByUser)
+    .Include(s => s.ReviewerAssignments)
+    .Where(s => s.TopicId == __topicId_0 && s.IsActive && s.DeletedAt == null)'
+2025-10-04 02:20:33.521 +07:00 [DBG] Including navigation: 'Submission.Phase'.
+2025-10-04 02:20:33.522 +07:00 [DBG] Including navigation: 'Submission.SubmittedByUser'.
+2025-10-04 02:20:33.523 +07:00 [DBG] Including navigation: 'Submission.ReviewerAssignments'.
+2025-10-04 02:20:33.560 +07:00 [DBG] Generated query execution expression: 
+'queryContext => new SingleQueryingEnumerable<Submission>(
+    (RelationalQueryContext)queryContext, 
+    RelationalCommandCache.QueryExpression(
+        Client Projections:
+            0 -> Dictionary<IProperty, int> { [Property: Submission.Id (int) Required PK AfterSave:Throw ValueGenerated.OnAdd, 0], [Property: Submission.AdditionalNotes (string), 1], [Property: Submission.AiCheckDetails (string), 2], [Property: Submission.AiCheckScore (decimal?), 3], [Property: Submission.AiCheckStatus (AiCheckStatus) Required ValueGenerated.OnAdd, 4], [Property: Submission.CreatedAt (DateTime) Required, 5], [Property: Submission.CreatedBy (string), 6], [Property: Submission.DeletedAt (DateTime?), 7], [Property: Submission.DocumentUrl (string) MaxLength(500), 8], [Property: Submission.IsActive (bool) Required, 9], [Property: Submission.LastModifiedAt (DateTime?), 10], [Property: Submission.LastModifiedBy (string), 11], [Property: Submission.PhaseId (int) Required FK Index, 12], [Property: Submission.Status (SubmissionStatus) Required Index ValueGenerated.OnAdd, 13], [Property: Submission.SubmissionRound (int) Required Index ValueGenerated.OnAdd, 14], [Property: Submission.SubmittedAt (DateTime?) Index ValueGenerated.OnAdd, 15], [Property: Submission.SubmittedBy (int) Required FK Index, 16], [Property: Submission.TopicId (int) Required FK Index, 17], [Property: Submission.TopicVersionId (int?) FK Index, 18] }
+            1 -> Dictionary<IProperty, int> { [Property: Phase.Id (int) Required PK AfterSave:Throw ValueGenerated.OnAdd, 19], [Property: Phase.CreatedAt (DateTime) Required ValueGenerated.OnAdd, 20], [Property: Phase.CreatedBy (string), 21], [Property: Phase.DeletedAt (DateTime?), 22], [Property: Phase.EndDate (DateTime) Required, 23], [Property: Phase.IsActive (bool) Required Index Sentinel:True ValueGenerated.OnAdd, 24], [Property: Phase.LastModifiedAt (DateTime?), 25], [Property: Phase.LastModifiedBy (string), 26], [Property: Phase.Name (string) Required MaxLength(100), 27], [Property: Phase.PhaseTypeId (int) Required FK Index, 28], [Property: Phase.SemesterId (int) Required FK Index, 29], [Property: Phase.StartDate (DateTime) Required, 30], [Property: Phase.SubmissionDeadline (DateTime?), 31] }
+            2 -> Dictionary<IProperty, int> { [Property: User.Id (int) Required PK AfterSave:Throw ValueGenerated.OnAdd, 32], [Property: User.AccessFailedCount (int) Required, 33], [Property: User.ConcurrencyStamp (string), 34], [Property: User.CreatedAt (DateTime) Required, 35], [Property: User.DeletedAt (DateTime?), 36], [Property: User.Email (string), 37], [Property: User.EmailConfirmed (bool) Required, 38], [Property: User.LastModifiedAt (DateTime) Required, 39], [Property: User.LastModifiedBy (string), 40], [Property: User.LockoutEnabled (bool) Required, 41], [Property: User.LockoutEnd (DateTimeOffset?), 42], [Property: User.NormalizedEmail (string), 43], [Property: User.NormalizedUserName (string), 44], [Property: User.PasswordHash (string), 45], [Property: User.PhoneNumber (string), 46], [Property: User.PhoneNumberConfirmed (bool) Required, 47], [Property: User.SecurityStamp (string), 48], [Property: User.TwoFactorEnabled (bool) Required, 49], [Property: User.UserName (string), 50] }
+            3 -> 0
+            4 -> 19
+            5 -> 32
+            6 -> Dictionary<IProperty, int> { [Property: ReviewerAssignment.Id (int) Required PK AfterSave:Throw ValueGenerated.OnAdd, 51], [Property: ReviewerAssignment.AssignedAt (DateTime) Required ValueGenerated.OnAdd, 52], [Property: ReviewerAssignment.AssignedBy (int) Required FK Index, 53], [Property: ReviewerAssignment.AssignmentType (AssignmentTypes) Required ValueGenerated.OnAdd, 54], [Property: ReviewerAssignment.CompletedAt (DateTime?), 55], [Property: ReviewerAssignment.Deadline (DateTime?) Index, 56], [Property: ReviewerAssignment.ReviewerId (int) Required FK Index, 57], [Property: ReviewerAssignment.SkillMatchScore (decimal?), 58], [Property: ReviewerAssignment.StartedAt (DateTime?), 59], [Property: ReviewerAssignment.Status (AssignmentStatus) Required Index ValueGenerated.OnAdd, 60], [Property: ReviewerAssignment.SubmissionId (int) Required FK Index, 61] }
+            7 -> 51
+        SELECT s.Id, s.AdditionalNotes, s.AiCheckDetails, s.AiCheckScore, s.AiCheckStatus, s.CreatedAt, s.CreatedBy, s.DeletedAt, s.DocumentUrl, s.IsActive, s.LastModifiedAt, s.LastModifiedBy, s.PhaseId, s.Status, s.SubmissionRound, s.SubmittedAt, s.SubmittedBy, s.TopicId, s.TopicVersionId, p.Id, p.CreatedAt, p.CreatedBy, p.DeletedAt, p.EndDate, p.IsActive, p.LastModifiedAt, p.LastModifiedBy, p.Name, p.PhaseTypeId, p.SemesterId, p.StartDate, p.SubmissionDeadline, u.Id, u.AccessFailedCount, u.ConcurrencyStamp, u.CreatedAt, u.DeletedAt, u.Email, u.EmailConfirmed, u.LastModifiedAt, u.LastModifiedBy, u.LockoutEnabled, u.LockoutEnd, u.NormalizedEmail, u.NormalizedUserName, u.PasswordHash, u.PhoneNumber, u.PhoneNumberConfirmed, u.SecurityStamp, u.TwoFactorEnabled, u.UserName, r.Id, r.AssignedAt, r.AssignedBy, r.AssignmentType, r.CompletedAt, r.Deadline, r.ReviewerId, r.SkillMatchScore, r.StartedAt, r.Status, r.SubmissionId
+        FROM submissions AS s
+        INNER JOIN phases AS p ON s.PhaseId == p.Id
+        INNER JOIN users AS u ON s.SubmittedBy == u.Id
+        LEFT JOIN reviewer_assignments AS r ON s.Id == r.SubmissionId
+        WHERE ((s.TopicId == @__topicId_0) && s.IsActive) && (s.DeletedAt == NULL)
+        ORDER BY s.Id ASC, p.Id ASC, u.Id ASC), 
+    null, 
+    Func<QueryContext, DbDataReader, ResultContext, SingleQueryResultCoordinator, Submission>, 
+    App.DAL.Context.MyDbContext, 
+    False, 
+    False, 
+    True
+)'
+2025-10-04 02:20:33.562 +07:00 [DBG] Opening connection to database 'capbot_db' on server 'localhost'.
+2025-10-04 02:20:33.562 +07:00 [DBG] Opened connection to database 'capbot_db' on server 'localhost'.
+2025-10-04 02:20:33.563 +07:00 [DBG] Creating DbCommand for 'ExecuteReader'.
+2025-10-04 02:20:33.564 +07:00 [DBG] Created DbCommand for 'ExecuteReader' (0ms).
+2025-10-04 02:20:33.565 +07:00 [DBG] Initialized DbCommand for 'ExecuteReader' (1ms).
+2025-10-04 02:20:33.567 +07:00 [DBG] Executing DbCommand [Parameters=[@__topicId_0='?' (DbType = Int32)], CommandType='"Text"', CommandTimeout='30']
+SELECT [s].[Id], [s].[AdditionalNotes], [s].[AiCheckDetails], [s].[AiCheckScore], [s].[AiCheckStatus], [s].[CreatedAt], [s].[CreatedBy], [s].[DeletedAt], [s].[DocumentUrl], [s].[IsActive], [s].[LastModifiedAt], [s].[LastModifiedBy], [s].[PhaseId], [s].[Status], [s].[SubmissionRound], [s].[SubmittedAt], [s].[SubmittedBy], [s].[TopicId], [s].[TopicVersionId], [p].[Id], [p].[CreatedAt], [p].[CreatedBy], [p].[DeletedAt], [p].[EndDate], [p].[IsActive], [p].[LastModifiedAt], [p].[LastModifiedBy], [p].[Name], [p].[PhaseTypeId], [p].[SemesterId], [p].[StartDate], [p].[SubmissionDeadline], [u].[Id], [u].[AccessFailedCount], [u].[ConcurrencyStamp], [u].[CreatedAt], [u].[DeletedAt], [u].[Email], [u].[EmailConfirmed], [u].[LastModifiedAt], [u].[LastModifiedBy], [u].[LockoutEnabled], [u].[LockoutEnd], [u].[NormalizedEmail], [u].[NormalizedUserName], [u].[PasswordHash], [u].[PhoneNumber], [u].[PhoneNumberConfirmed], [u].[SecurityStamp], [u].[TwoFactorEnabled], [u].[UserName], [r].[Id], [r].[AssignedAt], [r].[AssignedBy], [r].[AssignmentType], [r].[CompletedAt], [r].[Deadline], [r].[ReviewerId], [r].[SkillMatchScore], [r].[StartedAt], [r].[Status], [r].[SubmissionId]
+FROM [submissions] AS [s]
+INNER JOIN [phases] AS [p] ON [s].[PhaseId] = [p].[Id]
+INNER JOIN [users] AS [u] ON [s].[SubmittedBy] = [u].[Id]
+LEFT JOIN [reviewer_assignments] AS [r] ON [s].[Id] = [r].[SubmissionId]
+WHERE [s].[TopicId] = @__topicId_0 AND [s].[IsActive] = CAST(1 AS bit) AND [s].[DeletedAt] IS NULL
+ORDER BY [s].[Id], [p].[Id], [u].[Id]
+2025-10-04 02:20:33.630 +07:00 [INF] Executed DbCommand (63ms) [Parameters=[@__topicId_0='?' (DbType = Int32)], CommandType='"Text"', CommandTimeout='30']
+SELECT [s].[Id], [s].[AdditionalNotes], [s].[AiCheckDetails], [s].[AiCheckScore], [s].[AiCheckStatus], [s].[CreatedAt], [s].[CreatedBy], [s].[DeletedAt], [s].[DocumentUrl], [s].[IsActive], [s].[LastModifiedAt], [s].[LastModifiedBy], [s].[PhaseId], [s].[Status], [s].[SubmissionRound], [s].[SubmittedAt], [s].[SubmittedBy], [s].[TopicId], [s].[TopicVersionId], [p].[Id], [p].[CreatedAt], [p].[CreatedBy], [p].[DeletedAt], [p].[EndDate], [p].[IsActive], [p].[LastModifiedAt], [p].[LastModifiedBy], [p].[Name], [p].[PhaseTypeId], [p].[SemesterId], [p].[StartDate], [p].[SubmissionDeadline], [u].[Id], [u].[AccessFailedCount], [u].[ConcurrencyStamp], [u].[CreatedAt], [u].[DeletedAt], [u].[Email], [u].[EmailConfirmed], [u].[LastModifiedAt], [u].[LastModifiedBy], [u].[LockoutEnabled], [u].[LockoutEnd], [u].[NormalizedEmail], [u].[NormalizedUserName], [u].[PasswordHash], [u].[PhoneNumber], [u].[PhoneNumberConfirmed], [u].[SecurityStamp], [u].[TwoFactorEnabled], [u].[UserName], [r].[Id], [r].[AssignedAt], [r].[AssignedBy], [r].[AssignmentType], [r].[CompletedAt], [r].[Deadline], [r].[ReviewerId], [r].[SkillMatchScore], [r].[StartedAt], [r].[Status], [r].[SubmissionId]
+FROM [submissions] AS [s]
+INNER JOIN [phases] AS [p] ON [s].[PhaseId] = [p].[Id]
+INNER JOIN [users] AS [u] ON [s].[SubmittedBy] = [u].[Id]
+LEFT JOIN [reviewer_assignments] AS [r] ON [s].[Id] = [r].[SubmissionId]
+WHERE [s].[TopicId] = @__topicId_0 AND [s].[IsActive] = CAST(1 AS bit) AND [s].[DeletedAt] IS NULL
+ORDER BY [s].[Id], [p].[Id], [u].[Id]
+2025-10-04 02:20:33.635 +07:00 [DBG] Closing data reader to 'capbot_db' on server 'localhost'.
+2025-10-04 02:20:33.636 +07:00 [DBG] A data reader for 'capbot_db' on server 'localhost' is being disposed after spending 3ms reading results.
+2025-10-04 02:20:33.636 +07:00 [DBG] Closing connection to database 'capbot_db' on server 'localhost'.
+2025-10-04 02:20:33.636 +07:00 [DBG] Closed connection to database 'capbot_db' on server 'localhost' (0ms).
+2025-10-04 02:20:33.645 +07:00 [DBG] Compiling query expression: 
+'DbSet<EntityFile>()
+    .AsNoTracking()
+    .Include(x => x.File)
+    .Where(x => x.EntityId == __p_0 && (int)x.EntityType == 1 && x.IsPrimary)
+    .FirstOrDefault()'
+2025-10-04 02:20:33.651 +07:00 [DBG] Including navigation: 'EntityFile.File'.
+2025-10-04 02:20:33.661 +07:00 [DBG] Generated query execution expression: 
+'queryContext => ShapedQueryCompilingExpressionVisitor.SingleOrDefaultAsync<EntityFile>(
+    asyncEnumerable: new SingleQueryingEnumerable<EntityFile>(
+        (RelationalQueryContext)queryContext, 
+        RelationalCommandCache.QueryExpression(
+            Client Projections:
+                0 -> Dictionary<IProperty, int> { [Property: EntityFile.Id (long) Required PK AfterSave:Throw ValueGenerated.OnAdd, 0], [Property: EntityFile.Caption (string) MaxLength(512), 1], [Property: EntityFile.CreatedAt (DateTime) Required, 2], [Property: EntityFile.EntityId (long) Required Index, 3], [Property: EntityFile.EntityType (EntityType) Required Index, 4], [Property: EntityFile.FileId (long) Required FK Index, 5], [Property: EntityFile.IsPrimary (bool) Required, 6] }
+                1 -> Dictionary<IProperty, int> { [Property: AppFile.Id (long) Required PK AfterSave:Throw ValueGenerated.OnAdd, 7], [Property: AppFile.Alt (string) MaxLength(255), 8], [Property: AppFile.Checksum (string) MaxLength(128), 9], [Property: AppFile.CreatedAt (DateTime) Required, 10], [Property: AppFile.CreatedBy (string), 11], [Property: AppFile.DeletedAt (DateTime?), 12], [Property: AppFile.FileName (string) Required MaxLength(255), 13], [Property: AppFile.FilePath (string) Required MaxLength(1024), 14], [Property: AppFile.FileSize (long) Required, 15], [Property: AppFile.FileType (FileType) Required, 16], [Property: AppFile.Height (int?), 17], [Property: AppFile.IsActive (bool) Required, 18], [Property: AppFile.LastModifiedAt (DateTime?), 19], [Property: AppFile.LastModifiedBy (string), 20], [Property: AppFile.MimeType (string) MaxLength(255), 21], [Property: AppFile.ThumbnailUrl (string) MaxLength(2048), 22], [Property: AppFile.Url (string) Required MaxLength(2048), 23], [Property: AppFile.Width (int?), 24] }
+            SELECT TOP(1) e.Id, e.Caption, e.CreatedAt, e.EntityId, e.EntityType, e.FileId, e.IsPrimary, f.Id, f.Alt, f.Checksum, f.CreatedAt, f.CreatedBy, f.DeletedAt, f.FileName, f.FilePath, f.FileSize, f.FileType, f.Height, f.IsActive, f.LastModifiedAt, f.LastModifiedBy, f.MimeType, f.ThumbnailUrl, f.Url, f.Width
+            FROM entity_files AS e
+            INNER JOIN files AS f ON e.FileId == f.Id
+            WHERE ((e.EntityId == @__p_0) && (e.EntityType == 1)) && e.IsPrimary), 
+        null, 
+        Func<QueryContext, DbDataReader, ResultContext, SingleQueryResultCoordinator, EntityFile>, 
+        App.DAL.Context.MyDbContext, 
+        False, 
+        False, 
+        True
+    ), 
+    cancellationToken: queryContext.CancellationToken)'
+2025-10-04 02:20:33.667 +07:00 [DBG] Opening connection to database 'capbot_db' on server 'localhost'.
+2025-10-04 02:20:33.668 +07:00 [DBG] Opened connection to database 'capbot_db' on server 'localhost'.
+2025-10-04 02:20:33.668 +07:00 [DBG] Creating DbCommand for 'ExecuteReader'.
+2025-10-04 02:20:33.668 +07:00 [DBG] Created DbCommand for 'ExecuteReader' (0ms).
+2025-10-04 02:20:33.668 +07:00 [DBG] Initialized DbCommand for 'ExecuteReader' (0ms).
+2025-10-04 02:20:33.668 +07:00 [DBG] Executing DbCommand [Parameters=[@__p_0='?' (DbType = Int64)], CommandType='"Text"', CommandTimeout='30']
+SELECT TOP(1) [e].[Id], [e].[Caption], [e].[CreatedAt], [e].[EntityId], [e].[EntityType], [e].[FileId], [e].[IsPrimary], [f].[Id], [f].[Alt], [f].[Checksum], [f].[CreatedAt], [f].[CreatedBy], [f].[DeletedAt], [f].[FileName], [f].[FilePath], [f].[FileSize], [f].[FileType], [f].[Height], [f].[IsActive], [f].[LastModifiedAt], [f].[LastModifiedBy], [f].[MimeType], [f].[ThumbnailUrl], [f].[Url], [f].[Width]
+FROM [entity_files] AS [e]
+INNER JOIN [files] AS [f] ON [e].[FileId] = [f].[Id]
+WHERE [e].[EntityId] = @__p_0 AND [e].[EntityType] = 1 AND [e].[IsPrimary] = CAST(1 AS bit)
+2025-10-04 02:20:33.695 +07:00 [INF] Executed DbCommand (26ms) [Parameters=[@__p_0='?' (DbType = Int64)], CommandType='"Text"', CommandTimeout='30']
+SELECT TOP(1) [e].[Id], [e].[Caption], [e].[CreatedAt], [e].[EntityId], [e].[EntityType], [e].[FileId], [e].[IsPrimary], [f].[Id], [f].[Alt], [f].[Checksum], [f].[CreatedAt], [f].[CreatedBy], [f].[DeletedAt], [f].[FileName], [f].[FilePath], [f].[FileSize], [f].[FileType], [f].[Height], [f].[IsActive], [f].[LastModifiedAt], [f].[LastModifiedBy], [f].[MimeType], [f].[ThumbnailUrl], [f].[Url], [f].[Width]
+FROM [entity_files] AS [e]
+INNER JOIN [files] AS [f] ON [e].[FileId] = [f].[Id]
+WHERE [e].[EntityId] = @__p_0 AND [e].[EntityType] = 1 AND [e].[IsPrimary] = CAST(1 AS bit)
+2025-10-04 02:20:33.695 +07:00 [DBG] Closing data reader to 'capbot_db' on server 'localhost'.
+2025-10-04 02:20:33.695 +07:00 [DBG] A data reader for 'capbot_db' on server 'localhost' is being disposed after spending 0ms reading results.
+2025-10-04 02:20:33.695 +07:00 [DBG] Closing connection to database 'capbot_db' on server 'localhost'.
+2025-10-04 02:20:33.696 +07:00 [DBG] Closed connection to database 'capbot_db' on server 'localhost' (0ms).
+2025-10-04 02:20:33.717 +07:00 [DBG] List of registered output formatters, in the following order: ["Microsoft.AspNetCore.OData.Formatter.ODataOutputFormatter","Microsoft.AspNetCore.OData.Formatter.ODataOutputFormatter","Microsoft.AspNetCore.OData.Formatter.ODataOutputFormatter","Microsoft.AspNetCore.Mvc.Formatters.HttpNoContentOutputFormatter","Microsoft.AspNetCore.Mvc.Formatters.StringOutputFormatter","Microsoft.AspNetCore.Mvc.Formatters.StreamOutputFormatter","Microsoft.AspNetCore.Mvc.Formatters.SystemTextJsonOutputFormatter"]
+2025-10-04 02:20:33.718 +07:00 [DBG] No information found on request to perform content negotiation.
+2025-10-04 02:20:33.719 +07:00 [DBG] Attempting to select the first output formatter in the output formatters list which supports a content type from the explicitly specified content types '["application/json"]'.
+2025-10-04 02:20:33.722 +07:00 [DBG] Selected output formatter 'Microsoft.AspNetCore.Mvc.Formatters.SystemTextJsonOutputFormatter' and content type 'application/json' to write the response.
+2025-10-04 02:20:33.722 +07:00 [INF] Executing ObjectResult, writing value of type 'FS.Commons.FSResponse'.
+2025-10-04 02:20:33.827 +07:00 [INF] Executed action CapBot.api.Controllers.TopicController.GetDetail (CapBot.api) in 754.0804ms
+2025-10-04 02:20:33.828 +07:00 [INF] Executed endpoint 'CapBot.api.Controllers.TopicController.GetDetail (CapBot.api)'
+2025-10-04 02:20:33.835 +07:00 [DBG] Connection id "0HNG2M7AQS921" completed keep alive response.
+2025-10-04 02:20:33.837 +07:00 [DBG] 'MyDbContext' disposed.
+2025-10-04 02:20:33.837 +07:00 [DBG] Disposing connection to database 'capbot_db' on server 'localhost'.
+2025-10-04 02:20:33.837 +07:00 [DBG] Disposed connection to database '' on server '' (0ms).
+2025-10-04 02:20:33.839 +07:00 [INF] Request finished HTTP/1.1 GET http://localhost:5207/api/topic/detail/104 - 200 null application/json; charset=utf-8 1018.9879ms
+2025-10-04 02:20:43.044 +07:00 [DBG] Connection id "0HNG2M7AQS921" received FIN.
+2025-10-04 02:20:43.044 +07:00 [DBG] Connection id "0HNG2M7AQS921" sending FIN because: "The Socket transport's send loop completed gracefully."
+2025-10-04 02:20:43.045 +07:00 [DBG] Connection id "0HNG2M7AQS921" disconnecting.
+2025-10-04 02:20:43.046 +07:00 [DBG] Connection id "0HNG2M7AQS921" stopped.
+2025-10-04 02:22:33.109 +07:00 [DBG] HttpMessageHandler expired after 120000ms for client ''
+2025-10-04 02:22:43.119 +07:00 [DBG] Starting HttpMessageHandler cleanup cycle with 1 items
+2025-10-04 02:22:43.122 +07:00 [DBG] Ending HttpMessageHandler cleanup cycle after 0.2244ms - processed: 0 items - remaining: 1 items
+2025-10-04 02:22:53.133 +07:00 [DBG] Starting HttpMessageHandler cleanup cycle with 1 items
+2025-10-04 02:22:53.134 +07:00 [DBG] Ending HttpMessageHandler cleanup cycle after 0.0061ms - processed: 0 items - remaining: 1 items
+2025-10-04 02:23:03.143 +07:00 [DBG] Starting HttpMessageHandler cleanup cycle with 1 items
+2025-10-04 02:23:03.143 +07:00 [DBG] Ending HttpMessageHandler cleanup cycle after 0.0082ms - processed: 0 items - remaining: 1 items
+2025-10-04 02:23:13.153 +07:00 [DBG] Starting HttpMessageHandler cleanup cycle with 1 items
+2025-10-04 02:23:13.153 +07:00 [DBG] Ending HttpMessageHandler cleanup cycle after 0.0057ms - processed: 0 items - remaining: 1 items
+2025-10-04 02:23:23.165 +07:00 [DBG] Starting HttpMessageHandler cleanup cycle with 1 items
+2025-10-04 02:23:23.166 +07:00 [DBG] Ending HttpMessageHandler cleanup cycle after 0.0046ms - processed: 0 items - remaining: 1 items
+2025-10-04 02:23:33.176 +07:00 [DBG] Starting HttpMessageHandler cleanup cycle with 1 items
+2025-10-04 02:23:33.177 +07:00 [DBG] Ending HttpMessageHandler cleanup cycle after 0.0302ms - processed: 0 items - remaining: 1 items
+2025-10-04 02:23:43.184 +07:00 [DBG] Starting HttpMessageHandler cleanup cycle with 1 items
+2025-10-04 02:23:43.185 +07:00 [DBG] Ending HttpMessageHandler cleanup cycle after 0.0036ms - processed: 0 items - remaining: 1 items
+2025-10-04 02:23:53.195 +07:00 [DBG] Starting HttpMessageHandler cleanup cycle with 1 items
+2025-10-04 02:23:53.195 +07:00 [DBG] Ending HttpMessageHandler cleanup cycle after 0.0062ms - processed: 0 items - remaining: 1 items
+2025-10-04 02:23:59.022 +07:00 [INF] Application is shutting down...
+2025-10-04 02:23:59.023 +07:00 [DBG] Hosting stopping
+2025-10-04 02:23:59.034 +07:00 [ERR] Lỗi khi kiểm tra deadline notifications
+System.Threading.Tasks.TaskCanceledException: A task was canceled.
+   at CapBot.api.Services.DeadlineNotificationService.ExecuteAsync(CancellationToken stoppingToken) in C:\Users\acer\Downloads\CBAI_API\capbot.api\Services\DeadlineNotificationService.cs:line 41
+2025-10-04 02:23:59.074 +07:00 [DBG] Hosting stopped
+2025-10-04 02:53:54.375 +07:00 [DBG] An 'IServiceProvider' was created for internal use by Entity Framework.
+2025-10-04 02:53:54.612 +07:00 [INF] User profile is available. Using 'C:\Users\acer\AppData\Local\ASP.NET\DataProtection-Keys' as key repository and Windows DPAPI to encrypt keys at rest.
+2025-10-04 02:53:55.260 +07:00 [DBG] No relationship from 'ReviewerAssignment' to 'User' has been configured by convention because there are multiple properties on one entity type - {'AssignedByUser', 'Reviewer'} that could be matched with the properties on the other entity type - {'ReviewerAssignments'}. This message can be disregarded if explicit configuration has been specified in 'OnModelCreating'.
+2025-10-04 02:53:55.321 +07:00 [DBG] No relationship from 'SubmissionWorkflowLog' to 'WorkflowState' has been configured by convention because there are multiple properties on one entity type - {'FromState', 'ToState'} that could be matched with the properties on the other entity type - {'FromStateLogs', 'ToStateLogs'}. This message can be disregarded if explicit configuration has been specified in 'OnModelCreating'.
+2025-10-04 02:53:55.363 +07:00 [DBG] No relationship from 'User' to 'ReviewerAssignment' has been configured by convention because there are multiple properties on one entity type - {'ReviewerAssignments'} that could be matched with the properties on the other entity type - {'AssignedByUser', 'Reviewer'}. This message can be disregarded if explicit configuration has been specified in 'OnModelCreating'.
+2025-10-04 02:53:55.367 +07:00 [DBG] No relationship from 'WorkflowState' to 'SubmissionWorkflowLog' has been configured by convention because there are multiple properties on one entity type - {'FromStateLogs', 'ToStateLogs'} that could be matched with the properties on the other entity type - {'FromState', 'ToState'}. This message can be disregarded if explicit configuration has been specified in 'OnModelCreating'.
+2025-10-04 02:53:55.368 +07:00 [DBG] No relationship from 'WorkflowState' to 'WorkflowTransition' has been configured by convention because there are multiple properties on one entity type - {'FromTransitions', 'ToTransitions'} that could be matched with the properties on the other entity type - {'FromState', 'ToState'}. This message can be disregarded if explicit configuration has been specified in 'OnModelCreating'.
+2025-10-04 02:53:55.372 +07:00 [DBG] No relationship from 'WorkflowTransition' to 'WorkflowState' has been configured by convention because there are multiple properties on one entity type - {'FromState', 'ToState'} that could be matched with the properties on the other entity type - {'FromTransitions', 'ToTransitions'}. This message can be disregarded if explicit configuration has been specified in 'OnModelCreating'.
+2025-10-04 02:53:55.981 +07:00 [DBG] No relationship from 'ReviewerAssignment' to 'User' has been configured by convention because there are multiple properties on one entity type - {'AssignedByUser', 'Reviewer'} that could be matched with the properties on the other entity type - {'ReviewerAssignments'}. This message can be disregarded if explicit configuration has been specified in 'OnModelCreating'.
+2025-10-04 02:53:55.984 +07:00 [DBG] No relationship from 'User' to 'ReviewerAssignment' has been configured by convention because there are multiple properties on one entity type - {'ReviewerAssignments'} that could be matched with the properties on the other entity type - {'AssignedByUser', 'Reviewer'}. This message can be disregarded if explicit configuration has been specified in 'OnModelCreating'.
+2025-10-04 02:53:56.034 +07:00 [DBG] No relationship from 'WorkflowTransition' to 'WorkflowState' has been configured by convention because there are multiple properties on one entity type - {'FromState', 'ToState'} that could be matched with the properties on the other entity type - {'FromTransitions', 'ToTransitions'}. This message can be disregarded if explicit configuration has been specified in 'OnModelCreating'.
+2025-10-04 02:53:56.039 +07:00 [DBG] No relationship from 'WorkflowState' to 'SubmissionWorkflowLog' has been configured by convention because there are multiple properties on one entity type - {'FromStateLogs', 'ToStateLogs'} that could be matched with the properties on the other entity type - {'FromState', 'ToState'}. This message can be disregarded if explicit configuration has been specified in 'OnModelCreating'.
+2025-10-04 02:53:56.040 +07:00 [DBG] No relationship from 'WorkflowState' to 'WorkflowTransition' has been configured by convention because there are multiple properties on one entity type - {'FromTransitions', 'ToTransitions'} that could be matched with the properties on the other entity type - {'FromState', 'ToState'}. This message can be disregarded if explicit configuration has been specified in 'OnModelCreating'.
+2025-10-04 02:53:56.045 +07:00 [DBG] No relationship from 'WorkflowState' to 'SubmissionWorkflowLog' has been configured by convention because there are multiple properties on one entity type - {'FromStateLogs', 'ToStateLogs'} that could be matched with the properties on the other entity type - {'FromState', 'ToState'}. This message can be disregarded if explicit configuration has been specified in 'OnModelCreating'.
+2025-10-04 02:53:56.066 +07:00 [DBG] No relationship from 'SubmissionWorkflowLog' to 'WorkflowState' has been configured by convention because there are multiple properties on one entity type - {'FromState', 'ToState'} that could be matched with the properties on the other entity type - {'FromStateLogs', 'ToStateLogs'}. This message can be disregarded if explicit configuration has been specified in 'OnModelCreating'.
+2025-10-04 02:53:56.068 +07:00 [DBG] No relationship from 'WorkflowState' to 'SubmissionWorkflowLog' has been configured by convention because there are multiple properties on one entity type - {'FromStateLogs', 'ToStateLogs'} that could be matched with the properties on the other entity type - {'FromState', 'ToState'}. This message can be disregarded if explicit configuration has been specified in 'OnModelCreating'.
+2025-10-04 02:53:56.196 +07:00 [DBG] The index {'LecturerId'} was not created on entity type 'LecturerSkill' as the properties are already covered by the index {'LecturerId', 'SkillTag'}.
+2025-10-04 02:53:56.197 +07:00 [DBG] The index {'SemesterId'} was not created on entity type 'Phase' as the properties are already covered by the index {'SemesterId', 'PhaseTypeId'}.
+2025-10-04 02:53:56.198 +07:00 [DBG] The index {'AssignmentId'} was not created on entity type 'Review' as the properties are already covered by the index {'AssignmentId', 'Status'}.
+2025-10-04 02:53:56.199 +07:00 [DBG] The index {'ReviewId'} was not created on entity type 'ReviewComment' as the properties are already covered by the index {'ReviewId', 'SectionName'}.
+2025-10-04 02:53:56.199 +07:00 [DBG] The index {'ReviewId'} was not created on entity type 'ReviewCriteriaScore' as the properties are already covered by the index {'ReviewId', 'CriteriaId'}.
+2025-10-04 02:53:56.200 +07:00 [DBG] The index {'ReviewerId'} was not created on entity type 'ReviewerAssignment' as the properties are already covered by the index {'ReviewerId', 'Status'}.
+2025-10-04 02:53:56.201 +07:00 [DBG] The index {'SubmissionId'} was not created on entity type 'ReviewerAssignment' as the properties are already covered by the index {'SubmissionId', 'ReviewerId'}.
+2025-10-04 02:53:56.203 +07:00 [DBG] The index {'ReviewerId'} was not created on entity type 'ReviewerPerformance' as the properties are already covered by the index {'ReviewerId', 'SemesterId'}.
+2025-10-04 02:53:56.205 +07:00 [DBG] The index {'PhaseId'} was not created on entity type 'Submission' as the properties are already covered by the index {'PhaseId', 'Status'}.
+2025-10-04 02:53:56.206 +07:00 [DBG] The index {'PhaseId'} was not created on entity type 'Submission' as the properties are already covered by the index {'PhaseId', 'Status', 'SubmittedAt'}.
+2025-10-04 02:53:56.206 +07:00 [DBG] The index {'TopicId'} was not created on entity type 'Submission' as the properties are already covered by the index {'TopicId', 'PhaseId', 'SubmissionRound'}.
+2025-10-04 02:53:56.207 +07:00 [DBG] The index {'SubmissionId'} was not created on entity type 'SubmissionWorkflowLog' as the properties are already covered by the index {'SubmissionId', 'CreatedAt'}.
+2025-10-04 02:53:56.208 +07:00 [DBG] The index {'UserId'} was not created on entity type 'SystemNotification' as the properties are already covered by the index {'UserId', 'IsRead', 'CreatedAt'}.
+2025-10-04 02:53:56.209 +07:00 [DBG] The index {'SemesterId'} was not created on entity type 'Topic' as the properties are already covered by the index {'SemesterId', 'IsApproved'}.
+2025-10-04 02:53:56.211 +07:00 [DBG] The index {'SupervisorId'} was not created on entity type 'Topic' as the properties are already covered by the index {'SupervisorId', 'SemesterId'}.
+2025-10-04 02:53:56.211 +07:00 [DBG] The index {'TopicId'} was not created on entity type 'TopicVersion' as the properties are already covered by the index {'TopicId', 'Status'}.
+2025-10-04 02:53:56.211 +07:00 [DBG] The index {'TopicId'} was not created on entity type 'TopicVersion' as the properties are already covered by the index {'TopicId', 'VersionNumber'}.
+2025-10-04 02:53:56.212 +07:00 [DBG] The index {'UserId'} was not created on entity type 'UserRole' as the properties are already covered by the index {'UserId', 'RoleId'}.
+2025-10-04 02:53:56.212 +07:00 [DBG] The index {'UserId'} was not created on entity type 'UserToken' as the properties are already covered by the index {'UserId', 'LoginProvider', 'Name'}.
+2025-10-04 02:53:56.622 +07:00 [WRN] The 'ProficiencyLevels' property 'ProficiencyLevel' on entity type 'LecturerSkill' is configured with a database-generated default, but has no configured sentinel value. The database-generated default will always be used for inserts when the property has the value '0', since this is the CLR default for the 'ProficiencyLevels' type. Consider using a nullable type, using a nullable backing field, or setting the sentinel value for the property to ensure the database default is used when, and only when, appropriate. See https://aka.ms/efcore-docs-default-values for more information.
+2025-10-04 02:53:56.623 +07:00 [WRN] The 'ReviewRecommendations' property 'Recommendation' on entity type 'Review' is configured with a database-generated default, but has no configured sentinel value. The database-generated default will always be used for inserts when the property has the value '0', since this is the CLR default for the 'ReviewRecommendations' type. Consider using a nullable type, using a nullable backing field, or setting the sentinel value for the property to ensure the database default is used when, and only when, appropriate. See https://aka.ms/efcore-docs-default-values for more information.
+2025-10-04 02:53:56.623 +07:00 [WRN] The 'ReviewStatus' property 'Status' on entity type 'Review' is configured with a database-generated default, but has no configured sentinel value. The database-generated default will always be used for inserts when the property has the value '0', since this is the CLR default for the 'ReviewStatus' type. Consider using a nullable type, using a nullable backing field, or setting the sentinel value for the property to ensure the database default is used when, and only when, appropriate. See https://aka.ms/efcore-docs-default-values for more information.
+2025-10-04 02:53:56.623 +07:00 [WRN] The 'CommentTypes' property 'CommentType' on entity type 'ReviewComment' is configured with a database-generated default, but has no configured sentinel value. The database-generated default will always be used for inserts when the property has the value '0', since this is the CLR default for the 'CommentTypes' type. Consider using a nullable type, using a nullable backing field, or setting the sentinel value for the property to ensure the database default is used when, and only when, appropriate. See https://aka.ms/efcore-docs-default-values for more information.
+2025-10-04 02:53:56.624 +07:00 [WRN] The 'PriorityLevels' property 'Priority' on entity type 'ReviewComment' is configured with a database-generated default, but has no configured sentinel value. The database-generated default will always be used for inserts when the property has the value '0', since this is the CLR default for the 'PriorityLevels' type. Consider using a nullable type, using a nullable backing field, or setting the sentinel value for the property to ensure the database default is used when, and only when, appropriate. See https://aka.ms/efcore-docs-default-values for more information.
+2025-10-04 02:53:56.624 +07:00 [WRN] The 'AssignmentTypes' property 'AssignmentType' on entity type 'ReviewerAssignment' is configured with a database-generated default, but has no configured sentinel value. The database-generated default will always be used for inserts when the property has the value '0', since this is the CLR default for the 'AssignmentTypes' type. Consider using a nullable type, using a nullable backing field, or setting the sentinel value for the property to ensure the database default is used when, and only when, appropriate. See https://aka.ms/efcore-docs-default-values for more information.
+2025-10-04 02:53:56.624 +07:00 [WRN] The 'AssignmentStatus' property 'Status' on entity type 'ReviewerAssignment' is configured with a database-generated default, but has no configured sentinel value. The database-generated default will always be used for inserts when the property has the value '0', since this is the CLR default for the 'AssignmentStatus' type. Consider using a nullable type, using a nullable backing field, or setting the sentinel value for the property to ensure the database default is used when, and only when, appropriate. See https://aka.ms/efcore-docs-default-values for more information.
+2025-10-04 02:53:56.625 +07:00 [WRN] The 'AiCheckStatus' property 'AiCheckStatus' on entity type 'Submission' is configured with a database-generated default, but has no configured sentinel value. The database-generated default will always be used for inserts when the property has the value '0', since this is the CLR default for the 'AiCheckStatus' type. Consider using a nullable type, using a nullable backing field, or setting the sentinel value for the property to ensure the database default is used when, and only when, appropriate. See https://aka.ms/efcore-docs-default-values for more information.
+2025-10-04 02:53:56.625 +07:00 [WRN] The 'SubmissionStatus' property 'Status' on entity type 'Submission' is configured with a database-generated default, but has no configured sentinel value. The database-generated default will always be used for inserts when the property has the value '0', since this is the CLR default for the 'SubmissionStatus' type. Consider using a nullable type, using a nullable backing field, or setting the sentinel value for the property to ensure the database default is used when, and only when, appropriate. See https://aka.ms/efcore-docs-default-values for more information.
+2025-10-04 02:53:56.626 +07:00 [WRN] The 'NotificationTypes' property 'Type' on entity type 'SystemNotification' is configured with a database-generated default, but has no configured sentinel value. The database-generated default will always be used for inserts when the property has the value '0', since this is the CLR default for the 'NotificationTypes' type. Consider using a nullable type, using a nullable backing field, or setting the sentinel value for the property to ensure the database default is used when, and only when, appropriate. See https://aka.ms/efcore-docs-default-values for more information.
+2025-10-04 02:53:56.626 +07:00 [WRN] The 'TopicStatus' property 'Status' on entity type 'TopicVersion' is configured with a database-generated default, but has no configured sentinel value. The database-generated default will always be used for inserts when the property has the value '0', since this is the CLR default for the 'TopicStatus' type. Consider using a nullable type, using a nullable backing field, or setting the sentinel value for the property to ensure the database default is used when, and only when, appropriate. See https://aka.ms/efcore-docs-default-values for more information.
+2025-10-04 02:53:56.946 +07:00 [DBG] Entity Framework Core 8.0.16 initialized 'MyDbContext' using provider 'Microsoft.EntityFrameworkCore.SqlServer:8.0.13' with options: MigrationsAssembly=App.DAL 
+2025-10-04 02:53:57.084 +07:00 [DBG] Compiling query expression: 
+'DbSet<Role>()
+    .FirstOrDefault(r => r.NormalizedName == __normalizedName_0)'
+2025-10-04 02:53:57.544 +07:00 [DBG] Generated query execution expression: 
+'queryContext => ShapedQueryCompilingExpressionVisitor.SingleOrDefaultAsync<Role>(
+    asyncEnumerable: new SingleQueryingEnumerable<Role>(
+        (RelationalQueryContext)queryContext, 
+        RelationalCommandCache.QueryExpression(
+            Projection Mapping:
+                EmptyProjectionMember -> Dictionary<IProperty, int> { [Property: Role.Id (int) Required PK AfterSave:Throw ValueGenerated.OnAdd, 0], [Property: Role.ConcurrencyStamp (string), 1], [Property: Role.IsAdmin (bool) Required, 2], [Property: Role.Name (string), 3], [Property: Role.NormalizedName (string), 4] }
+            SELECT TOP(1) r.Id, r.ConcurrencyStamp, r.IsAdmin, r.Name, r.NormalizedName
+            FROM roles AS r
+            WHERE r.NormalizedName == @__normalizedName_0), 
+        null, 
+        Func<QueryContext, DbDataReader, ResultContext, SingleQueryResultCoordinator, Role>, 
+        App.DAL.Context.MyDbContext, 
+        False, 
+        False, 
+        True
+    ), 
+    cancellationToken: queryContext.CancellationToken)'
+2025-10-04 02:53:57.661 +07:00 [DBG] Creating DbConnection.
+2025-10-04 02:53:57.711 +07:00 [DBG] Created DbConnection. (46ms).
+2025-10-04 02:53:57.722 +07:00 [DBG] Opening connection to database 'capbot_db' on server 'localhost'.
+2025-10-04 02:53:58.295 +07:00 [DBG] Opened connection to database 'capbot_db' on server 'localhost'.
+2025-10-04 02:53:58.300 +07:00 [DBG] Creating DbCommand for 'ExecuteReader'.
+2025-10-04 02:53:58.311 +07:00 [DBG] Created DbCommand for 'ExecuteReader' (7ms).
+2025-10-04 02:53:58.328 +07:00 [DBG] Initialized DbCommand for 'ExecuteReader' (29ms).
+2025-10-04 02:53:58.345 +07:00 [DBG] Executing DbCommand [Parameters=[@__normalizedName_0='?' (Size = 4000)], CommandType='"Text"', CommandTimeout='30']
+SELECT TOP(1) [r].[Id], [r].[ConcurrencyStamp], [r].[IsAdmin], [r].[Name], [r].[NormalizedName]
+FROM [roles] AS [r]
+WHERE [r].[NormalizedName] = @__normalizedName_0
+2025-10-04 02:53:58.461 +07:00 [INF] Executed DbCommand (119ms) [Parameters=[@__normalizedName_0='?' (Size = 4000)], CommandType='"Text"', CommandTimeout='30']
+SELECT TOP(1) [r].[Id], [r].[ConcurrencyStamp], [r].[IsAdmin], [r].[Name], [r].[NormalizedName]
+FROM [roles] AS [r]
+WHERE [r].[NormalizedName] = @__normalizedName_0
+2025-10-04 02:53:58.529 +07:00 [DBG] Context 'MyDbContext' started tracking 'Role' entity. Consider using 'DbContextOptionsBuilder.EnableSensitiveDataLogging' to see key values.
+2025-10-04 02:53:58.560 +07:00 [DBG] Closing data reader to 'capbot_db' on server 'localhost'.
+2025-10-04 02:53:58.572 +07:00 [DBG] A data reader for 'capbot_db' on server 'localhost' is being disposed after spending 102ms reading results.
+2025-10-04 02:53:58.575 +07:00 [DBG] Closing connection to database 'capbot_db' on server 'localhost'.
+2025-10-04 02:53:58.580 +07:00 [DBG] Closed connection to database 'capbot_db' on server 'localhost' (4ms).
+2025-10-04 02:53:58.587 +07:00 [DBG] Opening connection to database 'capbot_db' on server 'localhost'.
+2025-10-04 02:53:58.589 +07:00 [DBG] Opened connection to database 'capbot_db' on server 'localhost'.
+2025-10-04 02:53:58.589 +07:00 [DBG] Creating DbCommand for 'ExecuteReader'.
+2025-10-04 02:53:58.589 +07:00 [DBG] Created DbCommand for 'ExecuteReader' (0ms).
+2025-10-04 02:53:58.589 +07:00 [DBG] Initialized DbCommand for 'ExecuteReader' (0ms).
+2025-10-04 02:53:58.590 +07:00 [DBG] Executing DbCommand [Parameters=[@__normalizedName_0='?' (Size = 4000)], CommandType='"Text"', CommandTimeout='30']
+SELECT TOP(1) [r].[Id], [r].[ConcurrencyStamp], [r].[IsAdmin], [r].[Name], [r].[NormalizedName]
+FROM [roles] AS [r]
+WHERE [r].[NormalizedName] = @__normalizedName_0
+2025-10-04 02:53:58.595 +07:00 [INF] Executed DbCommand (5ms) [Parameters=[@__normalizedName_0='?' (Size = 4000)], CommandType='"Text"', CommandTimeout='30']
+SELECT TOP(1) [r].[Id], [r].[ConcurrencyStamp], [r].[IsAdmin], [r].[Name], [r].[NormalizedName]
+FROM [roles] AS [r]
+WHERE [r].[NormalizedName] = @__normalizedName_0
+2025-10-04 02:53:58.596 +07:00 [DBG] Context 'MyDbContext' started tracking 'Role' entity. Consider using 'DbContextOptionsBuilder.EnableSensitiveDataLogging' to see key values.
+2025-10-04 02:53:58.596 +07:00 [DBG] Closing data reader to 'capbot_db' on server 'localhost'.
+2025-10-04 02:53:58.596 +07:00 [DBG] A data reader for 'capbot_db' on server 'localhost' is being disposed after spending 1ms reading results.
+2025-10-04 02:53:58.597 +07:00 [DBG] Closing connection to database 'capbot_db' on server 'localhost'.
+2025-10-04 02:53:58.597 +07:00 [DBG] Closed connection to database 'capbot_db' on server 'localhost' (0ms).
+2025-10-04 02:53:58.599 +07:00 [DBG] Opening connection to database 'capbot_db' on server 'localhost'.
+2025-10-04 02:53:58.601 +07:00 [DBG] Opened connection to database 'capbot_db' on server 'localhost'.
+2025-10-04 02:53:58.601 +07:00 [DBG] Creating DbCommand for 'ExecuteReader'.
+2025-10-04 02:53:58.601 +07:00 [DBG] Created DbCommand for 'ExecuteReader' (0ms).
+2025-10-04 02:53:58.602 +07:00 [DBG] Initialized DbCommand for 'ExecuteReader' (0ms).
+2025-10-04 02:53:58.602 +07:00 [DBG] Executing DbCommand [Parameters=[@__normalizedName_0='?' (Size = 4000)], CommandType='"Text"', CommandTimeout='30']
+SELECT TOP(1) [r].[Id], [r].[ConcurrencyStamp], [r].[IsAdmin], [r].[Name], [r].[NormalizedName]
+FROM [roles] AS [r]
+WHERE [r].[NormalizedName] = @__normalizedName_0
+2025-10-04 02:53:58.605 +07:00 [INF] Executed DbCommand (3ms) [Parameters=[@__normalizedName_0='?' (Size = 4000)], CommandType='"Text"', CommandTimeout='30']
+SELECT TOP(1) [r].[Id], [r].[ConcurrencyStamp], [r].[IsAdmin], [r].[Name], [r].[NormalizedName]
+FROM [roles] AS [r]
+WHERE [r].[NormalizedName] = @__normalizedName_0
+2025-10-04 02:53:58.606 +07:00 [DBG] Context 'MyDbContext' started tracking 'Role' entity. Consider using 'DbContextOptionsBuilder.EnableSensitiveDataLogging' to see key values.
+2025-10-04 02:53:58.606 +07:00 [DBG] Closing data reader to 'capbot_db' on server 'localhost'.
+2025-10-04 02:53:58.606 +07:00 [DBG] A data reader for 'capbot_db' on server 'localhost' is being disposed after spending 0ms reading results.
+2025-10-04 02:53:58.606 +07:00 [DBG] Closing connection to database 'capbot_db' on server 'localhost'.
+2025-10-04 02:53:58.606 +07:00 [DBG] Closed connection to database 'capbot_db' on server 'localhost' (0ms).
+2025-10-04 02:53:58.607 +07:00 [DBG] Opening connection to database 'capbot_db' on server 'localhost'.
+2025-10-04 02:53:58.607 +07:00 [DBG] Opened connection to database 'capbot_db' on server 'localhost'.
+2025-10-04 02:53:58.607 +07:00 [DBG] Creating DbCommand for 'ExecuteReader'.
+2025-10-04 02:53:58.607 +07:00 [DBG] Created DbCommand for 'ExecuteReader' (0ms).
+2025-10-04 02:53:58.608 +07:00 [DBG] Initialized DbCommand for 'ExecuteReader' (0ms).
+2025-10-04 02:53:58.608 +07:00 [DBG] Executing DbCommand [Parameters=[@__normalizedName_0='?' (Size = 4000)], CommandType='"Text"', CommandTimeout='30']
+SELECT TOP(1) [r].[Id], [r].[ConcurrencyStamp], [r].[IsAdmin], [r].[Name], [r].[NormalizedName]
+FROM [roles] AS [r]
+WHERE [r].[NormalizedName] = @__normalizedName_0
+2025-10-04 02:53:58.612 +07:00 [INF] Executed DbCommand (5ms) [Parameters=[@__normalizedName_0='?' (Size = 4000)], CommandType='"Text"', CommandTimeout='30']
+SELECT TOP(1) [r].[Id], [r].[ConcurrencyStamp], [r].[IsAdmin], [r].[Name], [r].[NormalizedName]
+FROM [roles] AS [r]
+WHERE [r].[NormalizedName] = @__normalizedName_0
+2025-10-04 02:53:58.613 +07:00 [DBG] Context 'MyDbContext' started tracking 'Role' entity. Consider using 'DbContextOptionsBuilder.EnableSensitiveDataLogging' to see key values.
+2025-10-04 02:53:58.613 +07:00 [DBG] Closing data reader to 'capbot_db' on server 'localhost'.
+2025-10-04 02:53:58.614 +07:00 [DBG] A data reader for 'capbot_db' on server 'localhost' is being disposed after spending 0ms reading results.
+2025-10-04 02:53:58.614 +07:00 [DBG] Closing connection to database 'capbot_db' on server 'localhost'.
+2025-10-04 02:53:58.615 +07:00 [DBG] Closed connection to database 'capbot_db' on server 'localhost' (0ms).
+2025-10-04 02:53:58.626 +07:00 [DBG] Compiling query expression: 
+'DbSet<User>()
+    .SingleOrDefault(u => u.NormalizedEmail == __normalizedEmail_0)'
+2025-10-04 02:53:58.637 +07:00 [DBG] Generated query execution expression: 
+'queryContext => ShapedQueryCompilingExpressionVisitor.SingleOrDefaultAsync<User>(
+    asyncEnumerable: new SingleQueryingEnumerable<User>(
+        (RelationalQueryContext)queryContext, 
+        RelationalCommandCache.QueryExpression(
+            Projection Mapping:
+                EmptyProjectionMember -> Dictionary<IProperty, int> { [Property: User.Id (int) Required PK AfterSave:Throw ValueGenerated.OnAdd, 0], [Property: User.AccessFailedCount (int) Required, 1], [Property: User.ConcurrencyStamp (string), 2], [Property: User.CreatedAt (DateTime) Required, 3], [Property: User.DeletedAt (DateTime?), 4], [Property: User.Email (string), 5], [Property: User.EmailConfirmed (bool) Required, 6], [Property: User.LastModifiedAt (DateTime) Required, 7], [Property: User.LastModifiedBy (string), 8], [Property: User.LockoutEnabled (bool) Required, 9], [Property: User.LockoutEnd (DateTimeOffset?), 10], [Property: User.NormalizedEmail (string), 11], [Property: User.NormalizedUserName (string), 12], [Property: User.PasswordHash (string), 13], [Property: User.PhoneNumber (string), 14], [Property: User.PhoneNumberConfirmed (bool) Required, 15], [Property: User.SecurityStamp (string), 16], [Property: User.TwoFactorEnabled (bool) Required, 17], [Property: User.UserName (string), 18] }
+            SELECT TOP(2) u.Id, u.AccessFailedCount, u.ConcurrencyStamp, u.CreatedAt, u.DeletedAt, u.Email, u.EmailConfirmed, u.LastModifiedAt, u.LastModifiedBy, u.LockoutEnabled, u.LockoutEnd, u.NormalizedEmail, u.NormalizedUserName, u.PasswordHash, u.PhoneNumber, u.PhoneNumberConfirmed, u.SecurityStamp, u.TwoFactorEnabled, u.UserName
+            FROM users AS u
+            WHERE u.NormalizedEmail == @__normalizedEmail_0), 
+        null, 
+        Func<QueryContext, DbDataReader, ResultContext, SingleQueryResultCoordinator, User>, 
+        App.DAL.Context.MyDbContext, 
+        False, 
+        False, 
+        True
+    ), 
+    cancellationToken: queryContext.CancellationToken)'
+2025-10-04 02:53:58.638 +07:00 [DBG] Opening connection to database 'capbot_db' on server 'localhost'.
+2025-10-04 02:53:58.639 +07:00 [DBG] Opened connection to database 'capbot_db' on server 'localhost'.
+2025-10-04 02:53:58.639 +07:00 [DBG] Creating DbCommand for 'ExecuteReader'.
+2025-10-04 02:53:58.639 +07:00 [DBG] Created DbCommand for 'ExecuteReader' (0ms).
+2025-10-04 02:53:58.639 +07:00 [DBG] Initialized DbCommand for 'ExecuteReader' (0ms).
+2025-10-04 02:53:58.639 +07:00 [DBG] Executing DbCommand [Parameters=[@__normalizedEmail_0='?' (Size = 4000)], CommandType='"Text"', CommandTimeout='30']
+SELECT TOP(2) [u].[Id], [u].[AccessFailedCount], [u].[ConcurrencyStamp], [u].[CreatedAt], [u].[DeletedAt], [u].[Email], [u].[EmailConfirmed], [u].[LastModifiedAt], [u].[LastModifiedBy], [u].[LockoutEnabled], [u].[LockoutEnd], [u].[NormalizedEmail], [u].[NormalizedUserName], [u].[PasswordHash], [u].[PhoneNumber], [u].[PhoneNumberConfirmed], [u].[SecurityStamp], [u].[TwoFactorEnabled], [u].[UserName]
+FROM [users] AS [u]
+WHERE [u].[NormalizedEmail] = @__normalizedEmail_0
+2025-10-04 02:53:58.652 +07:00 [INF] Executed DbCommand (12ms) [Parameters=[@__normalizedEmail_0='?' (Size = 4000)], CommandType='"Text"', CommandTimeout='30']
+SELECT TOP(2) [u].[Id], [u].[AccessFailedCount], [u].[ConcurrencyStamp], [u].[CreatedAt], [u].[DeletedAt], [u].[Email], [u].[EmailConfirmed], [u].[LastModifiedAt], [u].[LastModifiedBy], [u].[LockoutEnabled], [u].[LockoutEnd], [u].[NormalizedEmail], [u].[NormalizedUserName], [u].[PasswordHash], [u].[PhoneNumber], [u].[PhoneNumberConfirmed], [u].[SecurityStamp], [u].[TwoFactorEnabled], [u].[UserName]
+FROM [users] AS [u]
+WHERE [u].[NormalizedEmail] = @__normalizedEmail_0
+2025-10-04 02:53:58.690 +07:00 [DBG] Context 'MyDbContext' started tracking 'User' entity. Consider using 'DbContextOptionsBuilder.EnableSensitiveDataLogging' to see key values.
+2025-10-04 02:53:58.729 +07:00 [DBG] Closing data reader to 'capbot_db' on server 'localhost'.
+2025-10-04 02:53:58.729 +07:00 [DBG] A data reader for 'capbot_db' on server 'localhost' is being disposed after spending 77ms reading results.
+2025-10-04 02:53:58.730 +07:00 [DBG] Closing connection to database 'capbot_db' on server 'localhost'.
+2025-10-04 02:53:58.730 +07:00 [DBG] Closed connection to database 'capbot_db' on server 'localhost' (0ms).
+2025-10-04 02:53:58.735 +07:00 [INF] Admin user 'admin.capbot@gmail.com' already exists
+2025-10-04 02:53:58.738 +07:00 [DBG] Opening connection to database 'capbot_db' on server 'localhost'.
+2025-10-04 02:53:58.738 +07:00 [DBG] Opened connection to database 'capbot_db' on server 'localhost'.
+2025-10-04 02:53:58.738 +07:00 [DBG] Creating DbCommand for 'ExecuteReader'.
+2025-10-04 02:53:58.738 +07:00 [DBG] Created DbCommand for 'ExecuteReader' (0ms).
+2025-10-04 02:53:58.738 +07:00 [DBG] Initialized DbCommand for 'ExecuteReader' (0ms).
+2025-10-04 02:53:58.738 +07:00 [DBG] Executing DbCommand [Parameters=[@__normalizedEmail_0='?' (Size = 4000)], CommandType='"Text"', CommandTimeout='30']
+SELECT TOP(2) [u].[Id], [u].[AccessFailedCount], [u].[ConcurrencyStamp], [u].[CreatedAt], [u].[DeletedAt], [u].[Email], [u].[EmailConfirmed], [u].[LastModifiedAt], [u].[LastModifiedBy], [u].[LockoutEnabled], [u].[LockoutEnd], [u].[NormalizedEmail], [u].[NormalizedUserName], [u].[PasswordHash], [u].[PhoneNumber], [u].[PhoneNumberConfirmed], [u].[SecurityStamp], [u].[TwoFactorEnabled], [u].[UserName]
+FROM [users] AS [u]
+WHERE [u].[NormalizedEmail] = @__normalizedEmail_0
+2025-10-04 02:53:58.741 +07:00 [INF] Executed DbCommand (3ms) [Parameters=[@__normalizedEmail_0='?' (Size = 4000)], CommandType='"Text"', CommandTimeout='30']
+SELECT TOP(2) [u].[Id], [u].[AccessFailedCount], [u].[ConcurrencyStamp], [u].[CreatedAt], [u].[DeletedAt], [u].[Email], [u].[EmailConfirmed], [u].[LastModifiedAt], [u].[LastModifiedBy], [u].[LockoutEnabled], [u].[LockoutEnd], [u].[NormalizedEmail], [u].[NormalizedUserName], [u].[PasswordHash], [u].[PhoneNumber], [u].[PhoneNumberConfirmed], [u].[SecurityStamp], [u].[TwoFactorEnabled], [u].[UserName]
+FROM [users] AS [u]
+WHERE [u].[NormalizedEmail] = @__normalizedEmail_0
+2025-10-04 02:53:58.742 +07:00 [DBG] Context 'MyDbContext' started tracking 'User' entity. Consider using 'DbContextOptionsBuilder.EnableSensitiveDataLogging' to see key values.
+2025-10-04 02:53:58.742 +07:00 [DBG] Closing data reader to 'capbot_db' on server 'localhost'.
+2025-10-04 02:53:58.742 +07:00 [DBG] A data reader for 'capbot_db' on server 'localhost' is being disposed after spending 0ms reading results.
+2025-10-04 02:53:58.742 +07:00 [DBG] Closing connection to database 'capbot_db' on server 'localhost'.
+2025-10-04 02:53:58.742 +07:00 [DBG] Closed connection to database 'capbot_db' on server 'localhost' (0ms).
+2025-10-04 02:53:58.742 +07:00 [INF] Sample moderator 'moderator@example.com' already exists
+2025-10-04 02:53:58.743 +07:00 [DBG] Opening connection to database 'capbot_db' on server 'localhost'.
+2025-10-04 02:53:58.743 +07:00 [DBG] Opened connection to database 'capbot_db' on server 'localhost'.
+2025-10-04 02:53:58.743 +07:00 [DBG] Creating DbCommand for 'ExecuteReader'.
+2025-10-04 02:53:58.744 +07:00 [DBG] Created DbCommand for 'ExecuteReader' (0ms).
+2025-10-04 02:53:58.744 +07:00 [DBG] Initialized DbCommand for 'ExecuteReader' (0ms).
+2025-10-04 02:53:58.744 +07:00 [DBG] Executing DbCommand [Parameters=[@__normalizedEmail_0='?' (Size = 4000)], CommandType='"Text"', CommandTimeout='30']
+SELECT TOP(2) [u].[Id], [u].[AccessFailedCount], [u].[ConcurrencyStamp], [u].[CreatedAt], [u].[DeletedAt], [u].[Email], [u].[EmailConfirmed], [u].[LastModifiedAt], [u].[LastModifiedBy], [u].[LockoutEnabled], [u].[LockoutEnd], [u].[NormalizedEmail], [u].[NormalizedUserName], [u].[PasswordHash], [u].[PhoneNumber], [u].[PhoneNumberConfirmed], [u].[SecurityStamp], [u].[TwoFactorEnabled], [u].[UserName]
+FROM [users] AS [u]
+WHERE [u].[NormalizedEmail] = @__normalizedEmail_0
+2025-10-04 02:53:58.745 +07:00 [INF] Executed DbCommand (1ms) [Parameters=[@__normalizedEmail_0='?' (Size = 4000)], CommandType='"Text"', CommandTimeout='30']
+SELECT TOP(2) [u].[Id], [u].[AccessFailedCount], [u].[ConcurrencyStamp], [u].[CreatedAt], [u].[DeletedAt], [u].[Email], [u].[EmailConfirmed], [u].[LastModifiedAt], [u].[LastModifiedBy], [u].[LockoutEnabled], [u].[LockoutEnd], [u].[NormalizedEmail], [u].[NormalizedUserName], [u].[PasswordHash], [u].[PhoneNumber], [u].[PhoneNumberConfirmed], [u].[SecurityStamp], [u].[TwoFactorEnabled], [u].[UserName]
+FROM [users] AS [u]
+WHERE [u].[NormalizedEmail] = @__normalizedEmail_0
+2025-10-04 02:53:58.745 +07:00 [DBG] Context 'MyDbContext' started tracking 'User' entity. Consider using 'DbContextOptionsBuilder.EnableSensitiveDataLogging' to see key values.
+2025-10-04 02:53:58.746 +07:00 [DBG] Closing data reader to 'capbot_db' on server 'localhost'.
+2025-10-04 02:53:58.746 +07:00 [DBG] A data reader for 'capbot_db' on server 'localhost' is being disposed after spending 0ms reading results.
+2025-10-04 02:53:58.746 +07:00 [DBG] Closing connection to database 'capbot_db' on server 'localhost'.
+2025-10-04 02:53:58.746 +07:00 [DBG] Closed connection to database 'capbot_db' on server 'localhost' (0ms).
+2025-10-04 02:53:58.746 +07:00 [DBG] Opening connection to database 'capbot_db' on server 'localhost'.
+2025-10-04 02:53:58.746 +07:00 [DBG] Opened connection to database 'capbot_db' on server 'localhost'.
+2025-10-04 02:53:58.746 +07:00 [DBG] Creating DbCommand for 'ExecuteReader'.
+2025-10-04 02:53:58.747 +07:00 [DBG] Created DbCommand for 'ExecuteReader' (0ms).
+2025-10-04 02:53:58.747 +07:00 [DBG] Initialized DbCommand for 'ExecuteReader' (0ms).
+2025-10-04 02:53:58.747 +07:00 [DBG] Executing DbCommand [Parameters=[@__normalizedEmail_0='?' (Size = 4000)], CommandType='"Text"', CommandTimeout='30']
+SELECT TOP(2) [u].[Id], [u].[AccessFailedCount], [u].[ConcurrencyStamp], [u].[CreatedAt], [u].[DeletedAt], [u].[Email], [u].[EmailConfirmed], [u].[LastModifiedAt], [u].[LastModifiedBy], [u].[LockoutEnabled], [u].[LockoutEnd], [u].[NormalizedEmail], [u].[NormalizedUserName], [u].[PasswordHash], [u].[PhoneNumber], [u].[PhoneNumberConfirmed], [u].[SecurityStamp], [u].[TwoFactorEnabled], [u].[UserName]
+FROM [users] AS [u]
+WHERE [u].[NormalizedEmail] = @__normalizedEmail_0
+2025-10-04 02:53:58.749 +07:00 [INF] Executed DbCommand (2ms) [Parameters=[@__normalizedEmail_0='?' (Size = 4000)], CommandType='"Text"', CommandTimeout='30']
+SELECT TOP(2) [u].[Id], [u].[AccessFailedCount], [u].[ConcurrencyStamp], [u].[CreatedAt], [u].[DeletedAt], [u].[Email], [u].[EmailConfirmed], [u].[LastModifiedAt], [u].[LastModifiedBy], [u].[LockoutEnabled], [u].[LockoutEnd], [u].[NormalizedEmail], [u].[NormalizedUserName], [u].[PasswordHash], [u].[PhoneNumber], [u].[PhoneNumberConfirmed], [u].[SecurityStamp], [u].[TwoFactorEnabled], [u].[UserName]
+FROM [users] AS [u]
+WHERE [u].[NormalizedEmail] = @__normalizedEmail_0
+2025-10-04 02:53:58.750 +07:00 [DBG] Context 'MyDbContext' started tracking 'User' entity. Consider using 'DbContextOptionsBuilder.EnableSensitiveDataLogging' to see key values.
+2025-10-04 02:53:58.751 +07:00 [DBG] Closing data reader to 'capbot_db' on server 'localhost'.
+2025-10-04 02:53:58.751 +07:00 [DBG] A data reader for 'capbot_db' on server 'localhost' is being disposed after spending 0ms reading results.
+2025-10-04 02:53:58.751 +07:00 [DBG] Closing connection to database 'capbot_db' on server 'localhost'.
+2025-10-04 02:53:58.751 +07:00 [DBG] Closed connection to database 'capbot_db' on server 'localhost' (0ms).
+2025-10-04 02:53:58.751 +07:00 [INF] Data seeding completed successfully
+2025-10-04 02:53:58.753 +07:00 [DBG] 'MyDbContext' disposed.
+2025-10-04 02:53:58.756 +07:00 [DBG] Disposing connection to database 'capbot_db' on server 'localhost'.
+2025-10-04 02:53:58.760 +07:00 [DBG] Disposed connection to database '' on server '' (2ms).
+2025-10-04 02:53:58.789 +07:00 [DBG] Registered SignalR Protocol: json, implemented by Microsoft.AspNetCore.SignalR.Protocol.JsonHubProtocol.
+2025-10-04 02:53:59.067 +07:00 [DBG] Registered model binder providers, in the following order: ["Microsoft.AspNetCore.Mvc.ModelBinding.Binders.BinderTypeModelBinderProvider","Microsoft.AspNetCore.Mvc.ModelBinding.Binders.ServicesModelBinderProvider","Microsoft.AspNetCore.Mvc.ModelBinding.Binders.BodyModelBinderProvider","Microsoft.AspNetCore.Mvc.ModelBinding.Binders.HeaderModelBinderProvider","Microsoft.AspNetCore.Mvc.ModelBinding.Binders.FloatingPointTypeModelBinderProvider","Microsoft.AspNetCore.Mvc.ModelBinding.Binders.EnumTypeModelBinderProvider","Microsoft.AspNetCore.Mvc.ModelBinding.Binders.DateTimeModelBinderProvider","Microsoft.AspNetCore.Mvc.ModelBinding.Binders.SimpleTypeModelBinderProvider","Microsoft.AspNetCore.Mvc.ModelBinding.Binders.TryParseModelBinderProvider","Microsoft.AspNetCore.Mvc.ModelBinding.Binders.CancellationTokenModelBinderProvider"]
+2025-10-04 02:53:59.237 +07:00 [DBG] Hosting starting
+2025-10-04 02:53:59.250 +07:00 [DBG] Reading data from file 'C:\Users\acer\AppData\Local\ASP.NET\DataProtection-Keys\key-30a711c8-7ddc-4a0d-8c07-4439effde9db.xml'.
+2025-10-04 02:53:59.253 +07:00 [DBG] Reading data from file 'C:\Users\acer\AppData\Local\ASP.NET\DataProtection-Keys\key-732ee668-a56c-4fc9-b9d2-4188dc372919.xml'.
+2025-10-04 02:53:59.254 +07:00 [DBG] Reading data from file 'C:\Users\acer\AppData\Local\ASP.NET\DataProtection-Keys\key-ad0e504d-5eaf-4fbc-adde-d8f26319af02.xml'.
+2025-10-04 02:53:59.261 +07:00 [DBG] Found key {30a711c8-7ddc-4a0d-8c07-4439effde9db}.
+2025-10-04 02:53:59.270 +07:00 [DBG] Found key {732ee668-a56c-4fc9-b9d2-4188dc372919}.
+2025-10-04 02:53:59.271 +07:00 [DBG] Found key {ad0e504d-5eaf-4fbc-adde-d8f26319af02}.
+2025-10-04 02:53:59.278 +07:00 [DBG] Considering key {30a711c8-7ddc-4a0d-8c07-4439effde9db} with expiration date 2025-11-11 18:32:26Z as default key.
+2025-10-04 02:53:59.285 +07:00 [DBG] Forwarded activator type request from Microsoft.AspNetCore.DataProtection.XmlEncryption.DpapiXmlDecryptor, Microsoft.AspNetCore.DataProtection, Version=8.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60 to Microsoft.AspNetCore.DataProtection.XmlEncryption.DpapiXmlDecryptor, Microsoft.AspNetCore.DataProtection, Culture=neutral, PublicKeyToken=adb9793829ddae60
+2025-10-04 02:53:59.285 +07:00 [DBG] Decrypting secret element using Windows DPAPI.
+2025-10-04 02:53:59.287 +07:00 [DBG] Forwarded activator type request from Microsoft.AspNetCore.DataProtection.AuthenticatedEncryption.ConfigurationModel.AuthenticatedEncryptorDescriptorDeserializer, Microsoft.AspNetCore.DataProtection, Version=8.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60 to Microsoft.AspNetCore.DataProtection.AuthenticatedEncryption.ConfigurationModel.AuthenticatedEncryptorDescriptorDeserializer, Microsoft.AspNetCore.DataProtection, Culture=neutral, PublicKeyToken=adb9793829ddae60
+2025-10-04 02:53:59.288 +07:00 [DBG] Opening CNG algorithm 'AES' from provider 'null' with chaining mode CBC.
+2025-10-04 02:53:59.292 +07:00 [DBG] Opening CNG algorithm 'SHA256' from provider 'null' with HMAC.
+2025-10-04 02:53:59.295 +07:00 [DBG] Using key {30a711c8-7ddc-4a0d-8c07-4439effde9db} as the default key.
+2025-10-04 02:53:59.296 +07:00 [DBG] Key ring with default key {30a711c8-7ddc-4a0d-8c07-4439effde9db} was loaded during application startup.
+2025-10-04 02:53:59.378 +07:00 [INF] Now listening on: http://localhost:5207
+2025-10-04 02:53:59.378 +07:00 [DBG] Loaded hosting startup assembly CapBot.api
+2025-10-04 02:53:59.378 +07:00 [DBG] Loaded hosting startup assembly Microsoft.AspNetCore.Watch.BrowserRefresh
+2025-10-04 02:53:59.378 +07:00 [INF] Application started. Press Ctrl+C to shut down.
+2025-10-04 02:53:59.378 +07:00 [INF] Hosting environment: Development
+2025-10-04 02:53:59.378 +07:00 [INF] Content root path: C:\Users\acer\Downloads\CBAI_API\capbot.api
+2025-10-04 02:53:59.380 +07:00 [DBG] Hosting started
+2025-10-04 02:53:59.703 +07:00 [DBG] Connection id "0HNG2MQC634J6" accepted.
+2025-10-04 02:53:59.704 +07:00 [DBG] Connection id "0HNG2MQC634J6" started.
+2025-10-04 02:54:00.253 +07:00 [INF] Request starting HTTP/1.1 GET http://localhost:5207/index.html - null null
+2025-10-04 02:54:00.261 +07:00 [DBG] Connection id "0HNG2MQC634J7" accepted.
+2025-10-04 02:54:00.261 +07:00 [DBG] Connection id "0HNG2MQC634J7" started.
+2025-10-04 02:54:00.269 +07:00 [DBG] Wildcard detected, all requests with hosts will be allowed.
+2025-10-04 02:54:00.808 +07:00 [DBG] Response markup is scheduled to include browser refresh script injection.
+2025-10-04 02:54:00.850 +07:00 [DBG] Response markup was updated to include browser refresh script injection.
+2025-10-04 02:54:00.851 +07:00 [DBG] Connection id "0HNG2MQC634J6" completed keep alive response.
+2025-10-04 02:54:00.857 +07:00 [INF] Request finished HTTP/1.1 GET http://localhost:5207/index.html - 200 null text/html;charset=utf-8 605.4313ms
+2025-10-04 02:54:00.930 +07:00 [INF] Request starting HTTP/1.1 GET http://localhost:5207/_framework/aspnetcore-browser-refresh.js - null null
+2025-10-04 02:54:00.938 +07:00 [DBG] Connection id "0HNG2MQC634J6" completed keep alive response.
+2025-10-04 02:54:00.939 +07:00 [INF] Request finished HTTP/1.1 GET http://localhost:5207/_framework/aspnetcore-browser-refresh.js - 200 13732 application/javascript; charset=utf-8 9.6473ms
+2025-10-04 02:54:01.393 +07:00 [INF] Request starting HTTP/1.1 GET http://localhost:5207/swagger/v1/swagger.json - null null
+2025-10-04 02:54:01.783 +07:00 [DBG] Connection id "0HNG2MQC634J7" received FIN.
+2025-10-04 02:54:01.787 +07:00 [DBG] Connection id "0HNG2MQC634J7" sending FIN because: "The Socket transport's send loop completed gracefully."
+2025-10-04 02:54:01.789 +07:00 [DBG] Connection id "0HNG2MQC634J7" disconnecting.
+2025-10-04 02:54:01.793 +07:00 [DBG] Connection id "0HNG2MQC634J7" stopped.
+2025-10-04 02:54:02.777 +07:00 [DBG] Connection id "0HNG2MQC634J6" completed keep alive response.
+2025-10-04 02:54:02.779 +07:00 [INF] Request finished HTTP/1.1 GET http://localhost:5207/swagger/v1/swagger.json - 200 null application/json;charset=utf-8 1385.1598ms
+2025-10-04 02:54:06.996 +07:00 [INF] Request starting HTTP/1.1 GET http://localhost:5207/api/topic/detail/104 - null null
+2025-10-04 02:54:06.999 +07:00 [DBG] The request path /api/topic/detail/104 does not match a supported file type
+2025-10-04 02:54:07.000 +07:00 [WRN] Failed to determine the https port for redirect.
+2025-10-04 02:54:07.001 +07:00 [DBG] The request path /api/topic/detail/104 does not match a supported file type
+2025-10-04 02:54:07.096 +07:00 [DBG] 1 candidate(s) found for the request path '/api/topic/detail/104'
+2025-10-04 02:54:07.098 +07:00 [DBG] Endpoint 'CapBot.api.Controllers.TopicController.GetDetail (CapBot.api)' with route pattern 'api/topic/detail/{topicId}' is valid for the request path '/api/topic/detail/104'
+2025-10-04 02:54:07.099 +07:00 [DBG] Request matched endpoint 'CapBot.api.Controllers.TopicController.GetDetail (CapBot.api)'
+2025-10-04 02:54:07.213 +07:00 [DBG] Successfully validated the token.
+2025-10-04 02:54:07.214 +07:00 [DBG] AuthenticationScheme: Bearer was successfully authenticated.
+2025-10-04 02:54:07.223 +07:00 [INF] Executing endpoint 'CapBot.api.Controllers.TopicController.GetDetail (CapBot.api)'
+2025-10-04 02:54:07.249 +07:00 [INF] Route matched with {action = "GetDetail", controller = "Topic"}. Executing controller action with signature System.Threading.Tasks.Task`1[Microsoft.AspNetCore.Mvc.IActionResult] GetDetail(Int32) on controller CapBot.api.Controllers.TopicController (CapBot.api).
+2025-10-04 02:54:07.252 +07:00 [DBG] Execution plan of authorization filters (in the following order): ["None"]
+2025-10-04 02:54:07.253 +07:00 [DBG] Execution plan of resource filters (in the following order): ["Microsoft.AspNetCore.Mvc.ConsumesAttribute"]
+2025-10-04 02:54:07.255 +07:00 [DBG] Execution plan of action filters (in the following order): ["Microsoft.AspNetCore.Mvc.ModelBinding.UnsupportedContentTypeFilter (Order: -3000)"]
+2025-10-04 02:54:07.255 +07:00 [DBG] Execution plan of exception filters (in the following order): ["None"]
+2025-10-04 02:54:07.255 +07:00 [DBG] Execution plan of result filters (in the following order): ["Microsoft.AspNetCore.Mvc.Infrastructure.ClientErrorResultFilter (Order: -2000)","Microsoft.AspNetCore.Mvc.ProducesAttribute (Order: 0)"]
+2025-10-04 02:54:07.258 +07:00 [DBG] Executing controller factory for controller CapBot.api.Controllers.TopicController (CapBot.api)
+2025-10-04 02:54:07.280 +07:00 [DBG] Executed controller factory for controller CapBot.api.Controllers.TopicController (CapBot.api)
+2025-10-04 02:54:07.286 +07:00 [DBG] Attempting to bind parameter 'topicId' of type 'System.Int32' ...
+2025-10-04 02:54:07.288 +07:00 [DBG] Attempting to bind parameter 'topicId' of type 'System.Int32' using the name 'topicId' in request data ...
+2025-10-04 02:54:07.289 +07:00 [DBG] Done attempting to bind parameter 'topicId' of type 'System.Int32'.
+2025-10-04 02:54:07.289 +07:00 [DBG] Done attempting to bind parameter 'topicId' of type 'System.Int32'.
+2025-10-04 02:54:07.289 +07:00 [DBG] Attempting to validate the bound parameter 'topicId' of type 'System.Int32' ...
+2025-10-04 02:54:07.291 +07:00 [DBG] Done attempting to validate the bound parameter 'topicId' of type 'System.Int32'.
+2025-10-04 02:54:07.367 +07:00 [DBG] Entity Framework Core 8.0.16 initialized 'MyDbContext' using provider 'Microsoft.EntityFrameworkCore.SqlServer:8.0.13' with options: MigrationsAssembly=App.DAL 
+2025-10-04 02:54:07.381 +07:00 [DBG] Compiling query expression: 
+'DbSet<Topic>()
+    .AsNoTracking()
+    .Include(x => x.Supervisor)
+    .Include(x => x.Category)
+    .Include(x => x.Semester)
+    .Include(x => x.TopicVersions)
+    .Where(x => x.Id == __topicId_0 && x.IsActive && x.DeletedAt == null)
+    .FirstOrDefault()'
+2025-10-04 02:54:07.396 +07:00 [DBG] Including navigation: 'Topic.Supervisor'.
+2025-10-04 02:54:07.398 +07:00 [DBG] Including navigation: 'Topic.Category'.
+2025-10-04 02:54:07.399 +07:00 [DBG] Including navigation: 'Topic.Semester'.
+2025-10-04 02:54:07.400 +07:00 [DBG] Including navigation: 'Topic.TopicVersions'.
+2025-10-04 02:54:07.537 +07:00 [DBG] Generated query execution expression: 
+'queryContext => ShapedQueryCompilingExpressionVisitor.SingleOrDefaultAsync<Topic>(
+    asyncEnumerable: new SingleQueryingEnumerable<Topic>(
+        (RelationalQueryContext)queryContext, 
+        RelationalCommandCache.QueryExpression(
+            Client Projections:
+                0 -> Dictionary<IProperty, int> { [Property: Topic.Id (int) Required PK AfterSave:Throw ValueGenerated.OnAdd, 0], [Property: Topic.Abbreviation (string), 1], [Property: Topic.CategoryId (int?) FK Index, 2], [Property: Topic.Content (string), 3], [Property: Topic.Context (string), 4], [Property: Topic.CreatedAt (DateTime) Required ValueGenerated.OnAdd, 5], [Property: Topic.CreatedBy (string), 6], [Property: Topic.DeletedAt (DateTime?), 7], [Property: Topic.Description (string), 8], [Property: Topic.EN_Title (string) Required MaxLength(500), 9], [Property: Topic.IsActive (bool) Required, 10], [Property: Topic.IsApproved (bool) Required Index Sentinel:True ValueGenerated.OnAdd, 11], [Property: Topic.IsLegacy (bool) Required Index ValueGenerated.OnAdd, 12], [Property: Topic.LastModifiedAt (DateTime?), 13], [Property: Topic.LastModifiedBy (string), 14], [Property: Topic.MaxStudents (int) Required ValueGenerated.OnAdd, 15], [Property: Topic.Objectives (string), 16], [Property: Topic.PotentialDuplicate (string), 17], [Property: Topic.Problem (string), 18], [Property: Topic.SemesterId (int) Required FK Index, 19], [Property: Topic.SupervisorId (int) Required FK Index, 20], [Property: Topic.VN_title (string), 21] }
+                1 -> Dictionary<IProperty, int> { [Property: User.Id (int) Required PK AfterSave:Throw ValueGenerated.OnAdd, 22], [Property: User.AccessFailedCount (int) Required, 23], [Property: User.ConcurrencyStamp (string), 24], [Property: User.CreatedAt (DateTime) Required, 25], [Property: User.DeletedAt (DateTime?), 26], [Property: User.Email (string), 27], [Property: User.EmailConfirmed (bool) Required, 28], [Property: User.LastModifiedAt (DateTime) Required, 29], [Property: User.LastModifiedBy (string), 30], [Property: User.LockoutEnabled (bool) Required, 31], [Property: User.LockoutEnd (DateTimeOffset?), 32], [Property: User.NormalizedEmail (string), 33], [Property: User.NormalizedUserName (string), 34], [Property: User.PasswordHash (string), 35], [Property: User.PhoneNumber (string), 36], [Property: User.PhoneNumberConfirmed (bool) Required, 37], [Property: User.SecurityStamp (string), 38], [Property: User.TwoFactorEnabled (bool) Required, 39], [Property: User.UserName (string), 40] }
+                2 -> Dictionary<IProperty, int> { [Property: TopicCategory.Id (int) Required PK AfterSave:Throw ValueGenerated.OnAdd, 41], [Property: TopicCategory.CreatedAt (DateTime) Required ValueGenerated.OnAdd, 42], [Property: TopicCategory.CreatedBy (string), 43], [Property: TopicCategory.DeletedAt (DateTime?), 44], [Property: TopicCategory.Description (string), 45], [Property: TopicCategory.IsActive (bool) Required, 46], [Property: TopicCategory.LastModifiedAt (DateTime?), 47], [Property: TopicCategory.LastModifiedBy (string), 48], [Property: TopicCategory.Name (string) Required MaxLength(100), 49] }
+                3 -> Dictionary<IProperty, int> { [Property: Semester.Id (int) Required PK AfterSave:Throw ValueGenerated.OnAdd, 50], [Property: Semester.CreatedAt (DateTime) Required, 51], [Property: Semester.CreatedBy (string), 52], [Property: Semester.DeletedAt (DateTime?), 53], [Property: Semester.Description (string), 54], [Property: Semester.EndDate (DateTime) Required, 55], [Property: Semester.IsActive (bool) Required, 56], [Property: Semester.LastModifiedAt (DateTime?), 57], [Property: Semester.LastModifiedBy (string), 58], [Property: Semester.Name (string) Required Index MaxLength(50), 59], [Property: Semester.StartDate (DateTime) Required, 60] }
+                4 -> 0
+                5 -> 22
+                6 -> 41
+                7 -> 50
+                8 -> Dictionary<IProperty, int> { [Property: TopicVersion.Id (int) Required PK AfterSave:Throw ValueGenerated.OnAdd, 61], [Property: TopicVersion.Content (string), 62], [Property: TopicVersion.Context (string), 63], [Property: TopicVersion.CreatedAt (DateTime) Required ValueGenerated.OnAdd, 64], [Property: TopicVersion.CreatedBy (string), 65], [Property: TopicVersion.DeletedAt (DateTime?), 66], [Property: TopicVersion.Description (string), 67], [Property: TopicVersion.DocumentUrl (string) MaxLength(500), 68], [Property: TopicVersion.EN_Title (string) Required MaxLength(500), 69], [Property: TopicVersion.ExpectedOutcomes (string), 70], [Property: TopicVersion.IsActive (bool) Required, 71], [Property: TopicVersion.LastModifiedAt (DateTime?), 72], [Property: TopicVersion.LastModifiedBy (string), 73], [Property: TopicVersion.Methodology (string), 74], [Property: TopicVersion.Objectives (string), 75], [Property: TopicVersion.PotentialDuplicate (string), 76], [Property: TopicVersion.Problem (string), 77], [Property: TopicVersion.Requirements (string), 78], [Property: TopicVersion.Status (TopicStatus) Required Index ValueGenerated.OnAdd, 79], [Property: TopicVersion.SubmittedAt (DateTime?), 80], [Property: TopicVersion.SubmittedBy (int?) FK Index, 81], [Property: TopicVersion.TopicId (int) Required FK Index, 82], [Property: TopicVersion.VN_title (string), 83], [Property: TopicVersion.VersionNumber (int) Required Index, 84] }
+                9 -> 61
+            SELECT t1.Id, t1.Abbreviation, t1.CategoryId, t1.Content, t1.Context, t1.CreatedAt, t1.CreatedBy, t1.DeletedAt, t1.Description, t1.EN_Title, t1.IsActive, t1.IsApproved, t1.IsLegacy, t1.LastModifiedAt, t1.LastModifiedBy, t1.MaxStudents, t1.Objectives, t1.PotentialDuplicate, t1.Problem, t1.SemesterId, t1.SupervisorId, t1.VN_title, t1.Id0, t1.AccessFailedCount, t1.ConcurrencyStamp, t1.CreatedAt0, t1.DeletedAt0, t1.Email, t1.EmailConfirmed, t1.LastModifiedAt0, t1.LastModifiedBy0, t1.LockoutEnabled, t1.LockoutEnd, t1.NormalizedEmail, t1.NormalizedUserName, t1.PasswordHash, t1.PhoneNumber, t1.PhoneNumberConfirmed, t1.SecurityStamp, t1.TwoFactorEnabled, t1.UserName, t1.Id1, t1.CreatedAt1, t1.CreatedBy0, t1.DeletedAt1, t1.Description0, t1.IsActive0, t1.LastModifiedAt1, t1.LastModifiedBy1, t1.Name, t1.Id2, t1.CreatedAt2, t1.CreatedBy1, t1.DeletedAt2, t1.Description1, t1.EndDate, t1.IsActive1, t1.LastModifiedAt2, t1.LastModifiedBy2, t1.Name0, t1.StartDate, t2.Id, t2.Content, t2.Context, t2.CreatedAt, t2.CreatedBy, t2.DeletedAt, t2.Description, t2.DocumentUrl, t2.EN_Title, t2.ExpectedOutcomes, t2.IsActive, t2.LastModifiedAt, t2.LastModifiedBy, t2.Methodology, t2.Objectives, t2.PotentialDuplicate, t2.Problem, t2.Requirements, t2.Status, t2.SubmittedAt, t2.SubmittedBy, t2.TopicId, t2.VN_title, t2.VersionNumber
+            FROM 
+            (
+                SELECT TOP(1) t.Id, t.Abbreviation, t.CategoryId, t.Content, t.Context, t.CreatedAt, t.CreatedBy, t.DeletedAt, t.Description, t.EN_Title, t.IsActive, t.IsApproved, t.IsLegacy, t.LastModifiedAt, t.LastModifiedBy, t.MaxStudents, t.Objectives, t.PotentialDuplicate, t.Problem, t.SemesterId, t.SupervisorId, t.VN_title, u.Id AS Id0, u.AccessFailedCount, u.ConcurrencyStamp, u.CreatedAt AS CreatedAt0, u.DeletedAt AS DeletedAt0, u.Email, u.EmailConfirmed, u.LastModifiedAt AS LastModifiedAt0, u.LastModifiedBy AS LastModifiedBy0, u.LockoutEnabled, u.LockoutEnd, u.NormalizedEmail, u.NormalizedUserName, u.PasswordHash, u.PhoneNumber, u.PhoneNumberConfirmed, u.SecurityStamp, u.TwoFactorEnabled, u.UserName, t0.Id AS Id1, t0.CreatedAt AS CreatedAt1, t0.CreatedBy AS CreatedBy0, t0.DeletedAt AS DeletedAt1, t0.Description AS Description0, t0.IsActive AS IsActive0, t0.LastModifiedAt AS LastModifiedAt1, t0.LastModifiedBy AS LastModifiedBy1, t0.Name, s.Id AS Id2, s.CreatedAt AS CreatedAt2, s.CreatedBy AS CreatedBy1, s.DeletedAt AS DeletedAt2, s.Description AS Description1, s.EndDate, s.IsActive AS IsActive1, s.LastModifiedAt AS LastModifiedAt2, s.LastModifiedBy AS LastModifiedBy2, s.Name AS Name0, s.StartDate
+                FROM topics AS t
+                INNER JOIN users AS u ON t.SupervisorId == u.Id
+                LEFT JOIN topic_categories AS t0 ON t.CategoryId == t0.Id
+                INNER JOIN semesters AS s ON t.SemesterId == s.Id
+                WHERE ((t.Id == @__topicId_0) && t.IsActive) && (t.DeletedAt == NULL)
+            ) AS t1
+            LEFT JOIN topic_versions AS t2 ON t1.Id == t2.TopicId
+            ORDER BY t1.Id ASC, t1.Id0 ASC, t1.Id1 ASC, t1.Id2 ASC), 
+        null, 
+        Func<QueryContext, DbDataReader, ResultContext, SingleQueryResultCoordinator, Topic>, 
+        App.DAL.Context.MyDbContext, 
+        False, 
+        False, 
+        True
+    ), 
+    cancellationToken: queryContext.CancellationToken)'
+2025-10-04 02:54:07.558 +07:00 [DBG] Creating DbConnection.
+2025-10-04 02:54:07.560 +07:00 [DBG] Created DbConnection. (1ms).
+2025-10-04 02:54:07.561 +07:00 [DBG] Opening connection to database 'capbot_db' on server 'localhost'.
+2025-10-04 02:54:07.562 +07:00 [DBG] Opened connection to database 'capbot_db' on server 'localhost'.
+2025-10-04 02:54:07.565 +07:00 [DBG] Creating DbCommand for 'ExecuteReader'.
+2025-10-04 02:54:07.568 +07:00 [DBG] Created DbCommand for 'ExecuteReader' (3ms).
+2025-10-04 02:54:07.568 +07:00 [DBG] Initialized DbCommand for 'ExecuteReader' (3ms).
+2025-10-04 02:54:07.570 +07:00 [DBG] Executing DbCommand [Parameters=[@__topicId_0='?' (DbType = Int32)], CommandType='"Text"', CommandTimeout='30']
+SELECT [t1].[Id], [t1].[Abbreviation], [t1].[CategoryId], [t1].[Content], [t1].[Context], [t1].[CreatedAt], [t1].[CreatedBy], [t1].[DeletedAt], [t1].[Description], [t1].[EN_Title], [t1].[IsActive], [t1].[IsApproved], [t1].[IsLegacy], [t1].[LastModifiedAt], [t1].[LastModifiedBy], [t1].[MaxStudents], [t1].[Objectives], [t1].[PotentialDuplicate], [t1].[Problem], [t1].[SemesterId], [t1].[SupervisorId], [t1].[VN_title], [t1].[Id0], [t1].[AccessFailedCount], [t1].[ConcurrencyStamp], [t1].[CreatedAt0], [t1].[DeletedAt0], [t1].[Email], [t1].[EmailConfirmed], [t1].[LastModifiedAt0], [t1].[LastModifiedBy0], [t1].[LockoutEnabled], [t1].[LockoutEnd], [t1].[NormalizedEmail], [t1].[NormalizedUserName], [t1].[PasswordHash], [t1].[PhoneNumber], [t1].[PhoneNumberConfirmed], [t1].[SecurityStamp], [t1].[TwoFactorEnabled], [t1].[UserName], [t1].[Id1], [t1].[CreatedAt1], [t1].[CreatedBy0], [t1].[DeletedAt1], [t1].[Description0], [t1].[IsActive0], [t1].[LastModifiedAt1], [t1].[LastModifiedBy1], [t1].[Name], [t1].[Id2], [t1].[CreatedAt2], [t1].[CreatedBy1], [t1].[DeletedAt2], [t1].[Description1], [t1].[EndDate], [t1].[IsActive1], [t1].[LastModifiedAt2], [t1].[LastModifiedBy2], [t1].[Name0], [t1].[StartDate], [t2].[Id], [t2].[Content], [t2].[Context], [t2].[CreatedAt], [t2].[CreatedBy], [t2].[DeletedAt], [t2].[Description], [t2].[DocumentUrl], [t2].[EN_Title], [t2].[ExpectedOutcomes], [t2].[IsActive], [t2].[LastModifiedAt], [t2].[LastModifiedBy], [t2].[Methodology], [t2].[Objectives], [t2].[PotentialDuplicate], [t2].[Problem], [t2].[Requirements], [t2].[Status], [t2].[SubmittedAt], [t2].[SubmittedBy], [t2].[TopicId], [t2].[VN_title], [t2].[VersionNumber]
+FROM (
+    SELECT TOP(1) [t].[Id], [t].[Abbreviation], [t].[CategoryId], [t].[Content], [t].[Context], [t].[CreatedAt], [t].[CreatedBy], [t].[DeletedAt], [t].[Description], [t].[EN_Title], [t].[IsActive], [t].[IsApproved], [t].[IsLegacy], [t].[LastModifiedAt], [t].[LastModifiedBy], [t].[MaxStudents], [t].[Objectives], [t].[PotentialDuplicate], [t].[Problem], [t].[SemesterId], [t].[SupervisorId], [t].[VN_title], [u].[Id] AS [Id0], [u].[AccessFailedCount], [u].[ConcurrencyStamp], [u].[CreatedAt] AS [CreatedAt0], [u].[DeletedAt] AS [DeletedAt0], [u].[Email], [u].[EmailConfirmed], [u].[LastModifiedAt] AS [LastModifiedAt0], [u].[LastModifiedBy] AS [LastModifiedBy0], [u].[LockoutEnabled], [u].[LockoutEnd], [u].[NormalizedEmail], [u].[NormalizedUserName], [u].[PasswordHash], [u].[PhoneNumber], [u].[PhoneNumberConfirmed], [u].[SecurityStamp], [u].[TwoFactorEnabled], [u].[UserName], [t0].[Id] AS [Id1], [t0].[CreatedAt] AS [CreatedAt1], [t0].[CreatedBy] AS [CreatedBy0], [t0].[DeletedAt] AS [DeletedAt1], [t0].[Description] AS [Description0], [t0].[IsActive] AS [IsActive0], [t0].[LastModifiedAt] AS [LastModifiedAt1], [t0].[LastModifiedBy] AS [LastModifiedBy1], [t0].[Name], [s].[Id] AS [Id2], [s].[CreatedAt] AS [CreatedAt2], [s].[CreatedBy] AS [CreatedBy1], [s].[DeletedAt] AS [DeletedAt2], [s].[Description] AS [Description1], [s].[EndDate], [s].[IsActive] AS [IsActive1], [s].[LastModifiedAt] AS [LastModifiedAt2], [s].[LastModifiedBy] AS [LastModifiedBy2], [s].[Name] AS [Name0], [s].[StartDate]
+    FROM [topics] AS [t]
+    INNER JOIN [users] AS [u] ON [t].[SupervisorId] = [u].[Id]
+    LEFT JOIN [topic_categories] AS [t0] ON [t].[CategoryId] = [t0].[Id]
+    INNER JOIN [semesters] AS [s] ON [t].[SemesterId] = [s].[Id]
+    WHERE [t].[Id] = @__topicId_0 AND [t].[IsActive] = CAST(1 AS bit) AND [t].[DeletedAt] IS NULL
+) AS [t1]
+LEFT JOIN [topic_versions] AS [t2] ON [t1].[Id] = [t2].[TopicId]
+ORDER BY [t1].[Id], [t1].[Id0], [t1].[Id1], [t1].[Id2]
+2025-10-04 02:54:07.687 +07:00 [INF] Executed DbCommand (118ms) [Parameters=[@__topicId_0='?' (DbType = Int32)], CommandType='"Text"', CommandTimeout='30']
+SELECT [t1].[Id], [t1].[Abbreviation], [t1].[CategoryId], [t1].[Content], [t1].[Context], [t1].[CreatedAt], [t1].[CreatedBy], [t1].[DeletedAt], [t1].[Description], [t1].[EN_Title], [t1].[IsActive], [t1].[IsApproved], [t1].[IsLegacy], [t1].[LastModifiedAt], [t1].[LastModifiedBy], [t1].[MaxStudents], [t1].[Objectives], [t1].[PotentialDuplicate], [t1].[Problem], [t1].[SemesterId], [t1].[SupervisorId], [t1].[VN_title], [t1].[Id0], [t1].[AccessFailedCount], [t1].[ConcurrencyStamp], [t1].[CreatedAt0], [t1].[DeletedAt0], [t1].[Email], [t1].[EmailConfirmed], [t1].[LastModifiedAt0], [t1].[LastModifiedBy0], [t1].[LockoutEnabled], [t1].[LockoutEnd], [t1].[NormalizedEmail], [t1].[NormalizedUserName], [t1].[PasswordHash], [t1].[PhoneNumber], [t1].[PhoneNumberConfirmed], [t1].[SecurityStamp], [t1].[TwoFactorEnabled], [t1].[UserName], [t1].[Id1], [t1].[CreatedAt1], [t1].[CreatedBy0], [t1].[DeletedAt1], [t1].[Description0], [t1].[IsActive0], [t1].[LastModifiedAt1], [t1].[LastModifiedBy1], [t1].[Name], [t1].[Id2], [t1].[CreatedAt2], [t1].[CreatedBy1], [t1].[DeletedAt2], [t1].[Description1], [t1].[EndDate], [t1].[IsActive1], [t1].[LastModifiedAt2], [t1].[LastModifiedBy2], [t1].[Name0], [t1].[StartDate], [t2].[Id], [t2].[Content], [t2].[Context], [t2].[CreatedAt], [t2].[CreatedBy], [t2].[DeletedAt], [t2].[Description], [t2].[DocumentUrl], [t2].[EN_Title], [t2].[ExpectedOutcomes], [t2].[IsActive], [t2].[LastModifiedAt], [t2].[LastModifiedBy], [t2].[Methodology], [t2].[Objectives], [t2].[PotentialDuplicate], [t2].[Problem], [t2].[Requirements], [t2].[Status], [t2].[SubmittedAt], [t2].[SubmittedBy], [t2].[TopicId], [t2].[VN_title], [t2].[VersionNumber]
+FROM (
+    SELECT TOP(1) [t].[Id], [t].[Abbreviation], [t].[CategoryId], [t].[Content], [t].[Context], [t].[CreatedAt], [t].[CreatedBy], [t].[DeletedAt], [t].[Description], [t].[EN_Title], [t].[IsActive], [t].[IsApproved], [t].[IsLegacy], [t].[LastModifiedAt], [t].[LastModifiedBy], [t].[MaxStudents], [t].[Objectives], [t].[PotentialDuplicate], [t].[Problem], [t].[SemesterId], [t].[SupervisorId], [t].[VN_title], [u].[Id] AS [Id0], [u].[AccessFailedCount], [u].[ConcurrencyStamp], [u].[CreatedAt] AS [CreatedAt0], [u].[DeletedAt] AS [DeletedAt0], [u].[Email], [u].[EmailConfirmed], [u].[LastModifiedAt] AS [LastModifiedAt0], [u].[LastModifiedBy] AS [LastModifiedBy0], [u].[LockoutEnabled], [u].[LockoutEnd], [u].[NormalizedEmail], [u].[NormalizedUserName], [u].[PasswordHash], [u].[PhoneNumber], [u].[PhoneNumberConfirmed], [u].[SecurityStamp], [u].[TwoFactorEnabled], [u].[UserName], [t0].[Id] AS [Id1], [t0].[CreatedAt] AS [CreatedAt1], [t0].[CreatedBy] AS [CreatedBy0], [t0].[DeletedAt] AS [DeletedAt1], [t0].[Description] AS [Description0], [t0].[IsActive] AS [IsActive0], [t0].[LastModifiedAt] AS [LastModifiedAt1], [t0].[LastModifiedBy] AS [LastModifiedBy1], [t0].[Name], [s].[Id] AS [Id2], [s].[CreatedAt] AS [CreatedAt2], [s].[CreatedBy] AS [CreatedBy1], [s].[DeletedAt] AS [DeletedAt2], [s].[Description] AS [Description1], [s].[EndDate], [s].[IsActive] AS [IsActive1], [s].[LastModifiedAt] AS [LastModifiedAt2], [s].[LastModifiedBy] AS [LastModifiedBy2], [s].[Name] AS [Name0], [s].[StartDate]
+    FROM [topics] AS [t]
+    INNER JOIN [users] AS [u] ON [t].[SupervisorId] = [u].[Id]
+    LEFT JOIN [topic_categories] AS [t0] ON [t].[CategoryId] = [t0].[Id]
+    INNER JOIN [semesters] AS [s] ON [t].[SemesterId] = [s].[Id]
+    WHERE [t].[Id] = @__topicId_0 AND [t].[IsActive] = CAST(1 AS bit) AND [t].[DeletedAt] IS NULL
+) AS [t1]
+LEFT JOIN [topic_versions] AS [t2] ON [t1].[Id] = [t2].[TopicId]
+ORDER BY [t1].[Id], [t1].[Id0], [t1].[Id1], [t1].[Id2]
+2025-10-04 02:54:07.702 +07:00 [DBG] Closing data reader to 'capbot_db' on server 'localhost'.
+2025-10-04 02:54:07.702 +07:00 [DBG] A data reader for 'capbot_db' on server 'localhost' is being disposed after spending 14ms reading results.
+2025-10-04 02:54:07.702 +07:00 [DBG] Closing connection to database 'capbot_db' on server 'localhost'.
+2025-10-04 02:54:07.703 +07:00 [DBG] Closed connection to database 'capbot_db' on server 'localhost' (0ms).
+2025-10-04 02:54:07.707 +07:00 [DBG] Compiling query expression: 
+'DbSet<Submission>()
+    .AsNoTracking()
+    .Include(s => s.Phase)
+    .Include(s => s.SubmittedByUser)
+    .Include(s => s.ReviewerAssignments)
+    .Where(s => s.TopicId == __topicId_0 && s.IsActive && s.DeletedAt == null)'
+2025-10-04 02:54:07.712 +07:00 [DBG] Including navigation: 'Submission.Phase'.
+2025-10-04 02:54:07.718 +07:00 [DBG] Including navigation: 'Submission.SubmittedByUser'.
+2025-10-04 02:54:07.719 +07:00 [DBG] Including navigation: 'Submission.ReviewerAssignments'.
+2025-10-04 02:54:07.763 +07:00 [DBG] Generated query execution expression: 
+'queryContext => new SingleQueryingEnumerable<Submission>(
+    (RelationalQueryContext)queryContext, 
+    RelationalCommandCache.QueryExpression(
+        Client Projections:
+            0 -> Dictionary<IProperty, int> { [Property: Submission.Id (int) Required PK AfterSave:Throw ValueGenerated.OnAdd, 0], [Property: Submission.AdditionalNotes (string), 1], [Property: Submission.AiCheckDetails (string), 2], [Property: Submission.AiCheckScore (decimal?), 3], [Property: Submission.AiCheckStatus (AiCheckStatus) Required ValueGenerated.OnAdd, 4], [Property: Submission.CreatedAt (DateTime) Required, 5], [Property: Submission.CreatedBy (string), 6], [Property: Submission.DeletedAt (DateTime?), 7], [Property: Submission.DocumentUrl (string) MaxLength(500), 8], [Property: Submission.IsActive (bool) Required, 9], [Property: Submission.LastModifiedAt (DateTime?), 10], [Property: Submission.LastModifiedBy (string), 11], [Property: Submission.PhaseId (int) Required FK Index, 12], [Property: Submission.Status (SubmissionStatus) Required Index ValueGenerated.OnAdd, 13], [Property: Submission.SubmissionRound (int) Required Index ValueGenerated.OnAdd, 14], [Property: Submission.SubmittedAt (DateTime?) Index ValueGenerated.OnAdd, 15], [Property: Submission.SubmittedBy (int) Required FK Index, 16], [Property: Submission.TopicId (int) Required FK Index, 17], [Property: Submission.TopicVersionId (int?) FK Index, 18] }
+            1 -> Dictionary<IProperty, int> { [Property: Phase.Id (int) Required PK AfterSave:Throw ValueGenerated.OnAdd, 19], [Property: Phase.CreatedAt (DateTime) Required ValueGenerated.OnAdd, 20], [Property: Phase.CreatedBy (string), 21], [Property: Phase.DeletedAt (DateTime?), 22], [Property: Phase.EndDate (DateTime) Required, 23], [Property: Phase.IsActive (bool) Required Index Sentinel:True ValueGenerated.OnAdd, 24], [Property: Phase.LastModifiedAt (DateTime?), 25], [Property: Phase.LastModifiedBy (string), 26], [Property: Phase.Name (string) Required MaxLength(100), 27], [Property: Phase.PhaseTypeId (int) Required FK Index, 28], [Property: Phase.SemesterId (int) Required FK Index, 29], [Property: Phase.StartDate (DateTime) Required, 30], [Property: Phase.SubmissionDeadline (DateTime?), 31] }
+            2 -> Dictionary<IProperty, int> { [Property: User.Id (int) Required PK AfterSave:Throw ValueGenerated.OnAdd, 32], [Property: User.AccessFailedCount (int) Required, 33], [Property: User.ConcurrencyStamp (string), 34], [Property: User.CreatedAt (DateTime) Required, 35], [Property: User.DeletedAt (DateTime?), 36], [Property: User.Email (string), 37], [Property: User.EmailConfirmed (bool) Required, 38], [Property: User.LastModifiedAt (DateTime) Required, 39], [Property: User.LastModifiedBy (string), 40], [Property: User.LockoutEnabled (bool) Required, 41], [Property: User.LockoutEnd (DateTimeOffset?), 42], [Property: User.NormalizedEmail (string), 43], [Property: User.NormalizedUserName (string), 44], [Property: User.PasswordHash (string), 45], [Property: User.PhoneNumber (string), 46], [Property: User.PhoneNumberConfirmed (bool) Required, 47], [Property: User.SecurityStamp (string), 48], [Property: User.TwoFactorEnabled (bool) Required, 49], [Property: User.UserName (string), 50] }
+            3 -> 0
+            4 -> 19
+            5 -> 32
+            6 -> Dictionary<IProperty, int> { [Property: ReviewerAssignment.Id (int) Required PK AfterSave:Throw ValueGenerated.OnAdd, 51], [Property: ReviewerAssignment.AssignedAt (DateTime) Required ValueGenerated.OnAdd, 52], [Property: ReviewerAssignment.AssignedBy (int) Required FK Index, 53], [Property: ReviewerAssignment.AssignmentType (AssignmentTypes) Required ValueGenerated.OnAdd, 54], [Property: ReviewerAssignment.CompletedAt (DateTime?), 55], [Property: ReviewerAssignment.Deadline (DateTime?) Index, 56], [Property: ReviewerAssignment.ReviewerId (int) Required FK Index, 57], [Property: ReviewerAssignment.SkillMatchScore (decimal?), 58], [Property: ReviewerAssignment.StartedAt (DateTime?), 59], [Property: ReviewerAssignment.Status (AssignmentStatus) Required Index ValueGenerated.OnAdd, 60], [Property: ReviewerAssignment.SubmissionId (int) Required FK Index, 61] }
+            7 -> 51
+        SELECT s.Id, s.AdditionalNotes, s.AiCheckDetails, s.AiCheckScore, s.AiCheckStatus, s.CreatedAt, s.CreatedBy, s.DeletedAt, s.DocumentUrl, s.IsActive, s.LastModifiedAt, s.LastModifiedBy, s.PhaseId, s.Status, s.SubmissionRound, s.SubmittedAt, s.SubmittedBy, s.TopicId, s.TopicVersionId, p.Id, p.CreatedAt, p.CreatedBy, p.DeletedAt, p.EndDate, p.IsActive, p.LastModifiedAt, p.LastModifiedBy, p.Name, p.PhaseTypeId, p.SemesterId, p.StartDate, p.SubmissionDeadline, u.Id, u.AccessFailedCount, u.ConcurrencyStamp, u.CreatedAt, u.DeletedAt, u.Email, u.EmailConfirmed, u.LastModifiedAt, u.LastModifiedBy, u.LockoutEnabled, u.LockoutEnd, u.NormalizedEmail, u.NormalizedUserName, u.PasswordHash, u.PhoneNumber, u.PhoneNumberConfirmed, u.SecurityStamp, u.TwoFactorEnabled, u.UserName, r.Id, r.AssignedAt, r.AssignedBy, r.AssignmentType, r.CompletedAt, r.Deadline, r.ReviewerId, r.SkillMatchScore, r.StartedAt, r.Status, r.SubmissionId
+        FROM submissions AS s
+        INNER JOIN phases AS p ON s.PhaseId == p.Id
+        INNER JOIN users AS u ON s.SubmittedBy == u.Id
+        LEFT JOIN reviewer_assignments AS r ON s.Id == r.SubmissionId
+        WHERE ((s.TopicId == @__topicId_0) && s.IsActive) && (s.DeletedAt == NULL)
+        ORDER BY s.Id ASC, p.Id ASC, u.Id ASC), 
+    null, 
+    Func<QueryContext, DbDataReader, ResultContext, SingleQueryResultCoordinator, Submission>, 
+    App.DAL.Context.MyDbContext, 
+    False, 
+    False, 
+    True
+)'
+2025-10-04 02:54:07.769 +07:00 [DBG] Opening connection to database 'capbot_db' on server 'localhost'.
+2025-10-04 02:54:07.770 +07:00 [DBG] Opened connection to database 'capbot_db' on server 'localhost'.
+2025-10-04 02:54:07.770 +07:00 [DBG] Creating DbCommand for 'ExecuteReader'.
+2025-10-04 02:54:07.770 +07:00 [DBG] Created DbCommand for 'ExecuteReader' (0ms).
+2025-10-04 02:54:07.770 +07:00 [DBG] Initialized DbCommand for 'ExecuteReader' (0ms).
+2025-10-04 02:54:07.770 +07:00 [DBG] Executing DbCommand [Parameters=[@__topicId_0='?' (DbType = Int32)], CommandType='"Text"', CommandTimeout='30']
+SELECT [s].[Id], [s].[AdditionalNotes], [s].[AiCheckDetails], [s].[AiCheckScore], [s].[AiCheckStatus], [s].[CreatedAt], [s].[CreatedBy], [s].[DeletedAt], [s].[DocumentUrl], [s].[IsActive], [s].[LastModifiedAt], [s].[LastModifiedBy], [s].[PhaseId], [s].[Status], [s].[SubmissionRound], [s].[SubmittedAt], [s].[SubmittedBy], [s].[TopicId], [s].[TopicVersionId], [p].[Id], [p].[CreatedAt], [p].[CreatedBy], [p].[DeletedAt], [p].[EndDate], [p].[IsActive], [p].[LastModifiedAt], [p].[LastModifiedBy], [p].[Name], [p].[PhaseTypeId], [p].[SemesterId], [p].[StartDate], [p].[SubmissionDeadline], [u].[Id], [u].[AccessFailedCount], [u].[ConcurrencyStamp], [u].[CreatedAt], [u].[DeletedAt], [u].[Email], [u].[EmailConfirmed], [u].[LastModifiedAt], [u].[LastModifiedBy], [u].[LockoutEnabled], [u].[LockoutEnd], [u].[NormalizedEmail], [u].[NormalizedUserName], [u].[PasswordHash], [u].[PhoneNumber], [u].[PhoneNumberConfirmed], [u].[SecurityStamp], [u].[TwoFactorEnabled], [u].[UserName], [r].[Id], [r].[AssignedAt], [r].[AssignedBy], [r].[AssignmentType], [r].[CompletedAt], [r].[Deadline], [r].[ReviewerId], [r].[SkillMatchScore], [r].[StartedAt], [r].[Status], [r].[SubmissionId]
+FROM [submissions] AS [s]
+INNER JOIN [phases] AS [p] ON [s].[PhaseId] = [p].[Id]
+INNER JOIN [users] AS [u] ON [s].[SubmittedBy] = [u].[Id]
+LEFT JOIN [reviewer_assignments] AS [r] ON [s].[Id] = [r].[SubmissionId]
+WHERE [s].[TopicId] = @__topicId_0 AND [s].[IsActive] = CAST(1 AS bit) AND [s].[DeletedAt] IS NULL
+ORDER BY [s].[Id], [p].[Id], [u].[Id]
+2025-10-04 02:54:07.814 +07:00 [INF] Executed DbCommand (43ms) [Parameters=[@__topicId_0='?' (DbType = Int32)], CommandType='"Text"', CommandTimeout='30']
+SELECT [s].[Id], [s].[AdditionalNotes], [s].[AiCheckDetails], [s].[AiCheckScore], [s].[AiCheckStatus], [s].[CreatedAt], [s].[CreatedBy], [s].[DeletedAt], [s].[DocumentUrl], [s].[IsActive], [s].[LastModifiedAt], [s].[LastModifiedBy], [s].[PhaseId], [s].[Status], [s].[SubmissionRound], [s].[SubmittedAt], [s].[SubmittedBy], [s].[TopicId], [s].[TopicVersionId], [p].[Id], [p].[CreatedAt], [p].[CreatedBy], [p].[DeletedAt], [p].[EndDate], [p].[IsActive], [p].[LastModifiedAt], [p].[LastModifiedBy], [p].[Name], [p].[PhaseTypeId], [p].[SemesterId], [p].[StartDate], [p].[SubmissionDeadline], [u].[Id], [u].[AccessFailedCount], [u].[ConcurrencyStamp], [u].[CreatedAt], [u].[DeletedAt], [u].[Email], [u].[EmailConfirmed], [u].[LastModifiedAt], [u].[LastModifiedBy], [u].[LockoutEnabled], [u].[LockoutEnd], [u].[NormalizedEmail], [u].[NormalizedUserName], [u].[PasswordHash], [u].[PhoneNumber], [u].[PhoneNumberConfirmed], [u].[SecurityStamp], [u].[TwoFactorEnabled], [u].[UserName], [r].[Id], [r].[AssignedAt], [r].[AssignedBy], [r].[AssignmentType], [r].[CompletedAt], [r].[Deadline], [r].[ReviewerId], [r].[SkillMatchScore], [r].[StartedAt], [r].[Status], [r].[SubmissionId]
+FROM [submissions] AS [s]
+INNER JOIN [phases] AS [p] ON [s].[PhaseId] = [p].[Id]
+INNER JOIN [users] AS [u] ON [s].[SubmittedBy] = [u].[Id]
+LEFT JOIN [reviewer_assignments] AS [r] ON [s].[Id] = [r].[SubmissionId]
+WHERE [s].[TopicId] = @__topicId_0 AND [s].[IsActive] = CAST(1 AS bit) AND [s].[DeletedAt] IS NULL
+ORDER BY [s].[Id], [p].[Id], [u].[Id]
+2025-10-04 02:54:07.819 +07:00 [DBG] Closing data reader to 'capbot_db' on server 'localhost'.
+2025-10-04 02:54:07.819 +07:00 [DBG] A data reader for 'capbot_db' on server 'localhost' is being disposed after spending 2ms reading results.
+2025-10-04 02:54:07.819 +07:00 [DBG] Closing connection to database 'capbot_db' on server 'localhost'.
+2025-10-04 02:54:07.820 +07:00 [DBG] Closed connection to database 'capbot_db' on server 'localhost' (0ms).
+2025-10-04 02:54:07.835 +07:00 [DBG] Compiling query expression: 
+'DbSet<EntityFile>()
+    .AsNoTracking()
+    .Include(x => x.File)
+    .Where(x => x.EntityId == __p_0 && (int)x.EntityType == 1 && x.IsPrimary)
+    .FirstOrDefault()'
+2025-10-04 02:54:07.837 +07:00 [DBG] Including navigation: 'EntityFile.File'.
+2025-10-04 02:54:07.852 +07:00 [DBG] Generated query execution expression: 
+'queryContext => ShapedQueryCompilingExpressionVisitor.SingleOrDefaultAsync<EntityFile>(
+    asyncEnumerable: new SingleQueryingEnumerable<EntityFile>(
+        (RelationalQueryContext)queryContext, 
+        RelationalCommandCache.QueryExpression(
+            Client Projections:
+                0 -> Dictionary<IProperty, int> { [Property: EntityFile.Id (long) Required PK AfterSave:Throw ValueGenerated.OnAdd, 0], [Property: EntityFile.Caption (string) MaxLength(512), 1], [Property: EntityFile.CreatedAt (DateTime) Required, 2], [Property: EntityFile.EntityId (long) Required Index, 3], [Property: EntityFile.EntityType (EntityType) Required Index, 4], [Property: EntityFile.FileId (long) Required FK Index, 5], [Property: EntityFile.IsPrimary (bool) Required, 6] }
+                1 -> Dictionary<IProperty, int> { [Property: AppFile.Id (long) Required PK AfterSave:Throw ValueGenerated.OnAdd, 7], [Property: AppFile.Alt (string) MaxLength(255), 8], [Property: AppFile.Checksum (string) MaxLength(128), 9], [Property: AppFile.CreatedAt (DateTime) Required, 10], [Property: AppFile.CreatedBy (string), 11], [Property: AppFile.DeletedAt (DateTime?), 12], [Property: AppFile.FileName (string) Required MaxLength(255), 13], [Property: AppFile.FilePath (string) Required MaxLength(1024), 14], [Property: AppFile.FileSize (long) Required, 15], [Property: AppFile.FileType (FileType) Required, 16], [Property: AppFile.Height (int?), 17], [Property: AppFile.IsActive (bool) Required, 18], [Property: AppFile.LastModifiedAt (DateTime?), 19], [Property: AppFile.LastModifiedBy (string), 20], [Property: AppFile.MimeType (string) MaxLength(255), 21], [Property: AppFile.ThumbnailUrl (string) MaxLength(2048), 22], [Property: AppFile.Url (string) Required MaxLength(2048), 23], [Property: AppFile.Width (int?), 24] }
+            SELECT TOP(1) e.Id, e.Caption, e.CreatedAt, e.EntityId, e.EntityType, e.FileId, e.IsPrimary, f.Id, f.Alt, f.Checksum, f.CreatedAt, f.CreatedBy, f.DeletedAt, f.FileName, f.FilePath, f.FileSize, f.FileType, f.Height, f.IsActive, f.LastModifiedAt, f.LastModifiedBy, f.MimeType, f.ThumbnailUrl, f.Url, f.Width
+            FROM entity_files AS e
+            INNER JOIN files AS f ON e.FileId == f.Id
+            WHERE ((e.EntityId == @__p_0) && (e.EntityType == 1)) && e.IsPrimary), 
+        null, 
+        Func<QueryContext, DbDataReader, ResultContext, SingleQueryResultCoordinator, EntityFile>, 
+        App.DAL.Context.MyDbContext, 
+        False, 
+        False, 
+        True
+    ), 
+    cancellationToken: queryContext.CancellationToken)'
+2025-10-04 02:54:07.855 +07:00 [DBG] Opening connection to database 'capbot_db' on server 'localhost'.
+2025-10-04 02:54:07.856 +07:00 [DBG] Opened connection to database 'capbot_db' on server 'localhost'.
+2025-10-04 02:54:07.856 +07:00 [DBG] Creating DbCommand for 'ExecuteReader'.
+2025-10-04 02:54:07.856 +07:00 [DBG] Created DbCommand for 'ExecuteReader' (0ms).
+2025-10-04 02:54:07.856 +07:00 [DBG] Initialized DbCommand for 'ExecuteReader' (0ms).
+2025-10-04 02:54:07.856 +07:00 [DBG] Executing DbCommand [Parameters=[@__p_0='?' (DbType = Int64)], CommandType='"Text"', CommandTimeout='30']
+SELECT TOP(1) [e].[Id], [e].[Caption], [e].[CreatedAt], [e].[EntityId], [e].[EntityType], [e].[FileId], [e].[IsPrimary], [f].[Id], [f].[Alt], [f].[Checksum], [f].[CreatedAt], [f].[CreatedBy], [f].[DeletedAt], [f].[FileName], [f].[FilePath], [f].[FileSize], [f].[FileType], [f].[Height], [f].[IsActive], [f].[LastModifiedAt], [f].[LastModifiedBy], [f].[MimeType], [f].[ThumbnailUrl], [f].[Url], [f].[Width]
+FROM [entity_files] AS [e]
+INNER JOIN [files] AS [f] ON [e].[FileId] = [f].[Id]
+WHERE [e].[EntityId] = @__p_0 AND [e].[EntityType] = 1 AND [e].[IsPrimary] = CAST(1 AS bit)
+2025-10-04 02:54:07.867 +07:00 [INF] Executed DbCommand (10ms) [Parameters=[@__p_0='?' (DbType = Int64)], CommandType='"Text"', CommandTimeout='30']
+SELECT TOP(1) [e].[Id], [e].[Caption], [e].[CreatedAt], [e].[EntityId], [e].[EntityType], [e].[FileId], [e].[IsPrimary], [f].[Id], [f].[Alt], [f].[Checksum], [f].[CreatedAt], [f].[CreatedBy], [f].[DeletedAt], [f].[FileName], [f].[FilePath], [f].[FileSize], [f].[FileType], [f].[Height], [f].[IsActive], [f].[LastModifiedAt], [f].[LastModifiedBy], [f].[MimeType], [f].[ThumbnailUrl], [f].[Url], [f].[Width]
+FROM [entity_files] AS [e]
+INNER JOIN [files] AS [f] ON [e].[FileId] = [f].[Id]
+WHERE [e].[EntityId] = @__p_0 AND [e].[EntityType] = 1 AND [e].[IsPrimary] = CAST(1 AS bit)
+2025-10-04 02:54:07.868 +07:00 [DBG] Closing data reader to 'capbot_db' on server 'localhost'.
+2025-10-04 02:54:07.868 +07:00 [DBG] A data reader for 'capbot_db' on server 'localhost' is being disposed after spending 0ms reading results.
+2025-10-04 02:54:07.869 +07:00 [DBG] Closing connection to database 'capbot_db' on server 'localhost'.
+2025-10-04 02:54:07.869 +07:00 [DBG] Closed connection to database 'capbot_db' on server 'localhost' (0ms).
+2025-10-04 02:54:07.890 +07:00 [DBG] List of registered output formatters, in the following order: ["Microsoft.AspNetCore.OData.Formatter.ODataOutputFormatter","Microsoft.AspNetCore.OData.Formatter.ODataOutputFormatter","Microsoft.AspNetCore.OData.Formatter.ODataOutputFormatter","Microsoft.AspNetCore.Mvc.Formatters.HttpNoContentOutputFormatter","Microsoft.AspNetCore.Mvc.Formatters.StringOutputFormatter","Microsoft.AspNetCore.Mvc.Formatters.StreamOutputFormatter","Microsoft.AspNetCore.Mvc.Formatters.SystemTextJsonOutputFormatter"]
+2025-10-04 02:54:07.891 +07:00 [DBG] No information found on request to perform content negotiation.
+2025-10-04 02:54:07.894 +07:00 [DBG] Attempting to select the first output formatter in the output formatters list which supports a content type from the explicitly specified content types '["application/json"]'.
+2025-10-04 02:54:07.902 +07:00 [DBG] Selected output formatter 'Microsoft.AspNetCore.Mvc.Formatters.SystemTextJsonOutputFormatter' and content type 'application/json' to write the response.
+2025-10-04 02:54:07.902 +07:00 [INF] Executing ObjectResult, writing value of type 'FS.Commons.FSResponse'.
+2025-10-04 02:54:08.017 +07:00 [INF] Executed action CapBot.api.Controllers.TopicController.GetDetail (CapBot.api) in 751.3479ms
+2025-10-04 02:54:08.018 +07:00 [INF] Executed endpoint 'CapBot.api.Controllers.TopicController.GetDetail (CapBot.api)'
+2025-10-04 02:54:08.020 +07:00 [DBG] Connection id "0HNG2MQC634J6" completed keep alive response.
+2025-10-04 02:54:08.021 +07:00 [DBG] 'MyDbContext' disposed.
+2025-10-04 02:54:08.022 +07:00 [DBG] Disposing connection to database 'capbot_db' on server 'localhost'.
+2025-10-04 02:54:08.022 +07:00 [DBG] Disposed connection to database '' on server '' (0ms).
+2025-10-04 02:54:08.023 +07:00 [INF] Request finished HTTP/1.1 GET http://localhost:5207/api/topic/detail/104 - 200 null application/json; charset=utf-8 1027.2206ms
+2025-10-04 02:54:16.807 +07:00 [DBG] Connection id "0HNG2MQC634J6" received FIN.
+2025-10-04 02:54:16.808 +07:00 [DBG] Connection id "0HNG2MQC634J6" disconnecting.
+2025-10-04 02:54:16.809 +07:00 [DBG] Connection id "0HNG2MQC634J6" sending FIN because: "The Socket transport's send loop completed gracefully."
+2025-10-04 02:54:16.811 +07:00 [DBG] Connection id "0HNG2MQC634J6" stopped.
+2025-10-04 02:54:19.018 +07:00 [DBG] Connection id "0HNG2MQC634J8" accepted.
+2025-10-04 02:54:19.019 +07:00 [DBG] Connection id "0HNG2MQC634J8" started.
+2025-10-04 02:54:19.021 +07:00 [INF] Request starting HTTP/1.1 GET http://localhost:5207/api/topic/detail/104 - null null
+2025-10-04 02:54:19.021 +07:00 [DBG] The request path /api/topic/detail/104 does not match a supported file type
+2025-10-04 02:54:19.022 +07:00 [DBG] The request path /api/topic/detail/104 does not match a supported file type
+2025-10-04 02:54:19.050 +07:00 [DBG] 1 candidate(s) found for the request path '/api/topic/detail/104'
+2025-10-04 02:54:19.050 +07:00 [DBG] Endpoint 'CapBot.api.Controllers.TopicController.GetDetail (CapBot.api)' with route pattern 'api/topic/detail/{topicId}' is valid for the request path '/api/topic/detail/104'
+2025-10-04 02:54:19.050 +07:00 [DBG] Request matched endpoint 'CapBot.api.Controllers.TopicController.GetDetail (CapBot.api)'
+2025-10-04 02:54:19.062 +07:00 [DBG] Successfully validated the token.
+2025-10-04 02:54:19.062 +07:00 [DBG] AuthenticationScheme: Bearer was successfully authenticated.
+2025-10-04 02:54:19.063 +07:00 [INF] Executing endpoint 'CapBot.api.Controllers.TopicController.GetDetail (CapBot.api)'
+2025-10-04 02:54:19.063 +07:00 [INF] Route matched with {action = "GetDetail", controller = "Topic"}. Executing controller action with signature System.Threading.Tasks.Task`1[Microsoft.AspNetCore.Mvc.IActionResult] GetDetail(Int32) on controller CapBot.api.Controllers.TopicController (CapBot.api).
+2025-10-04 02:54:19.063 +07:00 [DBG] Execution plan of authorization filters (in the following order): ["None"]
+2025-10-04 02:54:19.064 +07:00 [DBG] Execution plan of resource filters (in the following order): ["Microsoft.AspNetCore.Mvc.ConsumesAttribute"]
+2025-10-04 02:54:19.064 +07:00 [DBG] Execution plan of action filters (in the following order): ["Microsoft.AspNetCore.Mvc.ModelBinding.UnsupportedContentTypeFilter (Order: -3000)"]
+2025-10-04 02:54:19.064 +07:00 [DBG] Execution plan of exception filters (in the following order): ["None"]
+2025-10-04 02:54:19.064 +07:00 [DBG] Execution plan of result filters (in the following order): ["Microsoft.AspNetCore.Mvc.Infrastructure.ClientErrorResultFilter (Order: -2000)","Microsoft.AspNetCore.Mvc.ProducesAttribute (Order: 0)"]
+2025-10-04 02:54:19.064 +07:00 [DBG] Executing controller factory for controller CapBot.api.Controllers.TopicController (CapBot.api)
+2025-10-04 02:54:19.068 +07:00 [DBG] Executed controller factory for controller CapBot.api.Controllers.TopicController (CapBot.api)
+2025-10-04 02:54:19.071 +07:00 [DBG] Attempting to bind parameter 'topicId' of type 'System.Int32' ...
+2025-10-04 02:54:19.074 +07:00 [DBG] Attempting to bind parameter 'topicId' of type 'System.Int32' using the name 'topicId' in request data ...
+2025-10-04 02:54:19.075 +07:00 [DBG] Done attempting to bind parameter 'topicId' of type 'System.Int32'.
+2025-10-04 02:54:19.075 +07:00 [DBG] Done attempting to bind parameter 'topicId' of type 'System.Int32'.
+2025-10-04 02:54:19.075 +07:00 [DBG] Attempting to validate the bound parameter 'topicId' of type 'System.Int32' ...
+2025-10-04 02:54:19.075 +07:00 [DBG] Done attempting to validate the bound parameter 'topicId' of type 'System.Int32'.
+2025-10-04 02:54:19.090 +07:00 [DBG] Entity Framework Core 8.0.16 initialized 'MyDbContext' using provider 'Microsoft.EntityFrameworkCore.SqlServer:8.0.13' with options: MigrationsAssembly=App.DAL 
+2025-10-04 02:54:19.092 +07:00 [DBG] Creating DbConnection.
+2025-10-04 02:54:19.093 +07:00 [DBG] Created DbConnection. (0ms).
+2025-10-04 02:54:19.093 +07:00 [DBG] Opening connection to database 'capbot_db' on server 'localhost'.
+2025-10-04 02:54:19.093 +07:00 [DBG] Opened connection to database 'capbot_db' on server 'localhost'.
+2025-10-04 02:54:19.093 +07:00 [DBG] Creating DbCommand for 'ExecuteReader'.
+2025-10-04 02:54:19.094 +07:00 [DBG] Created DbCommand for 'ExecuteReader' (0ms).
+2025-10-04 02:54:19.094 +07:00 [DBG] Initialized DbCommand for 'ExecuteReader' (0ms).
+2025-10-04 02:54:19.094 +07:00 [DBG] Executing DbCommand [Parameters=[@__topicId_0='?' (DbType = Int32)], CommandType='"Text"', CommandTimeout='30']
+SELECT [t1].[Id], [t1].[Abbreviation], [t1].[CategoryId], [t1].[Content], [t1].[Context], [t1].[CreatedAt], [t1].[CreatedBy], [t1].[DeletedAt], [t1].[Description], [t1].[EN_Title], [t1].[IsActive], [t1].[IsApproved], [t1].[IsLegacy], [t1].[LastModifiedAt], [t1].[LastModifiedBy], [t1].[MaxStudents], [t1].[Objectives], [t1].[PotentialDuplicate], [t1].[Problem], [t1].[SemesterId], [t1].[SupervisorId], [t1].[VN_title], [t1].[Id0], [t1].[AccessFailedCount], [t1].[ConcurrencyStamp], [t1].[CreatedAt0], [t1].[DeletedAt0], [t1].[Email], [t1].[EmailConfirmed], [t1].[LastModifiedAt0], [t1].[LastModifiedBy0], [t1].[LockoutEnabled], [t1].[LockoutEnd], [t1].[NormalizedEmail], [t1].[NormalizedUserName], [t1].[PasswordHash], [t1].[PhoneNumber], [t1].[PhoneNumberConfirmed], [t1].[SecurityStamp], [t1].[TwoFactorEnabled], [t1].[UserName], [t1].[Id1], [t1].[CreatedAt1], [t1].[CreatedBy0], [t1].[DeletedAt1], [t1].[Description0], [t1].[IsActive0], [t1].[LastModifiedAt1], [t1].[LastModifiedBy1], [t1].[Name], [t1].[Id2], [t1].[CreatedAt2], [t1].[CreatedBy1], [t1].[DeletedAt2], [t1].[Description1], [t1].[EndDate], [t1].[IsActive1], [t1].[LastModifiedAt2], [t1].[LastModifiedBy2], [t1].[Name0], [t1].[StartDate], [t2].[Id], [t2].[Content], [t2].[Context], [t2].[CreatedAt], [t2].[CreatedBy], [t2].[DeletedAt], [t2].[Description], [t2].[DocumentUrl], [t2].[EN_Title], [t2].[ExpectedOutcomes], [t2].[IsActive], [t2].[LastModifiedAt], [t2].[LastModifiedBy], [t2].[Methodology], [t2].[Objectives], [t2].[PotentialDuplicate], [t2].[Problem], [t2].[Requirements], [t2].[Status], [t2].[SubmittedAt], [t2].[SubmittedBy], [t2].[TopicId], [t2].[VN_title], [t2].[VersionNumber]
+FROM (
+    SELECT TOP(1) [t].[Id], [t].[Abbreviation], [t].[CategoryId], [t].[Content], [t].[Context], [t].[CreatedAt], [t].[CreatedBy], [t].[DeletedAt], [t].[Description], [t].[EN_Title], [t].[IsActive], [t].[IsApproved], [t].[IsLegacy], [t].[LastModifiedAt], [t].[LastModifiedBy], [t].[MaxStudents], [t].[Objectives], [t].[PotentialDuplicate], [t].[Problem], [t].[SemesterId], [t].[SupervisorId], [t].[VN_title], [u].[Id] AS [Id0], [u].[AccessFailedCount], [u].[ConcurrencyStamp], [u].[CreatedAt] AS [CreatedAt0], [u].[DeletedAt] AS [DeletedAt0], [u].[Email], [u].[EmailConfirmed], [u].[LastModifiedAt] AS [LastModifiedAt0], [u].[LastModifiedBy] AS [LastModifiedBy0], [u].[LockoutEnabled], [u].[LockoutEnd], [u].[NormalizedEmail], [u].[NormalizedUserName], [u].[PasswordHash], [u].[PhoneNumber], [u].[PhoneNumberConfirmed], [u].[SecurityStamp], [u].[TwoFactorEnabled], [u].[UserName], [t0].[Id] AS [Id1], [t0].[CreatedAt] AS [CreatedAt1], [t0].[CreatedBy] AS [CreatedBy0], [t0].[DeletedAt] AS [DeletedAt1], [t0].[Description] AS [Description0], [t0].[IsActive] AS [IsActive0], [t0].[LastModifiedAt] AS [LastModifiedAt1], [t0].[LastModifiedBy] AS [LastModifiedBy1], [t0].[Name], [s].[Id] AS [Id2], [s].[CreatedAt] AS [CreatedAt2], [s].[CreatedBy] AS [CreatedBy1], [s].[DeletedAt] AS [DeletedAt2], [s].[Description] AS [Description1], [s].[EndDate], [s].[IsActive] AS [IsActive1], [s].[LastModifiedAt] AS [LastModifiedAt2], [s].[LastModifiedBy] AS [LastModifiedBy2], [s].[Name] AS [Name0], [s].[StartDate]
+    FROM [topics] AS [t]
+    INNER JOIN [users] AS [u] ON [t].[SupervisorId] = [u].[Id]
+    LEFT JOIN [topic_categories] AS [t0] ON [t].[CategoryId] = [t0].[Id]
+    INNER JOIN [semesters] AS [s] ON [t].[SemesterId] = [s].[Id]
+    WHERE [t].[Id] = @__topicId_0 AND [t].[IsActive] = CAST(1 AS bit) AND [t].[DeletedAt] IS NULL
+) AS [t1]
+LEFT JOIN [topic_versions] AS [t2] ON [t1].[Id] = [t2].[TopicId]
+ORDER BY [t1].[Id], [t1].[Id0], [t1].[Id1], [t1].[Id2]
+2025-10-04 02:54:19.141 +07:00 [INF] Executed DbCommand (47ms) [Parameters=[@__topicId_0='?' (DbType = Int32)], CommandType='"Text"', CommandTimeout='30']
+SELECT [t1].[Id], [t1].[Abbreviation], [t1].[CategoryId], [t1].[Content], [t1].[Context], [t1].[CreatedAt], [t1].[CreatedBy], [t1].[DeletedAt], [t1].[Description], [t1].[EN_Title], [t1].[IsActive], [t1].[IsApproved], [t1].[IsLegacy], [t1].[LastModifiedAt], [t1].[LastModifiedBy], [t1].[MaxStudents], [t1].[Objectives], [t1].[PotentialDuplicate], [t1].[Problem], [t1].[SemesterId], [t1].[SupervisorId], [t1].[VN_title], [t1].[Id0], [t1].[AccessFailedCount], [t1].[ConcurrencyStamp], [t1].[CreatedAt0], [t1].[DeletedAt0], [t1].[Email], [t1].[EmailConfirmed], [t1].[LastModifiedAt0], [t1].[LastModifiedBy0], [t1].[LockoutEnabled], [t1].[LockoutEnd], [t1].[NormalizedEmail], [t1].[NormalizedUserName], [t1].[PasswordHash], [t1].[PhoneNumber], [t1].[PhoneNumberConfirmed], [t1].[SecurityStamp], [t1].[TwoFactorEnabled], [t1].[UserName], [t1].[Id1], [t1].[CreatedAt1], [t1].[CreatedBy0], [t1].[DeletedAt1], [t1].[Description0], [t1].[IsActive0], [t1].[LastModifiedAt1], [t1].[LastModifiedBy1], [t1].[Name], [t1].[Id2], [t1].[CreatedAt2], [t1].[CreatedBy1], [t1].[DeletedAt2], [t1].[Description1], [t1].[EndDate], [t1].[IsActive1], [t1].[LastModifiedAt2], [t1].[LastModifiedBy2], [t1].[Name0], [t1].[StartDate], [t2].[Id], [t2].[Content], [t2].[Context], [t2].[CreatedAt], [t2].[CreatedBy], [t2].[DeletedAt], [t2].[Description], [t2].[DocumentUrl], [t2].[EN_Title], [t2].[ExpectedOutcomes], [t2].[IsActive], [t2].[LastModifiedAt], [t2].[LastModifiedBy], [t2].[Methodology], [t2].[Objectives], [t2].[PotentialDuplicate], [t2].[Problem], [t2].[Requirements], [t2].[Status], [t2].[SubmittedAt], [t2].[SubmittedBy], [t2].[TopicId], [t2].[VN_title], [t2].[VersionNumber]
+FROM (
+    SELECT TOP(1) [t].[Id], [t].[Abbreviation], [t].[CategoryId], [t].[Content], [t].[Context], [t].[CreatedAt], [t].[CreatedBy], [t].[DeletedAt], [t].[Description], [t].[EN_Title], [t].[IsActive], [t].[IsApproved], [t].[IsLegacy], [t].[LastModifiedAt], [t].[LastModifiedBy], [t].[MaxStudents], [t].[Objectives], [t].[PotentialDuplicate], [t].[Problem], [t].[SemesterId], [t].[SupervisorId], [t].[VN_title], [u].[Id] AS [Id0], [u].[AccessFailedCount], [u].[ConcurrencyStamp], [u].[CreatedAt] AS [CreatedAt0], [u].[DeletedAt] AS [DeletedAt0], [u].[Email], [u].[EmailConfirmed], [u].[LastModifiedAt] AS [LastModifiedAt0], [u].[LastModifiedBy] AS [LastModifiedBy0], [u].[LockoutEnabled], [u].[LockoutEnd], [u].[NormalizedEmail], [u].[NormalizedUserName], [u].[PasswordHash], [u].[PhoneNumber], [u].[PhoneNumberConfirmed], [u].[SecurityStamp], [u].[TwoFactorEnabled], [u].[UserName], [t0].[Id] AS [Id1], [t0].[CreatedAt] AS [CreatedAt1], [t0].[CreatedBy] AS [CreatedBy0], [t0].[DeletedAt] AS [DeletedAt1], [t0].[Description] AS [Description0], [t0].[IsActive] AS [IsActive0], [t0].[LastModifiedAt] AS [LastModifiedAt1], [t0].[LastModifiedBy] AS [LastModifiedBy1], [t0].[Name], [s].[Id] AS [Id2], [s].[CreatedAt] AS [CreatedAt2], [s].[CreatedBy] AS [CreatedBy1], [s].[DeletedAt] AS [DeletedAt2], [s].[Description] AS [Description1], [s].[EndDate], [s].[IsActive] AS [IsActive1], [s].[LastModifiedAt] AS [LastModifiedAt2], [s].[LastModifiedBy] AS [LastModifiedBy2], [s].[Name] AS [Name0], [s].[StartDate]
+    FROM [topics] AS [t]
+    INNER JOIN [users] AS [u] ON [t].[SupervisorId] = [u].[Id]
+    LEFT JOIN [topic_categories] AS [t0] ON [t].[CategoryId] = [t0].[Id]
+    INNER JOIN [semesters] AS [s] ON [t].[SemesterId] = [s].[Id]
+    WHERE [t].[Id] = @__topicId_0 AND [t].[IsActive] = CAST(1 AS bit) AND [t].[DeletedAt] IS NULL
+) AS [t1]
+LEFT JOIN [topic_versions] AS [t2] ON [t1].[Id] = [t2].[TopicId]
+ORDER BY [t1].[Id], [t1].[Id0], [t1].[Id1], [t1].[Id2]
+2025-10-04 02:54:19.142 +07:00 [DBG] Closing data reader to 'capbot_db' on server 'localhost'.
+2025-10-04 02:54:19.142 +07:00 [DBG] A data reader for 'capbot_db' on server 'localhost' is being disposed after spending 0ms reading results.
+2025-10-04 02:54:19.142 +07:00 [DBG] Closing connection to database 'capbot_db' on server 'localhost'.
+2025-10-04 02:54:19.143 +07:00 [DBG] Closed connection to database 'capbot_db' on server 'localhost' (0ms).
+2025-10-04 02:54:19.144 +07:00 [DBG] Opening connection to database 'capbot_db' on server 'localhost'.
+2025-10-04 02:54:19.144 +07:00 [DBG] Opened connection to database 'capbot_db' on server 'localhost'.
+2025-10-04 02:54:19.144 +07:00 [DBG] Creating DbCommand for 'ExecuteReader'.
+2025-10-04 02:54:19.144 +07:00 [DBG] Created DbCommand for 'ExecuteReader' (0ms).
+2025-10-04 02:54:19.144 +07:00 [DBG] Initialized DbCommand for 'ExecuteReader' (0ms).
+2025-10-04 02:54:19.144 +07:00 [DBG] Executing DbCommand [Parameters=[@__topicId_0='?' (DbType = Int32)], CommandType='"Text"', CommandTimeout='30']
+SELECT [s].[Id], [s].[AdditionalNotes], [s].[AiCheckDetails], [s].[AiCheckScore], [s].[AiCheckStatus], [s].[CreatedAt], [s].[CreatedBy], [s].[DeletedAt], [s].[DocumentUrl], [s].[IsActive], [s].[LastModifiedAt], [s].[LastModifiedBy], [s].[PhaseId], [s].[Status], [s].[SubmissionRound], [s].[SubmittedAt], [s].[SubmittedBy], [s].[TopicId], [s].[TopicVersionId], [p].[Id], [p].[CreatedAt], [p].[CreatedBy], [p].[DeletedAt], [p].[EndDate], [p].[IsActive], [p].[LastModifiedAt], [p].[LastModifiedBy], [p].[Name], [p].[PhaseTypeId], [p].[SemesterId], [p].[StartDate], [p].[SubmissionDeadline], [u].[Id], [u].[AccessFailedCount], [u].[ConcurrencyStamp], [u].[CreatedAt], [u].[DeletedAt], [u].[Email], [u].[EmailConfirmed], [u].[LastModifiedAt], [u].[LastModifiedBy], [u].[LockoutEnabled], [u].[LockoutEnd], [u].[NormalizedEmail], [u].[NormalizedUserName], [u].[PasswordHash], [u].[PhoneNumber], [u].[PhoneNumberConfirmed], [u].[SecurityStamp], [u].[TwoFactorEnabled], [u].[UserName], [r].[Id], [r].[AssignedAt], [r].[AssignedBy], [r].[AssignmentType], [r].[CompletedAt], [r].[Deadline], [r].[ReviewerId], [r].[SkillMatchScore], [r].[StartedAt], [r].[Status], [r].[SubmissionId]
+FROM [submissions] AS [s]
+INNER JOIN [phases] AS [p] ON [s].[PhaseId] = [p].[Id]
+INNER JOIN [users] AS [u] ON [s].[SubmittedBy] = [u].[Id]
+LEFT JOIN [reviewer_assignments] AS [r] ON [s].[Id] = [r].[SubmissionId]
+WHERE [s].[TopicId] = @__topicId_0 AND [s].[IsActive] = CAST(1 AS bit) AND [s].[DeletedAt] IS NULL
+ORDER BY [s].[Id], [p].[Id], [u].[Id]
+2025-10-04 02:54:19.162 +07:00 [INF] Executed DbCommand (18ms) [Parameters=[@__topicId_0='?' (DbType = Int32)], CommandType='"Text"', CommandTimeout='30']
+SELECT [s].[Id], [s].[AdditionalNotes], [s].[AiCheckDetails], [s].[AiCheckScore], [s].[AiCheckStatus], [s].[CreatedAt], [s].[CreatedBy], [s].[DeletedAt], [s].[DocumentUrl], [s].[IsActive], [s].[LastModifiedAt], [s].[LastModifiedBy], [s].[PhaseId], [s].[Status], [s].[SubmissionRound], [s].[SubmittedAt], [s].[SubmittedBy], [s].[TopicId], [s].[TopicVersionId], [p].[Id], [p].[CreatedAt], [p].[CreatedBy], [p].[DeletedAt], [p].[EndDate], [p].[IsActive], [p].[LastModifiedAt], [p].[LastModifiedBy], [p].[Name], [p].[PhaseTypeId], [p].[SemesterId], [p].[StartDate], [p].[SubmissionDeadline], [u].[Id], [u].[AccessFailedCount], [u].[ConcurrencyStamp], [u].[CreatedAt], [u].[DeletedAt], [u].[Email], [u].[EmailConfirmed], [u].[LastModifiedAt], [u].[LastModifiedBy], [u].[LockoutEnabled], [u].[LockoutEnd], [u].[NormalizedEmail], [u].[NormalizedUserName], [u].[PasswordHash], [u].[PhoneNumber], [u].[PhoneNumberConfirmed], [u].[SecurityStamp], [u].[TwoFactorEnabled], [u].[UserName], [r].[Id], [r].[AssignedAt], [r].[AssignedBy], [r].[AssignmentType], [r].[CompletedAt], [r].[Deadline], [r].[ReviewerId], [r].[SkillMatchScore], [r].[StartedAt], [r].[Status], [r].[SubmissionId]
+FROM [submissions] AS [s]
+INNER JOIN [phases] AS [p] ON [s].[PhaseId] = [p].[Id]
+INNER JOIN [users] AS [u] ON [s].[SubmittedBy] = [u].[Id]
+LEFT JOIN [reviewer_assignments] AS [r] ON [s].[Id] = [r].[SubmissionId]
+WHERE [s].[TopicId] = @__topicId_0 AND [s].[IsActive] = CAST(1 AS bit) AND [s].[DeletedAt] IS NULL
+ORDER BY [s].[Id], [p].[Id], [u].[Id]
+2025-10-04 02:54:19.163 +07:00 [DBG] Closing data reader to 'capbot_db' on server 'localhost'.
+2025-10-04 02:54:19.163 +07:00 [DBG] A data reader for 'capbot_db' on server 'localhost' is being disposed after spending 0ms reading results.
+2025-10-04 02:54:19.163 +07:00 [DBG] Closing connection to database 'capbot_db' on server 'localhost'.
+2025-10-04 02:54:19.163 +07:00 [DBG] Closed connection to database 'capbot_db' on server 'localhost' (0ms).
+2025-10-04 02:54:19.165 +07:00 [DBG] Opening connection to database 'capbot_db' on server 'localhost'.
+2025-10-04 02:54:19.165 +07:00 [DBG] Opened connection to database 'capbot_db' on server 'localhost'.
+2025-10-04 02:54:19.165 +07:00 [DBG] Creating DbCommand for 'ExecuteReader'.
+2025-10-04 02:54:19.165 +07:00 [DBG] Created DbCommand for 'ExecuteReader' (0ms).
+2025-10-04 02:54:19.166 +07:00 [DBG] Initialized DbCommand for 'ExecuteReader' (0ms).
+2025-10-04 02:54:19.166 +07:00 [DBG] Executing DbCommand [Parameters=[@__p_0='?' (DbType = Int64)], CommandType='"Text"', CommandTimeout='30']
+SELECT TOP(1) [e].[Id], [e].[Caption], [e].[CreatedAt], [e].[EntityId], [e].[EntityType], [e].[FileId], [e].[IsPrimary], [f].[Id], [f].[Alt], [f].[Checksum], [f].[CreatedAt], [f].[CreatedBy], [f].[DeletedAt], [f].[FileName], [f].[FilePath], [f].[FileSize], [f].[FileType], [f].[Height], [f].[IsActive], [f].[LastModifiedAt], [f].[LastModifiedBy], [f].[MimeType], [f].[ThumbnailUrl], [f].[Url], [f].[Width]
+FROM [entity_files] AS [e]
+INNER JOIN [files] AS [f] ON [e].[FileId] = [f].[Id]
+WHERE [e].[EntityId] = @__p_0 AND [e].[EntityType] = 1 AND [e].[IsPrimary] = CAST(1 AS bit)
+2025-10-04 02:54:19.175 +07:00 [INF] Executed DbCommand (9ms) [Parameters=[@__p_0='?' (DbType = Int64)], CommandType='"Text"', CommandTimeout='30']
+SELECT TOP(1) [e].[Id], [e].[Caption], [e].[CreatedAt], [e].[EntityId], [e].[EntityType], [e].[FileId], [e].[IsPrimary], [f].[Id], [f].[Alt], [f].[Checksum], [f].[CreatedAt], [f].[CreatedBy], [f].[DeletedAt], [f].[FileName], [f].[FilePath], [f].[FileSize], [f].[FileType], [f].[Height], [f].[IsActive], [f].[LastModifiedAt], [f].[LastModifiedBy], [f].[MimeType], [f].[ThumbnailUrl], [f].[Url], [f].[Width]
+FROM [entity_files] AS [e]
+INNER JOIN [files] AS [f] ON [e].[FileId] = [f].[Id]
+WHERE [e].[EntityId] = @__p_0 AND [e].[EntityType] = 1 AND [e].[IsPrimary] = CAST(1 AS bit)
+2025-10-04 02:54:19.175 +07:00 [DBG] Closing data reader to 'capbot_db' on server 'localhost'.
+2025-10-04 02:54:19.175 +07:00 [DBG] A data reader for 'capbot_db' on server 'localhost' is being disposed after spending 0ms reading results.
+2025-10-04 02:54:19.175 +07:00 [DBG] Closing connection to database 'capbot_db' on server 'localhost'.
+2025-10-04 02:54:19.176 +07:00 [DBG] Closed connection to database 'capbot_db' on server 'localhost' (0ms).
+2025-10-04 02:54:19.176 +07:00 [DBG] List of registered output formatters, in the following order: ["Microsoft.AspNetCore.OData.Formatter.ODataOutputFormatter","Microsoft.AspNetCore.OData.Formatter.ODataOutputFormatter","Microsoft.AspNetCore.OData.Formatter.ODataOutputFormatter","Microsoft.AspNetCore.Mvc.Formatters.HttpNoContentOutputFormatter","Microsoft.AspNetCore.Mvc.Formatters.StringOutputFormatter","Microsoft.AspNetCore.Mvc.Formatters.StreamOutputFormatter","Microsoft.AspNetCore.Mvc.Formatters.SystemTextJsonOutputFormatter"]
+2025-10-04 02:54:19.176 +07:00 [DBG] No information found on request to perform content negotiation.
+2025-10-04 02:54:19.177 +07:00 [DBG] Attempting to select the first output formatter in the output formatters list which supports a content type from the explicitly specified content types '["application/json"]'.
+2025-10-04 02:54:19.177 +07:00 [DBG] Selected output formatter 'Microsoft.AspNetCore.Mvc.Formatters.SystemTextJsonOutputFormatter' and content type 'application/json' to write the response.
+2025-10-04 02:54:19.177 +07:00 [INF] Executing ObjectResult, writing value of type 'FS.Commons.FSResponse'.
+2025-10-04 02:54:19.178 +07:00 [INF] Executed action CapBot.api.Controllers.TopicController.GetDetail (CapBot.api) in 113.5904ms
+2025-10-04 02:54:19.178 +07:00 [INF] Executed endpoint 'CapBot.api.Controllers.TopicController.GetDetail (CapBot.api)'
+2025-10-04 02:54:19.179 +07:00 [DBG] Connection id "0HNG2MQC634J8" completed keep alive response.
+2025-10-04 02:54:19.179 +07:00 [DBG] 'MyDbContext' disposed.
+2025-10-04 02:54:19.180 +07:00 [DBG] Disposing connection to database 'capbot_db' on server 'localhost'.
+2025-10-04 02:54:19.180 +07:00 [DBG] Disposed connection to database '' on server '' (0ms).
+2025-10-04 02:54:19.181 +07:00 [INF] Request finished HTTP/1.1 GET http://localhost:5207/api/topic/detail/104 - 200 null application/json; charset=utf-8 159.5914ms
+2025-10-04 02:54:19.921 +07:00 [INF] Request starting HTTP/1.1 GET http://localhost:5207/api/topic/detail/104 - null null
+2025-10-04 02:54:19.922 +07:00 [DBG] The request path /api/topic/detail/104 does not match a supported file type
+2025-10-04 02:54:19.922 +07:00 [DBG] The request path /api/topic/detail/104 does not match a supported file type
+2025-10-04 02:54:19.923 +07:00 [DBG] 1 candidate(s) found for the request path '/api/topic/detail/104'
+2025-10-04 02:54:19.924 +07:00 [DBG] Endpoint 'CapBot.api.Controllers.TopicController.GetDetail (CapBot.api)' with route pattern 'api/topic/detail/{topicId}' is valid for the request path '/api/topic/detail/104'
+2025-10-04 02:54:19.924 +07:00 [DBG] Request matched endpoint 'CapBot.api.Controllers.TopicController.GetDetail (CapBot.api)'
+2025-10-04 02:54:19.928 +07:00 [DBG] Successfully validated the token.
+2025-10-04 02:54:19.928 +07:00 [DBG] AuthenticationScheme: Bearer was successfully authenticated.
+2025-10-04 02:54:19.929 +07:00 [INF] Executing endpoint 'CapBot.api.Controllers.TopicController.GetDetail (CapBot.api)'
+2025-10-04 02:54:19.930 +07:00 [INF] Route matched with {action = "GetDetail", controller = "Topic"}. Executing controller action with signature System.Threading.Tasks.Task`1[Microsoft.AspNetCore.Mvc.IActionResult] GetDetail(Int32) on controller CapBot.api.Controllers.TopicController (CapBot.api).
+2025-10-04 02:54:19.930 +07:00 [DBG] Execution plan of authorization filters (in the following order): ["None"]
+2025-10-04 02:54:19.930 +07:00 [DBG] Execution plan of resource filters (in the following order): ["Microsoft.AspNetCore.Mvc.ConsumesAttribute"]
+2025-10-04 02:54:19.930 +07:00 [DBG] Execution plan of action filters (in the following order): ["Microsoft.AspNetCore.Mvc.ModelBinding.UnsupportedContentTypeFilter (Order: -3000)"]
+2025-10-04 02:54:19.931 +07:00 [DBG] Execution plan of exception filters (in the following order): ["None"]
+2025-10-04 02:54:19.931 +07:00 [DBG] Execution plan of result filters (in the following order): ["Microsoft.AspNetCore.Mvc.Infrastructure.ClientErrorResultFilter (Order: -2000)","Microsoft.AspNetCore.Mvc.ProducesAttribute (Order: 0)"]
+2025-10-04 02:54:19.931 +07:00 [DBG] Executing controller factory for controller CapBot.api.Controllers.TopicController (CapBot.api)
+2025-10-04 02:54:19.962 +07:00 [DBG] Executed controller factory for controller CapBot.api.Controllers.TopicController (CapBot.api)
+2025-10-04 02:54:19.963 +07:00 [DBG] Attempting to bind parameter 'topicId' of type 'System.Int32' ...
+2025-10-04 02:54:19.963 +07:00 [DBG] Attempting to bind parameter 'topicId' of type 'System.Int32' using the name 'topicId' in request data ...
+2025-10-04 02:54:19.963 +07:00 [DBG] Done attempting to bind parameter 'topicId' of type 'System.Int32'.
+2025-10-04 02:54:19.963 +07:00 [DBG] Done attempting to bind parameter 'topicId' of type 'System.Int32'.
+2025-10-04 02:54:19.963 +07:00 [DBG] Attempting to validate the bound parameter 'topicId' of type 'System.Int32' ...
+2025-10-04 02:54:19.963 +07:00 [DBG] Done attempting to validate the bound parameter 'topicId' of type 'System.Int32'.
+2025-10-04 02:54:19.965 +07:00 [DBG] Entity Framework Core 8.0.16 initialized 'MyDbContext' using provider 'Microsoft.EntityFrameworkCore.SqlServer:8.0.13' with options: MigrationsAssembly=App.DAL 
+2025-10-04 02:54:19.966 +07:00 [DBG] Creating DbConnection.
+2025-10-04 02:54:19.966 +07:00 [DBG] Created DbConnection. (0ms).
+2025-10-04 02:54:19.966 +07:00 [DBG] Opening connection to database 'capbot_db' on server 'localhost'.
+2025-10-04 02:54:19.966 +07:00 [DBG] Opened connection to database 'capbot_db' on server 'localhost'.
+2025-10-04 02:54:19.966 +07:00 [DBG] Creating DbCommand for 'ExecuteReader'.
+2025-10-04 02:54:19.966 +07:00 [DBG] Created DbCommand for 'ExecuteReader' (0ms).
+2025-10-04 02:54:19.966 +07:00 [DBG] Initialized DbCommand for 'ExecuteReader' (0ms).
+2025-10-04 02:54:19.967 +07:00 [DBG] Executing DbCommand [Parameters=[@__topicId_0='?' (DbType = Int32)], CommandType='"Text"', CommandTimeout='30']
+SELECT [t1].[Id], [t1].[Abbreviation], [t1].[CategoryId], [t1].[Content], [t1].[Context], [t1].[CreatedAt], [t1].[CreatedBy], [t1].[DeletedAt], [t1].[Description], [t1].[EN_Title], [t1].[IsActive], [t1].[IsApproved], [t1].[IsLegacy], [t1].[LastModifiedAt], [t1].[LastModifiedBy], [t1].[MaxStudents], [t1].[Objectives], [t1].[PotentialDuplicate], [t1].[Problem], [t1].[SemesterId], [t1].[SupervisorId], [t1].[VN_title], [t1].[Id0], [t1].[AccessFailedCount], [t1].[ConcurrencyStamp], [t1].[CreatedAt0], [t1].[DeletedAt0], [t1].[Email], [t1].[EmailConfirmed], [t1].[LastModifiedAt0], [t1].[LastModifiedBy0], [t1].[LockoutEnabled], [t1].[LockoutEnd], [t1].[NormalizedEmail], [t1].[NormalizedUserName], [t1].[PasswordHash], [t1].[PhoneNumber], [t1].[PhoneNumberConfirmed], [t1].[SecurityStamp], [t1].[TwoFactorEnabled], [t1].[UserName], [t1].[Id1], [t1].[CreatedAt1], [t1].[CreatedBy0], [t1].[DeletedAt1], [t1].[Description0], [t1].[IsActive0], [t1].[LastModifiedAt1], [t1].[LastModifiedBy1], [t1].[Name], [t1].[Id2], [t1].[CreatedAt2], [t1].[CreatedBy1], [t1].[DeletedAt2], [t1].[Description1], [t1].[EndDate], [t1].[IsActive1], [t1].[LastModifiedAt2], [t1].[LastModifiedBy2], [t1].[Name0], [t1].[StartDate], [t2].[Id], [t2].[Content], [t2].[Context], [t2].[CreatedAt], [t2].[CreatedBy], [t2].[DeletedAt], [t2].[Description], [t2].[DocumentUrl], [t2].[EN_Title], [t2].[ExpectedOutcomes], [t2].[IsActive], [t2].[LastModifiedAt], [t2].[LastModifiedBy], [t2].[Methodology], [t2].[Objectives], [t2].[PotentialDuplicate], [t2].[Problem], [t2].[Requirements], [t2].[Status], [t2].[SubmittedAt], [t2].[SubmittedBy], [t2].[TopicId], [t2].[VN_title], [t2].[VersionNumber]
+FROM (
+    SELECT TOP(1) [t].[Id], [t].[Abbreviation], [t].[CategoryId], [t].[Content], [t].[Context], [t].[CreatedAt], [t].[CreatedBy], [t].[DeletedAt], [t].[Description], [t].[EN_Title], [t].[IsActive], [t].[IsApproved], [t].[IsLegacy], [t].[LastModifiedAt], [t].[LastModifiedBy], [t].[MaxStudents], [t].[Objectives], [t].[PotentialDuplicate], [t].[Problem], [t].[SemesterId], [t].[SupervisorId], [t].[VN_title], [u].[Id] AS [Id0], [u].[AccessFailedCount], [u].[ConcurrencyStamp], [u].[CreatedAt] AS [CreatedAt0], [u].[DeletedAt] AS [DeletedAt0], [u].[Email], [u].[EmailConfirmed], [u].[LastModifiedAt] AS [LastModifiedAt0], [u].[LastModifiedBy] AS [LastModifiedBy0], [u].[LockoutEnabled], [u].[LockoutEnd], [u].[NormalizedEmail], [u].[NormalizedUserName], [u].[PasswordHash], [u].[PhoneNumber], [u].[PhoneNumberConfirmed], [u].[SecurityStamp], [u].[TwoFactorEnabled], [u].[UserName], [t0].[Id] AS [Id1], [t0].[CreatedAt] AS [CreatedAt1], [t0].[CreatedBy] AS [CreatedBy0], [t0].[DeletedAt] AS [DeletedAt1], [t0].[Description] AS [Description0], [t0].[IsActive] AS [IsActive0], [t0].[LastModifiedAt] AS [LastModifiedAt1], [t0].[LastModifiedBy] AS [LastModifiedBy1], [t0].[Name], [s].[Id] AS [Id2], [s].[CreatedAt] AS [CreatedAt2], [s].[CreatedBy] AS [CreatedBy1], [s].[DeletedAt] AS [DeletedAt2], [s].[Description] AS [Description1], [s].[EndDate], [s].[IsActive] AS [IsActive1], [s].[LastModifiedAt] AS [LastModifiedAt2], [s].[LastModifiedBy] AS [LastModifiedBy2], [s].[Name] AS [Name0], [s].[StartDate]
+    FROM [topics] AS [t]
+    INNER JOIN [users] AS [u] ON [t].[SupervisorId] = [u].[Id]
+    LEFT JOIN [topic_categories] AS [t0] ON [t].[CategoryId] = [t0].[Id]
+    INNER JOIN [semesters] AS [s] ON [t].[SemesterId] = [s].[Id]
+    WHERE [t].[Id] = @__topicId_0 AND [t].[IsActive] = CAST(1 AS bit) AND [t].[DeletedAt] IS NULL
+) AS [t1]
+LEFT JOIN [topic_versions] AS [t2] ON [t1].[Id] = [t2].[TopicId]
+ORDER BY [t1].[Id], [t1].[Id0], [t1].[Id1], [t1].[Id2]
+2025-10-04 02:54:19.982 +07:00 [INF] Executed DbCommand (16ms) [Parameters=[@__topicId_0='?' (DbType = Int32)], CommandType='"Text"', CommandTimeout='30']
+SELECT [t1].[Id], [t1].[Abbreviation], [t1].[CategoryId], [t1].[Content], [t1].[Context], [t1].[CreatedAt], [t1].[CreatedBy], [t1].[DeletedAt], [t1].[Description], [t1].[EN_Title], [t1].[IsActive], [t1].[IsApproved], [t1].[IsLegacy], [t1].[LastModifiedAt], [t1].[LastModifiedBy], [t1].[MaxStudents], [t1].[Objectives], [t1].[PotentialDuplicate], [t1].[Problem], [t1].[SemesterId], [t1].[SupervisorId], [t1].[VN_title], [t1].[Id0], [t1].[AccessFailedCount], [t1].[ConcurrencyStamp], [t1].[CreatedAt0], [t1].[DeletedAt0], [t1].[Email], [t1].[EmailConfirmed], [t1].[LastModifiedAt0], [t1].[LastModifiedBy0], [t1].[LockoutEnabled], [t1].[LockoutEnd], [t1].[NormalizedEmail], [t1].[NormalizedUserName], [t1].[PasswordHash], [t1].[PhoneNumber], [t1].[PhoneNumberConfirmed], [t1].[SecurityStamp], [t1].[TwoFactorEnabled], [t1].[UserName], [t1].[Id1], [t1].[CreatedAt1], [t1].[CreatedBy0], [t1].[DeletedAt1], [t1].[Description0], [t1].[IsActive0], [t1].[LastModifiedAt1], [t1].[LastModifiedBy1], [t1].[Name], [t1].[Id2], [t1].[CreatedAt2], [t1].[CreatedBy1], [t1].[DeletedAt2], [t1].[Description1], [t1].[EndDate], [t1].[IsActive1], [t1].[LastModifiedAt2], [t1].[LastModifiedBy2], [t1].[Name0], [t1].[StartDate], [t2].[Id], [t2].[Content], [t2].[Context], [t2].[CreatedAt], [t2].[CreatedBy], [t2].[DeletedAt], [t2].[Description], [t2].[DocumentUrl], [t2].[EN_Title], [t2].[ExpectedOutcomes], [t2].[IsActive], [t2].[LastModifiedAt], [t2].[LastModifiedBy], [t2].[Methodology], [t2].[Objectives], [t2].[PotentialDuplicate], [t2].[Problem], [t2].[Requirements], [t2].[Status], [t2].[SubmittedAt], [t2].[SubmittedBy], [t2].[TopicId], [t2].[VN_title], [t2].[VersionNumber]
+FROM (
+    SELECT TOP(1) [t].[Id], [t].[Abbreviation], [t].[CategoryId], [t].[Content], [t].[Context], [t].[CreatedAt], [t].[CreatedBy], [t].[DeletedAt], [t].[Description], [t].[EN_Title], [t].[IsActive], [t].[IsApproved], [t].[IsLegacy], [t].[LastModifiedAt], [t].[LastModifiedBy], [t].[MaxStudents], [t].[Objectives], [t].[PotentialDuplicate], [t].[Problem], [t].[SemesterId], [t].[SupervisorId], [t].[VN_title], [u].[Id] AS [Id0], [u].[AccessFailedCount], [u].[ConcurrencyStamp], [u].[CreatedAt] AS [CreatedAt0], [u].[DeletedAt] AS [DeletedAt0], [u].[Email], [u].[EmailConfirmed], [u].[LastModifiedAt] AS [LastModifiedAt0], [u].[LastModifiedBy] AS [LastModifiedBy0], [u].[LockoutEnabled], [u].[LockoutEnd], [u].[NormalizedEmail], [u].[NormalizedUserName], [u].[PasswordHash], [u].[PhoneNumber], [u].[PhoneNumberConfirmed], [u].[SecurityStamp], [u].[TwoFactorEnabled], [u].[UserName], [t0].[Id] AS [Id1], [t0].[CreatedAt] AS [CreatedAt1], [t0].[CreatedBy] AS [CreatedBy0], [t0].[DeletedAt] AS [DeletedAt1], [t0].[Description] AS [Description0], [t0].[IsActive] AS [IsActive0], [t0].[LastModifiedAt] AS [LastModifiedAt1], [t0].[LastModifiedBy] AS [LastModifiedBy1], [t0].[Name], [s].[Id] AS [Id2], [s].[CreatedAt] AS [CreatedAt2], [s].[CreatedBy] AS [CreatedBy1], [s].[DeletedAt] AS [DeletedAt2], [s].[Description] AS [Description1], [s].[EndDate], [s].[IsActive] AS [IsActive1], [s].[LastModifiedAt] AS [LastModifiedAt2], [s].[LastModifiedBy] AS [LastModifiedBy2], [s].[Name] AS [Name0], [s].[StartDate]
+    FROM [topics] AS [t]
+    INNER JOIN [users] AS [u] ON [t].[SupervisorId] = [u].[Id]
+    LEFT JOIN [topic_categories] AS [t0] ON [t].[CategoryId] = [t0].[Id]
+    INNER JOIN [semesters] AS [s] ON [t].[SemesterId] = [s].[Id]
+    WHERE [t].[Id] = @__topicId_0 AND [t].[IsActive] = CAST(1 AS bit) AND [t].[DeletedAt] IS NULL
+) AS [t1]
+LEFT JOIN [topic_versions] AS [t2] ON [t1].[Id] = [t2].[TopicId]
+ORDER BY [t1].[Id], [t1].[Id0], [t1].[Id1], [t1].[Id2]
+2025-10-04 02:54:19.982 +07:00 [DBG] Closing data reader to 'capbot_db' on server 'localhost'.
+2025-10-04 02:54:19.983 +07:00 [DBG] A data reader for 'capbot_db' on server 'localhost' is being disposed after spending 0ms reading results.
+2025-10-04 02:54:19.983 +07:00 [DBG] Closing connection to database 'capbot_db' on server 'localhost'.
+2025-10-04 02:54:19.983 +07:00 [DBG] Closed connection to database 'capbot_db' on server 'localhost' (0ms).
+2025-10-04 02:54:19.986 +07:00 [DBG] Opening connection to database 'capbot_db' on server 'localhost'.
+2025-10-04 02:54:19.986 +07:00 [DBG] Opened connection to database 'capbot_db' on server 'localhost'.
+2025-10-04 02:54:19.986 +07:00 [DBG] Creating DbCommand for 'ExecuteReader'.
+2025-10-04 02:54:19.986 +07:00 [DBG] Created DbCommand for 'ExecuteReader' (0ms).
+2025-10-04 02:54:19.987 +07:00 [DBG] Initialized DbCommand for 'ExecuteReader' (0ms).
+2025-10-04 02:54:19.987 +07:00 [DBG] Executing DbCommand [Parameters=[@__topicId_0='?' (DbType = Int32)], CommandType='"Text"', CommandTimeout='30']
+SELECT [s].[Id], [s].[AdditionalNotes], [s].[AiCheckDetails], [s].[AiCheckScore], [s].[AiCheckStatus], [s].[CreatedAt], [s].[CreatedBy], [s].[DeletedAt], [s].[DocumentUrl], [s].[IsActive], [s].[LastModifiedAt], [s].[LastModifiedBy], [s].[PhaseId], [s].[Status], [s].[SubmissionRound], [s].[SubmittedAt], [s].[SubmittedBy], [s].[TopicId], [s].[TopicVersionId], [p].[Id], [p].[CreatedAt], [p].[CreatedBy], [p].[DeletedAt], [p].[EndDate], [p].[IsActive], [p].[LastModifiedAt], [p].[LastModifiedBy], [p].[Name], [p].[PhaseTypeId], [p].[SemesterId], [p].[StartDate], [p].[SubmissionDeadline], [u].[Id], [u].[AccessFailedCount], [u].[ConcurrencyStamp], [u].[CreatedAt], [u].[DeletedAt], [u].[Email], [u].[EmailConfirmed], [u].[LastModifiedAt], [u].[LastModifiedBy], [u].[LockoutEnabled], [u].[LockoutEnd], [u].[NormalizedEmail], [u].[NormalizedUserName], [u].[PasswordHash], [u].[PhoneNumber], [u].[PhoneNumberConfirmed], [u].[SecurityStamp], [u].[TwoFactorEnabled], [u].[UserName], [r].[Id], [r].[AssignedAt], [r].[AssignedBy], [r].[AssignmentType], [r].[CompletedAt], [r].[Deadline], [r].[ReviewerId], [r].[SkillMatchScore], [r].[StartedAt], [r].[Status], [r].[SubmissionId]
+FROM [submissions] AS [s]
+INNER JOIN [phases] AS [p] ON [s].[PhaseId] = [p].[Id]
+INNER JOIN [users] AS [u] ON [s].[SubmittedBy] = [u].[Id]
+LEFT JOIN [reviewer_assignments] AS [r] ON [s].[Id] = [r].[SubmissionId]
+WHERE [s].[TopicId] = @__topicId_0 AND [s].[IsActive] = CAST(1 AS bit) AND [s].[DeletedAt] IS NULL
+ORDER BY [s].[Id], [p].[Id], [u].[Id]
+2025-10-04 02:54:19.999 +07:00 [INF] Executed DbCommand (12ms) [Parameters=[@__topicId_0='?' (DbType = Int32)], CommandType='"Text"', CommandTimeout='30']
+SELECT [s].[Id], [s].[AdditionalNotes], [s].[AiCheckDetails], [s].[AiCheckScore], [s].[AiCheckStatus], [s].[CreatedAt], [s].[CreatedBy], [s].[DeletedAt], [s].[DocumentUrl], [s].[IsActive], [s].[LastModifiedAt], [s].[LastModifiedBy], [s].[PhaseId], [s].[Status], [s].[SubmissionRound], [s].[SubmittedAt], [s].[SubmittedBy], [s].[TopicId], [s].[TopicVersionId], [p].[Id], [p].[CreatedAt], [p].[CreatedBy], [p].[DeletedAt], [p].[EndDate], [p].[IsActive], [p].[LastModifiedAt], [p].[LastModifiedBy], [p].[Name], [p].[PhaseTypeId], [p].[SemesterId], [p].[StartDate], [p].[SubmissionDeadline], [u].[Id], [u].[AccessFailedCount], [u].[ConcurrencyStamp], [u].[CreatedAt], [u].[DeletedAt], [u].[Email], [u].[EmailConfirmed], [u].[LastModifiedAt], [u].[LastModifiedBy], [u].[LockoutEnabled], [u].[LockoutEnd], [u].[NormalizedEmail], [u].[NormalizedUserName], [u].[PasswordHash], [u].[PhoneNumber], [u].[PhoneNumberConfirmed], [u].[SecurityStamp], [u].[TwoFactorEnabled], [u].[UserName], [r].[Id], [r].[AssignedAt], [r].[AssignedBy], [r].[AssignmentType], [r].[CompletedAt], [r].[Deadline], [r].[ReviewerId], [r].[SkillMatchScore], [r].[StartedAt], [r].[Status], [r].[SubmissionId]
+FROM [submissions] AS [s]
+INNER JOIN [phases] AS [p] ON [s].[PhaseId] = [p].[Id]
+INNER JOIN [users] AS [u] ON [s].[SubmittedBy] = [u].[Id]
+LEFT JOIN [reviewer_assignments] AS [r] ON [s].[Id] = [r].[SubmissionId]
+WHERE [s].[TopicId] = @__topicId_0 AND [s].[IsActive] = CAST(1 AS bit) AND [s].[DeletedAt] IS NULL
+ORDER BY [s].[Id], [p].[Id], [u].[Id]
+2025-10-04 02:54:20.000 +07:00 [DBG] Closing data reader to 'capbot_db' on server 'localhost'.
+2025-10-04 02:54:20.000 +07:00 [DBG] A data reader for 'capbot_db' on server 'localhost' is being disposed after spending 0ms reading results.
+2025-10-04 02:54:20.000 +07:00 [DBG] Closing connection to database 'capbot_db' on server 'localhost'.
+2025-10-04 02:54:20.000 +07:00 [DBG] Closed connection to database 'capbot_db' on server 'localhost' (0ms).
+2025-10-04 02:54:20.005 +07:00 [DBG] Opening connection to database 'capbot_db' on server 'localhost'.
+2025-10-04 02:54:20.005 +07:00 [DBG] Opened connection to database 'capbot_db' on server 'localhost'.
+2025-10-04 02:54:20.005 +07:00 [DBG] Creating DbCommand for 'ExecuteReader'.
+2025-10-04 02:54:20.006 +07:00 [DBG] Created DbCommand for 'ExecuteReader' (0ms).
+2025-10-04 02:54:20.006 +07:00 [DBG] Initialized DbCommand for 'ExecuteReader' (0ms).
+2025-10-04 02:54:20.006 +07:00 [DBG] Executing DbCommand [Parameters=[@__p_0='?' (DbType = Int64)], CommandType='"Text"', CommandTimeout='30']
+SELECT TOP(1) [e].[Id], [e].[Caption], [e].[CreatedAt], [e].[EntityId], [e].[EntityType], [e].[FileId], [e].[IsPrimary], [f].[Id], [f].[Alt], [f].[Checksum], [f].[CreatedAt], [f].[CreatedBy], [f].[DeletedAt], [f].[FileName], [f].[FilePath], [f].[FileSize], [f].[FileType], [f].[Height], [f].[IsActive], [f].[LastModifiedAt], [f].[LastModifiedBy], [f].[MimeType], [f].[ThumbnailUrl], [f].[Url], [f].[Width]
+FROM [entity_files] AS [e]
+INNER JOIN [files] AS [f] ON [e].[FileId] = [f].[Id]
+WHERE [e].[EntityId] = @__p_0 AND [e].[EntityType] = 1 AND [e].[IsPrimary] = CAST(1 AS bit)
+2025-10-04 02:54:20.011 +07:00 [INF] Executed DbCommand (5ms) [Parameters=[@__p_0='?' (DbType = Int64)], CommandType='"Text"', CommandTimeout='30']
+SELECT TOP(1) [e].[Id], [e].[Caption], [e].[CreatedAt], [e].[EntityId], [e].[EntityType], [e].[FileId], [e].[IsPrimary], [f].[Id], [f].[Alt], [f].[Checksum], [f].[CreatedAt], [f].[CreatedBy], [f].[DeletedAt], [f].[FileName], [f].[FilePath], [f].[FileSize], [f].[FileType], [f].[Height], [f].[IsActive], [f].[LastModifiedAt], [f].[LastModifiedBy], [f].[MimeType], [f].[ThumbnailUrl], [f].[Url], [f].[Width]
+FROM [entity_files] AS [e]
+INNER JOIN [files] AS [f] ON [e].[FileId] = [f].[Id]
+WHERE [e].[EntityId] = @__p_0 AND [e].[EntityType] = 1 AND [e].[IsPrimary] = CAST(1 AS bit)
+2025-10-04 02:54:20.011 +07:00 [DBG] Closing data reader to 'capbot_db' on server 'localhost'.
+2025-10-04 02:54:20.011 +07:00 [DBG] A data reader for 'capbot_db' on server 'localhost' is being disposed after spending 0ms reading results.
+2025-10-04 02:54:20.012 +07:00 [DBG] Closing connection to database 'capbot_db' on server 'localhost'.
+2025-10-04 02:54:20.012 +07:00 [DBG] Closed connection to database 'capbot_db' on server 'localhost' (0ms).
+2025-10-04 02:54:20.012 +07:00 [DBG] List of registered output formatters, in the following order: ["Microsoft.AspNetCore.OData.Formatter.ODataOutputFormatter","Microsoft.AspNetCore.OData.Formatter.ODataOutputFormatter","Microsoft.AspNetCore.OData.Formatter.ODataOutputFormatter","Microsoft.AspNetCore.Mvc.Formatters.HttpNoContentOutputFormatter","Microsoft.AspNetCore.Mvc.Formatters.StringOutputFormatter","Microsoft.AspNetCore.Mvc.Formatters.StreamOutputFormatter","Microsoft.AspNetCore.Mvc.Formatters.SystemTextJsonOutputFormatter"]
+2025-10-04 02:54:20.012 +07:00 [DBG] No information found on request to perform content negotiation.
+2025-10-04 02:54:20.012 +07:00 [DBG] Attempting to select the first output formatter in the output formatters list which supports a content type from the explicitly specified content types '["application/json"]'.
+2025-10-04 02:54:20.012 +07:00 [DBG] Selected output formatter 'Microsoft.AspNetCore.Mvc.Formatters.SystemTextJsonOutputFormatter' and content type 'application/json' to write the response.
+2025-10-04 02:54:20.012 +07:00 [INF] Executing ObjectResult, writing value of type 'FS.Commons.FSResponse'.
+2025-10-04 02:54:20.013 +07:00 [INF] Executed action CapBot.api.Controllers.TopicController.GetDetail (CapBot.api) in 81.8689ms
+2025-10-04 02:54:20.013 +07:00 [INF] Executed endpoint 'CapBot.api.Controllers.TopicController.GetDetail (CapBot.api)'
+2025-10-04 02:54:20.013 +07:00 [DBG] Connection id "0HNG2MQC634J8" completed keep alive response.
+2025-10-04 02:54:20.013 +07:00 [DBG] 'MyDbContext' disposed.
+2025-10-04 02:54:20.013 +07:00 [DBG] Disposing connection to database 'capbot_db' on server 'localhost'.
+2025-10-04 02:54:20.013 +07:00 [DBG] Disposed connection to database '' on server '' (0ms).
+2025-10-04 02:54:20.014 +07:00 [INF] Request finished HTTP/1.1 GET http://localhost:5207/api/topic/detail/104 - 200 null application/json; charset=utf-8 92.5697ms
+2025-10-04 02:54:20.402 +07:00 [INF] Request starting HTTP/1.1 GET http://localhost:5207/api/topic/detail/104 - null null
+2025-10-04 02:54:20.403 +07:00 [DBG] The request path /api/topic/detail/104 does not match a supported file type
+2025-10-04 02:54:20.403 +07:00 [DBG] The request path /api/topic/detail/104 does not match a supported file type
+2025-10-04 02:54:20.404 +07:00 [DBG] 1 candidate(s) found for the request path '/api/topic/detail/104'
+2025-10-04 02:54:20.404 +07:00 [DBG] Endpoint 'CapBot.api.Controllers.TopicController.GetDetail (CapBot.api)' with route pattern 'api/topic/detail/{topicId}' is valid for the request path '/api/topic/detail/104'
+2025-10-04 02:54:20.404 +07:00 [DBG] Request matched endpoint 'CapBot.api.Controllers.TopicController.GetDetail (CapBot.api)'
+2025-10-04 02:54:20.404 +07:00 [DBG] Successfully validated the token.
+2025-10-04 02:54:20.405 +07:00 [DBG] AuthenticationScheme: Bearer was successfully authenticated.
+2025-10-04 02:54:20.405 +07:00 [INF] Executing endpoint 'CapBot.api.Controllers.TopicController.GetDetail (CapBot.api)'
+2025-10-04 02:54:20.405 +07:00 [INF] Route matched with {action = "GetDetail", controller = "Topic"}. Executing controller action with signature System.Threading.Tasks.Task`1[Microsoft.AspNetCore.Mvc.IActionResult] GetDetail(Int32) on controller CapBot.api.Controllers.TopicController (CapBot.api).
+2025-10-04 02:54:20.406 +07:00 [DBG] Execution plan of authorization filters (in the following order): ["None"]
+2025-10-04 02:54:20.406 +07:00 [DBG] Execution plan of resource filters (in the following order): ["Microsoft.AspNetCore.Mvc.ConsumesAttribute"]
+2025-10-04 02:54:20.406 +07:00 [DBG] Execution plan of action filters (in the following order): ["Microsoft.AspNetCore.Mvc.ModelBinding.UnsupportedContentTypeFilter (Order: -3000)"]
+2025-10-04 02:54:20.406 +07:00 [DBG] Execution plan of exception filters (in the following order): ["None"]
+2025-10-04 02:54:20.406 +07:00 [DBG] Execution plan of result filters (in the following order): ["Microsoft.AspNetCore.Mvc.Infrastructure.ClientErrorResultFilter (Order: -2000)","Microsoft.AspNetCore.Mvc.ProducesAttribute (Order: 0)"]
+2025-10-04 02:54:20.406 +07:00 [DBG] Executing controller factory for controller CapBot.api.Controllers.TopicController (CapBot.api)
+2025-10-04 02:54:20.407 +07:00 [DBG] Executed controller factory for controller CapBot.api.Controllers.TopicController (CapBot.api)
+2025-10-04 02:54:20.407 +07:00 [DBG] Attempting to bind parameter 'topicId' of type 'System.Int32' ...
+2025-10-04 02:54:20.407 +07:00 [DBG] Attempting to bind parameter 'topicId' of type 'System.Int32' using the name 'topicId' in request data ...
+2025-10-04 02:54:20.408 +07:00 [DBG] Done attempting to bind parameter 'topicId' of type 'System.Int32'.
+2025-10-04 02:54:20.408 +07:00 [DBG] Done attempting to bind parameter 'topicId' of type 'System.Int32'.
+2025-10-04 02:54:20.408 +07:00 [DBG] Attempting to validate the bound parameter 'topicId' of type 'System.Int32' ...
+2025-10-04 02:54:20.408 +07:00 [DBG] Done attempting to validate the bound parameter 'topicId' of type 'System.Int32'.
+2025-10-04 02:54:20.409 +07:00 [DBG] Entity Framework Core 8.0.16 initialized 'MyDbContext' using provider 'Microsoft.EntityFrameworkCore.SqlServer:8.0.13' with options: MigrationsAssembly=App.DAL 
+2025-10-04 02:54:20.410 +07:00 [DBG] Creating DbConnection.
+2025-10-04 02:54:20.410 +07:00 [DBG] Created DbConnection. (0ms).
+2025-10-04 02:54:20.410 +07:00 [DBG] Opening connection to database 'capbot_db' on server 'localhost'.
+2025-10-04 02:54:20.410 +07:00 [DBG] Opened connection to database 'capbot_db' on server 'localhost'.
+2025-10-04 02:54:20.410 +07:00 [DBG] Creating DbCommand for 'ExecuteReader'.
+2025-10-04 02:54:20.411 +07:00 [DBG] Created DbCommand for 'ExecuteReader' (0ms).
+2025-10-04 02:54:20.411 +07:00 [DBG] Initialized DbCommand for 'ExecuteReader' (0ms).
+2025-10-04 02:54:20.411 +07:00 [DBG] Executing DbCommand [Parameters=[@__topicId_0='?' (DbType = Int32)], CommandType='"Text"', CommandTimeout='30']
+SELECT [t1].[Id], [t1].[Abbreviation], [t1].[CategoryId], [t1].[Content], [t1].[Context], [t1].[CreatedAt], [t1].[CreatedBy], [t1].[DeletedAt], [t1].[Description], [t1].[EN_Title], [t1].[IsActive], [t1].[IsApproved], [t1].[IsLegacy], [t1].[LastModifiedAt], [t1].[LastModifiedBy], [t1].[MaxStudents], [t1].[Objectives], [t1].[PotentialDuplicate], [t1].[Problem], [t1].[SemesterId], [t1].[SupervisorId], [t1].[VN_title], [t1].[Id0], [t1].[AccessFailedCount], [t1].[ConcurrencyStamp], [t1].[CreatedAt0], [t1].[DeletedAt0], [t1].[Email], [t1].[EmailConfirmed], [t1].[LastModifiedAt0], [t1].[LastModifiedBy0], [t1].[LockoutEnabled], [t1].[LockoutEnd], [t1].[NormalizedEmail], [t1].[NormalizedUserName], [t1].[PasswordHash], [t1].[PhoneNumber], [t1].[PhoneNumberConfirmed], [t1].[SecurityStamp], [t1].[TwoFactorEnabled], [t1].[UserName], [t1].[Id1], [t1].[CreatedAt1], [t1].[CreatedBy0], [t1].[DeletedAt1], [t1].[Description0], [t1].[IsActive0], [t1].[LastModifiedAt1], [t1].[LastModifiedBy1], [t1].[Name], [t1].[Id2], [t1].[CreatedAt2], [t1].[CreatedBy1], [t1].[DeletedAt2], [t1].[Description1], [t1].[EndDate], [t1].[IsActive1], [t1].[LastModifiedAt2], [t1].[LastModifiedBy2], [t1].[Name0], [t1].[StartDate], [t2].[Id], [t2].[Content], [t2].[Context], [t2].[CreatedAt], [t2].[CreatedBy], [t2].[DeletedAt], [t2].[Description], [t2].[DocumentUrl], [t2].[EN_Title], [t2].[ExpectedOutcomes], [t2].[IsActive], [t2].[LastModifiedAt], [t2].[LastModifiedBy], [t2].[Methodology], [t2].[Objectives], [t2].[PotentialDuplicate], [t2].[Problem], [t2].[Requirements], [t2].[Status], [t2].[SubmittedAt], [t2].[SubmittedBy], [t2].[TopicId], [t2].[VN_title], [t2].[VersionNumber]
+FROM (
+    SELECT TOP(1) [t].[Id], [t].[Abbreviation], [t].[CategoryId], [t].[Content], [t].[Context], [t].[CreatedAt], [t].[CreatedBy], [t].[DeletedAt], [t].[Description], [t].[EN_Title], [t].[IsActive], [t].[IsApproved], [t].[IsLegacy], [t].[LastModifiedAt], [t].[LastModifiedBy], [t].[MaxStudents], [t].[Objectives], [t].[PotentialDuplicate], [t].[Problem], [t].[SemesterId], [t].[SupervisorId], [t].[VN_title], [u].[Id] AS [Id0], [u].[AccessFailedCount], [u].[ConcurrencyStamp], [u].[CreatedAt] AS [CreatedAt0], [u].[DeletedAt] AS [DeletedAt0], [u].[Email], [u].[EmailConfirmed], [u].[LastModifiedAt] AS [LastModifiedAt0], [u].[LastModifiedBy] AS [LastModifiedBy0], [u].[LockoutEnabled], [u].[LockoutEnd], [u].[NormalizedEmail], [u].[NormalizedUserName], [u].[PasswordHash], [u].[PhoneNumber], [u].[PhoneNumberConfirmed], [u].[SecurityStamp], [u].[TwoFactorEnabled], [u].[UserName], [t0].[Id] AS [Id1], [t0].[CreatedAt] AS [CreatedAt1], [t0].[CreatedBy] AS [CreatedBy0], [t0].[DeletedAt] AS [DeletedAt1], [t0].[Description] AS [Description0], [t0].[IsActive] AS [IsActive0], [t0].[LastModifiedAt] AS [LastModifiedAt1], [t0].[LastModifiedBy] AS [LastModifiedBy1], [t0].[Name], [s].[Id] AS [Id2], [s].[CreatedAt] AS [CreatedAt2], [s].[CreatedBy] AS [CreatedBy1], [s].[DeletedAt] AS [DeletedAt2], [s].[Description] AS [Description1], [s].[EndDate], [s].[IsActive] AS [IsActive1], [s].[LastModifiedAt] AS [LastModifiedAt2], [s].[LastModifiedBy] AS [LastModifiedBy2], [s].[Name] AS [Name0], [s].[StartDate]
+    FROM [topics] AS [t]
+    INNER JOIN [users] AS [u] ON [t].[SupervisorId] = [u].[Id]
+    LEFT JOIN [topic_categories] AS [t0] ON [t].[CategoryId] = [t0].[Id]
+    INNER JOIN [semesters] AS [s] ON [t].[SemesterId] = [s].[Id]
+    WHERE [t].[Id] = @__topicId_0 AND [t].[IsActive] = CAST(1 AS bit) AND [t].[DeletedAt] IS NULL
+) AS [t1]
+LEFT JOIN [topic_versions] AS [t2] ON [t1].[Id] = [t2].[TopicId]
+ORDER BY [t1].[Id], [t1].[Id0], [t1].[Id1], [t1].[Id2]
+2025-10-04 02:54:20.432 +07:00 [INF] Executed DbCommand (22ms) [Parameters=[@__topicId_0='?' (DbType = Int32)], CommandType='"Text"', CommandTimeout='30']
+SELECT [t1].[Id], [t1].[Abbreviation], [t1].[CategoryId], [t1].[Content], [t1].[Context], [t1].[CreatedAt], [t1].[CreatedBy], [t1].[DeletedAt], [t1].[Description], [t1].[EN_Title], [t1].[IsActive], [t1].[IsApproved], [t1].[IsLegacy], [t1].[LastModifiedAt], [t1].[LastModifiedBy], [t1].[MaxStudents], [t1].[Objectives], [t1].[PotentialDuplicate], [t1].[Problem], [t1].[SemesterId], [t1].[SupervisorId], [t1].[VN_title], [t1].[Id0], [t1].[AccessFailedCount], [t1].[ConcurrencyStamp], [t1].[CreatedAt0], [t1].[DeletedAt0], [t1].[Email], [t1].[EmailConfirmed], [t1].[LastModifiedAt0], [t1].[LastModifiedBy0], [t1].[LockoutEnabled], [t1].[LockoutEnd], [t1].[NormalizedEmail], [t1].[NormalizedUserName], [t1].[PasswordHash], [t1].[PhoneNumber], [t1].[PhoneNumberConfirmed], [t1].[SecurityStamp], [t1].[TwoFactorEnabled], [t1].[UserName], [t1].[Id1], [t1].[CreatedAt1], [t1].[CreatedBy0], [t1].[DeletedAt1], [t1].[Description0], [t1].[IsActive0], [t1].[LastModifiedAt1], [t1].[LastModifiedBy1], [t1].[Name], [t1].[Id2], [t1].[CreatedAt2], [t1].[CreatedBy1], [t1].[DeletedAt2], [t1].[Description1], [t1].[EndDate], [t1].[IsActive1], [t1].[LastModifiedAt2], [t1].[LastModifiedBy2], [t1].[Name0], [t1].[StartDate], [t2].[Id], [t2].[Content], [t2].[Context], [t2].[CreatedAt], [t2].[CreatedBy], [t2].[DeletedAt], [t2].[Description], [t2].[DocumentUrl], [t2].[EN_Title], [t2].[ExpectedOutcomes], [t2].[IsActive], [t2].[LastModifiedAt], [t2].[LastModifiedBy], [t2].[Methodology], [t2].[Objectives], [t2].[PotentialDuplicate], [t2].[Problem], [t2].[Requirements], [t2].[Status], [t2].[SubmittedAt], [t2].[SubmittedBy], [t2].[TopicId], [t2].[VN_title], [t2].[VersionNumber]
+FROM (
+    SELECT TOP(1) [t].[Id], [t].[Abbreviation], [t].[CategoryId], [t].[Content], [t].[Context], [t].[CreatedAt], [t].[CreatedBy], [t].[DeletedAt], [t].[Description], [t].[EN_Title], [t].[IsActive], [t].[IsApproved], [t].[IsLegacy], [t].[LastModifiedAt], [t].[LastModifiedBy], [t].[MaxStudents], [t].[Objectives], [t].[PotentialDuplicate], [t].[Problem], [t].[SemesterId], [t].[SupervisorId], [t].[VN_title], [u].[Id] AS [Id0], [u].[AccessFailedCount], [u].[ConcurrencyStamp], [u].[CreatedAt] AS [CreatedAt0], [u].[DeletedAt] AS [DeletedAt0], [u].[Email], [u].[EmailConfirmed], [u].[LastModifiedAt] AS [LastModifiedAt0], [u].[LastModifiedBy] AS [LastModifiedBy0], [u].[LockoutEnabled], [u].[LockoutEnd], [u].[NormalizedEmail], [u].[NormalizedUserName], [u].[PasswordHash], [u].[PhoneNumber], [u].[PhoneNumberConfirmed], [u].[SecurityStamp], [u].[TwoFactorEnabled], [u].[UserName], [t0].[Id] AS [Id1], [t0].[CreatedAt] AS [CreatedAt1], [t0].[CreatedBy] AS [CreatedBy0], [t0].[DeletedAt] AS [DeletedAt1], [t0].[Description] AS [Description0], [t0].[IsActive] AS [IsActive0], [t0].[LastModifiedAt] AS [LastModifiedAt1], [t0].[LastModifiedBy] AS [LastModifiedBy1], [t0].[Name], [s].[Id] AS [Id2], [s].[CreatedAt] AS [CreatedAt2], [s].[CreatedBy] AS [CreatedBy1], [s].[DeletedAt] AS [DeletedAt2], [s].[Description] AS [Description1], [s].[EndDate], [s].[IsActive] AS [IsActive1], [s].[LastModifiedAt] AS [LastModifiedAt2], [s].[LastModifiedBy] AS [LastModifiedBy2], [s].[Name] AS [Name0], [s].[StartDate]
+    FROM [topics] AS [t]
+    INNER JOIN [users] AS [u] ON [t].[SupervisorId] = [u].[Id]
+    LEFT JOIN [topic_categories] AS [t0] ON [t].[CategoryId] = [t0].[Id]
+    INNER JOIN [semesters] AS [s] ON [t].[SemesterId] = [s].[Id]
+    WHERE [t].[Id] = @__topicId_0 AND [t].[IsActive] = CAST(1 AS bit) AND [t].[DeletedAt] IS NULL
+) AS [t1]
+LEFT JOIN [topic_versions] AS [t2] ON [t1].[Id] = [t2].[TopicId]
+ORDER BY [t1].[Id], [t1].[Id0], [t1].[Id1], [t1].[Id2]
+2025-10-04 02:54:20.433 +07:00 [DBG] Closing data reader to 'capbot_db' on server 'localhost'.
+2025-10-04 02:54:20.433 +07:00 [DBG] A data reader for 'capbot_db' on server 'localhost' is being disposed after spending 0ms reading results.
+2025-10-04 02:54:20.433 +07:00 [DBG] Closing connection to database 'capbot_db' on server 'localhost'.
+2025-10-04 02:54:20.433 +07:00 [DBG] Closed connection to database 'capbot_db' on server 'localhost' (0ms).
+2025-10-04 02:54:20.434 +07:00 [DBG] Opening connection to database 'capbot_db' on server 'localhost'.
+2025-10-04 02:54:20.436 +07:00 [DBG] Opened connection to database 'capbot_db' on server 'localhost'.
+2025-10-04 02:54:20.437 +07:00 [DBG] Creating DbCommand for 'ExecuteReader'.
+2025-10-04 02:54:20.437 +07:00 [DBG] Created DbCommand for 'ExecuteReader' (0ms).
+2025-10-04 02:54:20.437 +07:00 [DBG] Initialized DbCommand for 'ExecuteReader' (0ms).
+2025-10-04 02:54:20.437 +07:00 [DBG] Executing DbCommand [Parameters=[@__topicId_0='?' (DbType = Int32)], CommandType='"Text"', CommandTimeout='30']
+SELECT [s].[Id], [s].[AdditionalNotes], [s].[AiCheckDetails], [s].[AiCheckScore], [s].[AiCheckStatus], [s].[CreatedAt], [s].[CreatedBy], [s].[DeletedAt], [s].[DocumentUrl], [s].[IsActive], [s].[LastModifiedAt], [s].[LastModifiedBy], [s].[PhaseId], [s].[Status], [s].[SubmissionRound], [s].[SubmittedAt], [s].[SubmittedBy], [s].[TopicId], [s].[TopicVersionId], [p].[Id], [p].[CreatedAt], [p].[CreatedBy], [p].[DeletedAt], [p].[EndDate], [p].[IsActive], [p].[LastModifiedAt], [p].[LastModifiedBy], [p].[Name], [p].[PhaseTypeId], [p].[SemesterId], [p].[StartDate], [p].[SubmissionDeadline], [u].[Id], [u].[AccessFailedCount], [u].[ConcurrencyStamp], [u].[CreatedAt], [u].[DeletedAt], [u].[Email], [u].[EmailConfirmed], [u].[LastModifiedAt], [u].[LastModifiedBy], [u].[LockoutEnabled], [u].[LockoutEnd], [u].[NormalizedEmail], [u].[NormalizedUserName], [u].[PasswordHash], [u].[PhoneNumber], [u].[PhoneNumberConfirmed], [u].[SecurityStamp], [u].[TwoFactorEnabled], [u].[UserName], [r].[Id], [r].[AssignedAt], [r].[AssignedBy], [r].[AssignmentType], [r].[CompletedAt], [r].[Deadline], [r].[ReviewerId], [r].[SkillMatchScore], [r].[StartedAt], [r].[Status], [r].[SubmissionId]
+FROM [submissions] AS [s]
+INNER JOIN [phases] AS [p] ON [s].[PhaseId] = [p].[Id]
+INNER JOIN [users] AS [u] ON [s].[SubmittedBy] = [u].[Id]
+LEFT JOIN [reviewer_assignments] AS [r] ON [s].[Id] = [r].[SubmissionId]
+WHERE [s].[TopicId] = @__topicId_0 AND [s].[IsActive] = CAST(1 AS bit) AND [s].[DeletedAt] IS NULL
+ORDER BY [s].[Id], [p].[Id], [u].[Id]
+2025-10-04 02:54:20.454 +07:00 [INF] Executed DbCommand (17ms) [Parameters=[@__topicId_0='?' (DbType = Int32)], CommandType='"Text"', CommandTimeout='30']
+SELECT [s].[Id], [s].[AdditionalNotes], [s].[AiCheckDetails], [s].[AiCheckScore], [s].[AiCheckStatus], [s].[CreatedAt], [s].[CreatedBy], [s].[DeletedAt], [s].[DocumentUrl], [s].[IsActive], [s].[LastModifiedAt], [s].[LastModifiedBy], [s].[PhaseId], [s].[Status], [s].[SubmissionRound], [s].[SubmittedAt], [s].[SubmittedBy], [s].[TopicId], [s].[TopicVersionId], [p].[Id], [p].[CreatedAt], [p].[CreatedBy], [p].[DeletedAt], [p].[EndDate], [p].[IsActive], [p].[LastModifiedAt], [p].[LastModifiedBy], [p].[Name], [p].[PhaseTypeId], [p].[SemesterId], [p].[StartDate], [p].[SubmissionDeadline], [u].[Id], [u].[AccessFailedCount], [u].[ConcurrencyStamp], [u].[CreatedAt], [u].[DeletedAt], [u].[Email], [u].[EmailConfirmed], [u].[LastModifiedAt], [u].[LastModifiedBy], [u].[LockoutEnabled], [u].[LockoutEnd], [u].[NormalizedEmail], [u].[NormalizedUserName], [u].[PasswordHash], [u].[PhoneNumber], [u].[PhoneNumberConfirmed], [u].[SecurityStamp], [u].[TwoFactorEnabled], [u].[UserName], [r].[Id], [r].[AssignedAt], [r].[AssignedBy], [r].[AssignmentType], [r].[CompletedAt], [r].[Deadline], [r].[ReviewerId], [r].[SkillMatchScore], [r].[StartedAt], [r].[Status], [r].[SubmissionId]
+FROM [submissions] AS [s]
+INNER JOIN [phases] AS [p] ON [s].[PhaseId] = [p].[Id]
+INNER JOIN [users] AS [u] ON [s].[SubmittedBy] = [u].[Id]
+LEFT JOIN [reviewer_assignments] AS [r] ON [s].[Id] = [r].[SubmissionId]
+WHERE [s].[TopicId] = @__topicId_0 AND [s].[IsActive] = CAST(1 AS bit) AND [s].[DeletedAt] IS NULL
+ORDER BY [s].[Id], [p].[Id], [u].[Id]
+2025-10-04 02:54:20.455 +07:00 [DBG] Closing data reader to 'capbot_db' on server 'localhost'.
+2025-10-04 02:54:20.456 +07:00 [DBG] A data reader for 'capbot_db' on server 'localhost' is being disposed after spending 0ms reading results.
+2025-10-04 02:54:20.456 +07:00 [DBG] Closing connection to database 'capbot_db' on server 'localhost'.
+2025-10-04 02:54:20.456 +07:00 [DBG] Closed connection to database 'capbot_db' on server 'localhost' (0ms).
+2025-10-04 02:54:20.457 +07:00 [DBG] Opening connection to database 'capbot_db' on server 'localhost'.
+2025-10-04 02:54:20.457 +07:00 [DBG] Opened connection to database 'capbot_db' on server 'localhost'.
+2025-10-04 02:54:20.457 +07:00 [DBG] Creating DbCommand for 'ExecuteReader'.
+2025-10-04 02:54:20.457 +07:00 [DBG] Created DbCommand for 'ExecuteReader' (0ms).
+2025-10-04 02:54:20.457 +07:00 [DBG] Initialized DbCommand for 'ExecuteReader' (0ms).
+2025-10-04 02:54:20.458 +07:00 [DBG] Executing DbCommand [Parameters=[@__p_0='?' (DbType = Int64)], CommandType='"Text"', CommandTimeout='30']
+SELECT TOP(1) [e].[Id], [e].[Caption], [e].[CreatedAt], [e].[EntityId], [e].[EntityType], [e].[FileId], [e].[IsPrimary], [f].[Id], [f].[Alt], [f].[Checksum], [f].[CreatedAt], [f].[CreatedBy], [f].[DeletedAt], [f].[FileName], [f].[FilePath], [f].[FileSize], [f].[FileType], [f].[Height], [f].[IsActive], [f].[LastModifiedAt], [f].[LastModifiedBy], [f].[MimeType], [f].[ThumbnailUrl], [f].[Url], [f].[Width]
+FROM [entity_files] AS [e]
+INNER JOIN [files] AS [f] ON [e].[FileId] = [f].[Id]
+WHERE [e].[EntityId] = @__p_0 AND [e].[EntityType] = 1 AND [e].[IsPrimary] = CAST(1 AS bit)
+2025-10-04 02:54:20.465 +07:00 [INF] Executed DbCommand (7ms) [Parameters=[@__p_0='?' (DbType = Int64)], CommandType='"Text"', CommandTimeout='30']
+SELECT TOP(1) [e].[Id], [e].[Caption], [e].[CreatedAt], [e].[EntityId], [e].[EntityType], [e].[FileId], [e].[IsPrimary], [f].[Id], [f].[Alt], [f].[Checksum], [f].[CreatedAt], [f].[CreatedBy], [f].[DeletedAt], [f].[FileName], [f].[FilePath], [f].[FileSize], [f].[FileType], [f].[Height], [f].[IsActive], [f].[LastModifiedAt], [f].[LastModifiedBy], [f].[MimeType], [f].[ThumbnailUrl], [f].[Url], [f].[Width]
+FROM [entity_files] AS [e]
+INNER JOIN [files] AS [f] ON [e].[FileId] = [f].[Id]
+WHERE [e].[EntityId] = @__p_0 AND [e].[EntityType] = 1 AND [e].[IsPrimary] = CAST(1 AS bit)
+2025-10-04 02:54:20.465 +07:00 [DBG] Closing data reader to 'capbot_db' on server 'localhost'.
+2025-10-04 02:54:20.465 +07:00 [DBG] A data reader for 'capbot_db' on server 'localhost' is being disposed after spending 0ms reading results.
+2025-10-04 02:54:20.465 +07:00 [DBG] Closing connection to database 'capbot_db' on server 'localhost'.
+2025-10-04 02:54:20.465 +07:00 [DBG] Closed connection to database 'capbot_db' on server 'localhost' (0ms).
+2025-10-04 02:54:20.466 +07:00 [DBG] List of registered output formatters, in the following order: ["Microsoft.AspNetCore.OData.Formatter.ODataOutputFormatter","Microsoft.AspNetCore.OData.Formatter.ODataOutputFormatter","Microsoft.AspNetCore.OData.Formatter.ODataOutputFormatter","Microsoft.AspNetCore.Mvc.Formatters.HttpNoContentOutputFormatter","Microsoft.AspNetCore.Mvc.Formatters.StringOutputFormatter","Microsoft.AspNetCore.Mvc.Formatters.StreamOutputFormatter","Microsoft.AspNetCore.Mvc.Formatters.SystemTextJsonOutputFormatter"]
+2025-10-04 02:54:20.466 +07:00 [DBG] No information found on request to perform content negotiation.
+2025-10-04 02:54:20.466 +07:00 [DBG] Attempting to select the first output formatter in the output formatters list which supports a content type from the explicitly specified content types '["application/json"]'.
+2025-10-04 02:54:20.466 +07:00 [DBG] Selected output formatter 'Microsoft.AspNetCore.Mvc.Formatters.SystemTextJsonOutputFormatter' and content type 'application/json' to write the response.
+2025-10-04 02:54:20.466 +07:00 [INF] Executing ObjectResult, writing value of type 'FS.Commons.FSResponse'.
+2025-10-04 02:54:20.467 +07:00 [INF] Executed action CapBot.api.Controllers.TopicController.GetDetail (CapBot.api) in 60.4765ms
+2025-10-04 02:54:20.467 +07:00 [INF] Executed endpoint 'CapBot.api.Controllers.TopicController.GetDetail (CapBot.api)'
+2025-10-04 02:54:20.467 +07:00 [DBG] Connection id "0HNG2MQC634J8" completed keep alive response.
+2025-10-04 02:54:20.467 +07:00 [DBG] 'MyDbContext' disposed.
+2025-10-04 02:54:20.467 +07:00 [DBG] Disposing connection to database 'capbot_db' on server 'localhost'.
+2025-10-04 02:54:20.467 +07:00 [DBG] Disposed connection to database '' on server '' (0ms).
+2025-10-04 02:54:20.467 +07:00 [INF] Request finished HTTP/1.1 GET http://localhost:5207/api/topic/detail/104 - 200 null application/json; charset=utf-8 65.423ms
+2025-10-04 02:54:20.587 +07:00 [INF] Request starting HTTP/1.1 GET http://localhost:5207/api/topic/detail/104 - null null
+2025-10-04 02:54:20.587 +07:00 [DBG] The request path /api/topic/detail/104 does not match a supported file type
+2025-10-04 02:54:20.587 +07:00 [DBG] The request path /api/topic/detail/104 does not match a supported file type
+2025-10-04 02:54:20.587 +07:00 [DBG] 1 candidate(s) found for the request path '/api/topic/detail/104'
+2025-10-04 02:54:20.587 +07:00 [DBG] Endpoint 'CapBot.api.Controllers.TopicController.GetDetail (CapBot.api)' with route pattern 'api/topic/detail/{topicId}' is valid for the request path '/api/topic/detail/104'
+2025-10-04 02:54:20.587 +07:00 [DBG] Request matched endpoint 'CapBot.api.Controllers.TopicController.GetDetail (CapBot.api)'
+2025-10-04 02:54:20.588 +07:00 [DBG] Successfully validated the token.
+2025-10-04 02:54:20.588 +07:00 [DBG] AuthenticationScheme: Bearer was successfully authenticated.
+2025-10-04 02:54:20.588 +07:00 [INF] Executing endpoint 'CapBot.api.Controllers.TopicController.GetDetail (CapBot.api)'
+2025-10-04 02:54:20.588 +07:00 [INF] Route matched with {action = "GetDetail", controller = "Topic"}. Executing controller action with signature System.Threading.Tasks.Task`1[Microsoft.AspNetCore.Mvc.IActionResult] GetDetail(Int32) on controller CapBot.api.Controllers.TopicController (CapBot.api).
+2025-10-04 02:54:20.588 +07:00 [DBG] Execution plan of authorization filters (in the following order): ["None"]
+2025-10-04 02:54:20.588 +07:00 [DBG] Execution plan of resource filters (in the following order): ["Microsoft.AspNetCore.Mvc.ConsumesAttribute"]
+2025-10-04 02:54:20.588 +07:00 [DBG] Execution plan of action filters (in the following order): ["Microsoft.AspNetCore.Mvc.ModelBinding.UnsupportedContentTypeFilter (Order: -3000)"]
+2025-10-04 02:54:20.588 +07:00 [DBG] Execution plan of exception filters (in the following order): ["None"]
+2025-10-04 02:54:20.589 +07:00 [DBG] Execution plan of result filters (in the following order): ["Microsoft.AspNetCore.Mvc.Infrastructure.ClientErrorResultFilter (Order: -2000)","Microsoft.AspNetCore.Mvc.ProducesAttribute (Order: 0)"]
+2025-10-04 02:54:20.589 +07:00 [DBG] Executing controller factory for controller CapBot.api.Controllers.TopicController (CapBot.api)
+2025-10-04 02:54:20.589 +07:00 [DBG] Executed controller factory for controller CapBot.api.Controllers.TopicController (CapBot.api)
+2025-10-04 02:54:20.589 +07:00 [DBG] Attempting to bind parameter 'topicId' of type 'System.Int32' ...
+2025-10-04 02:54:20.589 +07:00 [DBG] Attempting to bind parameter 'topicId' of type 'System.Int32' using the name 'topicId' in request data ...
+2025-10-04 02:54:20.589 +07:00 [DBG] Done attempting to bind parameter 'topicId' of type 'System.Int32'.
+2025-10-04 02:54:20.589 +07:00 [DBG] Done attempting to bind parameter 'topicId' of type 'System.Int32'.
+2025-10-04 02:54:20.589 +07:00 [DBG] Attempting to validate the bound parameter 'topicId' of type 'System.Int32' ...
+2025-10-04 02:54:20.589 +07:00 [DBG] Done attempting to validate the bound parameter 'topicId' of type 'System.Int32'.
+2025-10-04 02:54:20.590 +07:00 [DBG] Entity Framework Core 8.0.16 initialized 'MyDbContext' using provider 'Microsoft.EntityFrameworkCore.SqlServer:8.0.13' with options: MigrationsAssembly=App.DAL 
+2025-10-04 02:54:20.591 +07:00 [DBG] Creating DbConnection.
+2025-10-04 02:54:20.591 +07:00 [DBG] Created DbConnection. (0ms).
+2025-10-04 02:54:20.591 +07:00 [DBG] Opening connection to database 'capbot_db' on server 'localhost'.
+2025-10-04 02:54:20.591 +07:00 [DBG] Opened connection to database 'capbot_db' on server 'localhost'.
+2025-10-04 02:54:20.591 +07:00 [DBG] Creating DbCommand for 'ExecuteReader'.
+2025-10-04 02:54:20.591 +07:00 [DBG] Created DbCommand for 'ExecuteReader' (0ms).
+2025-10-04 02:54:20.592 +07:00 [DBG] Initialized DbCommand for 'ExecuteReader' (0ms).
+2025-10-04 02:54:20.592 +07:00 [DBG] Executing DbCommand [Parameters=[@__topicId_0='?' (DbType = Int32)], CommandType='"Text"', CommandTimeout='30']
+SELECT [t1].[Id], [t1].[Abbreviation], [t1].[CategoryId], [t1].[Content], [t1].[Context], [t1].[CreatedAt], [t1].[CreatedBy], [t1].[DeletedAt], [t1].[Description], [t1].[EN_Title], [t1].[IsActive], [t1].[IsApproved], [t1].[IsLegacy], [t1].[LastModifiedAt], [t1].[LastModifiedBy], [t1].[MaxStudents], [t1].[Objectives], [t1].[PotentialDuplicate], [t1].[Problem], [t1].[SemesterId], [t1].[SupervisorId], [t1].[VN_title], [t1].[Id0], [t1].[AccessFailedCount], [t1].[ConcurrencyStamp], [t1].[CreatedAt0], [t1].[DeletedAt0], [t1].[Email], [t1].[EmailConfirmed], [t1].[LastModifiedAt0], [t1].[LastModifiedBy0], [t1].[LockoutEnabled], [t1].[LockoutEnd], [t1].[NormalizedEmail], [t1].[NormalizedUserName], [t1].[PasswordHash], [t1].[PhoneNumber], [t1].[PhoneNumberConfirmed], [t1].[SecurityStamp], [t1].[TwoFactorEnabled], [t1].[UserName], [t1].[Id1], [t1].[CreatedAt1], [t1].[CreatedBy0], [t1].[DeletedAt1], [t1].[Description0], [t1].[IsActive0], [t1].[LastModifiedAt1], [t1].[LastModifiedBy1], [t1].[Name], [t1].[Id2], [t1].[CreatedAt2], [t1].[CreatedBy1], [t1].[DeletedAt2], [t1].[Description1], [t1].[EndDate], [t1].[IsActive1], [t1].[LastModifiedAt2], [t1].[LastModifiedBy2], [t1].[Name0], [t1].[StartDate], [t2].[Id], [t2].[Content], [t2].[Context], [t2].[CreatedAt], [t2].[CreatedBy], [t2].[DeletedAt], [t2].[Description], [t2].[DocumentUrl], [t2].[EN_Title], [t2].[ExpectedOutcomes], [t2].[IsActive], [t2].[LastModifiedAt], [t2].[LastModifiedBy], [t2].[Methodology], [t2].[Objectives], [t2].[PotentialDuplicate], [t2].[Problem], [t2].[Requirements], [t2].[Status], [t2].[SubmittedAt], [t2].[SubmittedBy], [t2].[TopicId], [t2].[VN_title], [t2].[VersionNumber]
+FROM (
+    SELECT TOP(1) [t].[Id], [t].[Abbreviation], [t].[CategoryId], [t].[Content], [t].[Context], [t].[CreatedAt], [t].[CreatedBy], [t].[DeletedAt], [t].[Description], [t].[EN_Title], [t].[IsActive], [t].[IsApproved], [t].[IsLegacy], [t].[LastModifiedAt], [t].[LastModifiedBy], [t].[MaxStudents], [t].[Objectives], [t].[PotentialDuplicate], [t].[Problem], [t].[SemesterId], [t].[SupervisorId], [t].[VN_title], [u].[Id] AS [Id0], [u].[AccessFailedCount], [u].[ConcurrencyStamp], [u].[CreatedAt] AS [CreatedAt0], [u].[DeletedAt] AS [DeletedAt0], [u].[Email], [u].[EmailConfirmed], [u].[LastModifiedAt] AS [LastModifiedAt0], [u].[LastModifiedBy] AS [LastModifiedBy0], [u].[LockoutEnabled], [u].[LockoutEnd], [u].[NormalizedEmail], [u].[NormalizedUserName], [u].[PasswordHash], [u].[PhoneNumber], [u].[PhoneNumberConfirmed], [u].[SecurityStamp], [u].[TwoFactorEnabled], [u].[UserName], [t0].[Id] AS [Id1], [t0].[CreatedAt] AS [CreatedAt1], [t0].[CreatedBy] AS [CreatedBy0], [t0].[DeletedAt] AS [DeletedAt1], [t0].[Description] AS [Description0], [t0].[IsActive] AS [IsActive0], [t0].[LastModifiedAt] AS [LastModifiedAt1], [t0].[LastModifiedBy] AS [LastModifiedBy1], [t0].[Name], [s].[Id] AS [Id2], [s].[CreatedAt] AS [CreatedAt2], [s].[CreatedBy] AS [CreatedBy1], [s].[DeletedAt] AS [DeletedAt2], [s].[Description] AS [Description1], [s].[EndDate], [s].[IsActive] AS [IsActive1], [s].[LastModifiedAt] AS [LastModifiedAt2], [s].[LastModifiedBy] AS [LastModifiedBy2], [s].[Name] AS [Name0], [s].[StartDate]
+    FROM [topics] AS [t]
+    INNER JOIN [users] AS [u] ON [t].[SupervisorId] = [u].[Id]
+    LEFT JOIN [topic_categories] AS [t0] ON [t].[CategoryId] = [t0].[Id]
+    INNER JOIN [semesters] AS [s] ON [t].[SemesterId] = [s].[Id]
+    WHERE [t].[Id] = @__topicId_0 AND [t].[IsActive] = CAST(1 AS bit) AND [t].[DeletedAt] IS NULL
+) AS [t1]
+LEFT JOIN [topic_versions] AS [t2] ON [t1].[Id] = [t2].[TopicId]
+ORDER BY [t1].[Id], [t1].[Id0], [t1].[Id1], [t1].[Id2]
+2025-10-04 02:54:20.616 +07:00 [INF] Executed DbCommand (24ms) [Parameters=[@__topicId_0='?' (DbType = Int32)], CommandType='"Text"', CommandTimeout='30']
+SELECT [t1].[Id], [t1].[Abbreviation], [t1].[CategoryId], [t1].[Content], [t1].[Context], [t1].[CreatedAt], [t1].[CreatedBy], [t1].[DeletedAt], [t1].[Description], [t1].[EN_Title], [t1].[IsActive], [t1].[IsApproved], [t1].[IsLegacy], [t1].[LastModifiedAt], [t1].[LastModifiedBy], [t1].[MaxStudents], [t1].[Objectives], [t1].[PotentialDuplicate], [t1].[Problem], [t1].[SemesterId], [t1].[SupervisorId], [t1].[VN_title], [t1].[Id0], [t1].[AccessFailedCount], [t1].[ConcurrencyStamp], [t1].[CreatedAt0], [t1].[DeletedAt0], [t1].[Email], [t1].[EmailConfirmed], [t1].[LastModifiedAt0], [t1].[LastModifiedBy0], [t1].[LockoutEnabled], [t1].[LockoutEnd], [t1].[NormalizedEmail], [t1].[NormalizedUserName], [t1].[PasswordHash], [t1].[PhoneNumber], [t1].[PhoneNumberConfirmed], [t1].[SecurityStamp], [t1].[TwoFactorEnabled], [t1].[UserName], [t1].[Id1], [t1].[CreatedAt1], [t1].[CreatedBy0], [t1].[DeletedAt1], [t1].[Description0], [t1].[IsActive0], [t1].[LastModifiedAt1], [t1].[LastModifiedBy1], [t1].[Name], [t1].[Id2], [t1].[CreatedAt2], [t1].[CreatedBy1], [t1].[DeletedAt2], [t1].[Description1], [t1].[EndDate], [t1].[IsActive1], [t1].[LastModifiedAt2], [t1].[LastModifiedBy2], [t1].[Name0], [t1].[StartDate], [t2].[Id], [t2].[Content], [t2].[Context], [t2].[CreatedAt], [t2].[CreatedBy], [t2].[DeletedAt], [t2].[Description], [t2].[DocumentUrl], [t2].[EN_Title], [t2].[ExpectedOutcomes], [t2].[IsActive], [t2].[LastModifiedAt], [t2].[LastModifiedBy], [t2].[Methodology], [t2].[Objectives], [t2].[PotentialDuplicate], [t2].[Problem], [t2].[Requirements], [t2].[Status], [t2].[SubmittedAt], [t2].[SubmittedBy], [t2].[TopicId], [t2].[VN_title], [t2].[VersionNumber]
+FROM (
+    SELECT TOP(1) [t].[Id], [t].[Abbreviation], [t].[CategoryId], [t].[Content], [t].[Context], [t].[CreatedAt], [t].[CreatedBy], [t].[DeletedAt], [t].[Description], [t].[EN_Title], [t].[IsActive], [t].[IsApproved], [t].[IsLegacy], [t].[LastModifiedAt], [t].[LastModifiedBy], [t].[MaxStudents], [t].[Objectives], [t].[PotentialDuplicate], [t].[Problem], [t].[SemesterId], [t].[SupervisorId], [t].[VN_title], [u].[Id] AS [Id0], [u].[AccessFailedCount], [u].[ConcurrencyStamp], [u].[CreatedAt] AS [CreatedAt0], [u].[DeletedAt] AS [DeletedAt0], [u].[Email], [u].[EmailConfirmed], [u].[LastModifiedAt] AS [LastModifiedAt0], [u].[LastModifiedBy] AS [LastModifiedBy0], [u].[LockoutEnabled], [u].[LockoutEnd], [u].[NormalizedEmail], [u].[NormalizedUserName], [u].[PasswordHash], [u].[PhoneNumber], [u].[PhoneNumberConfirmed], [u].[SecurityStamp], [u].[TwoFactorEnabled], [u].[UserName], [t0].[Id] AS [Id1], [t0].[CreatedAt] AS [CreatedAt1], [t0].[CreatedBy] AS [CreatedBy0], [t0].[DeletedAt] AS [DeletedAt1], [t0].[Description] AS [Description0], [t0].[IsActive] AS [IsActive0], [t0].[LastModifiedAt] AS [LastModifiedAt1], [t0].[LastModifiedBy] AS [LastModifiedBy1], [t0].[Name], [s].[Id] AS [Id2], [s].[CreatedAt] AS [CreatedAt2], [s].[CreatedBy] AS [CreatedBy1], [s].[DeletedAt] AS [DeletedAt2], [s].[Description] AS [Description1], [s].[EndDate], [s].[IsActive] AS [IsActive1], [s].[LastModifiedAt] AS [LastModifiedAt2], [s].[LastModifiedBy] AS [LastModifiedBy2], [s].[Name] AS [Name0], [s].[StartDate]
+    FROM [topics] AS [t]
+    INNER JOIN [users] AS [u] ON [t].[SupervisorId] = [u].[Id]
+    LEFT JOIN [topic_categories] AS [t0] ON [t].[CategoryId] = [t0].[Id]
+    INNER JOIN [semesters] AS [s] ON [t].[SemesterId] = [s].[Id]
+    WHERE [t].[Id] = @__topicId_0 AND [t].[IsActive] = CAST(1 AS bit) AND [t].[DeletedAt] IS NULL
+) AS [t1]
+LEFT JOIN [topic_versions] AS [t2] ON [t1].[Id] = [t2].[TopicId]
+ORDER BY [t1].[Id], [t1].[Id0], [t1].[Id1], [t1].[Id2]
+2025-10-04 02:54:20.616 +07:00 [DBG] Closing data reader to 'capbot_db' on server 'localhost'.
+2025-10-04 02:54:20.617 +07:00 [DBG] A data reader for 'capbot_db' on server 'localhost' is being disposed after spending 0ms reading results.
+2025-10-04 02:54:20.617 +07:00 [DBG] Closing connection to database 'capbot_db' on server 'localhost'.
+2025-10-04 02:54:20.617 +07:00 [DBG] Closed connection to database 'capbot_db' on server 'localhost' (0ms).
+2025-10-04 02:54:20.618 +07:00 [DBG] Opening connection to database 'capbot_db' on server 'localhost'.
+2025-10-04 02:54:20.618 +07:00 [DBG] Opened connection to database 'capbot_db' on server 'localhost'.
+2025-10-04 02:54:20.618 +07:00 [DBG] Creating DbCommand for 'ExecuteReader'.
+2025-10-04 02:54:20.619 +07:00 [DBG] Created DbCommand for 'ExecuteReader' (0ms).
+2025-10-04 02:54:20.619 +07:00 [DBG] Initialized DbCommand for 'ExecuteReader' (1ms).
+2025-10-04 02:54:20.620 +07:00 [DBG] Executing DbCommand [Parameters=[@__topicId_0='?' (DbType = Int32)], CommandType='"Text"', CommandTimeout='30']
+SELECT [s].[Id], [s].[AdditionalNotes], [s].[AiCheckDetails], [s].[AiCheckScore], [s].[AiCheckStatus], [s].[CreatedAt], [s].[CreatedBy], [s].[DeletedAt], [s].[DocumentUrl], [s].[IsActive], [s].[LastModifiedAt], [s].[LastModifiedBy], [s].[PhaseId], [s].[Status], [s].[SubmissionRound], [s].[SubmittedAt], [s].[SubmittedBy], [s].[TopicId], [s].[TopicVersionId], [p].[Id], [p].[CreatedAt], [p].[CreatedBy], [p].[DeletedAt], [p].[EndDate], [p].[IsActive], [p].[LastModifiedAt], [p].[LastModifiedBy], [p].[Name], [p].[PhaseTypeId], [p].[SemesterId], [p].[StartDate], [p].[SubmissionDeadline], [u].[Id], [u].[AccessFailedCount], [u].[ConcurrencyStamp], [u].[CreatedAt], [u].[DeletedAt], [u].[Email], [u].[EmailConfirmed], [u].[LastModifiedAt], [u].[LastModifiedBy], [u].[LockoutEnabled], [u].[LockoutEnd], [u].[NormalizedEmail], [u].[NormalizedUserName], [u].[PasswordHash], [u].[PhoneNumber], [u].[PhoneNumberConfirmed], [u].[SecurityStamp], [u].[TwoFactorEnabled], [u].[UserName], [r].[Id], [r].[AssignedAt], [r].[AssignedBy], [r].[AssignmentType], [r].[CompletedAt], [r].[Deadline], [r].[ReviewerId], [r].[SkillMatchScore], [r].[StartedAt], [r].[Status], [r].[SubmissionId]
+FROM [submissions] AS [s]
+INNER JOIN [phases] AS [p] ON [s].[PhaseId] = [p].[Id]
+INNER JOIN [users] AS [u] ON [s].[SubmittedBy] = [u].[Id]
+LEFT JOIN [reviewer_assignments] AS [r] ON [s].[Id] = [r].[SubmissionId]
+WHERE [s].[TopicId] = @__topicId_0 AND [s].[IsActive] = CAST(1 AS bit) AND [s].[DeletedAt] IS NULL
+ORDER BY [s].[Id], [p].[Id], [u].[Id]
+2025-10-04 02:54:20.652 +07:00 [INF] Executed DbCommand (31ms) [Parameters=[@__topicId_0='?' (DbType = Int32)], CommandType='"Text"', CommandTimeout='30']
+SELECT [s].[Id], [s].[AdditionalNotes], [s].[AiCheckDetails], [s].[AiCheckScore], [s].[AiCheckStatus], [s].[CreatedAt], [s].[CreatedBy], [s].[DeletedAt], [s].[DocumentUrl], [s].[IsActive], [s].[LastModifiedAt], [s].[LastModifiedBy], [s].[PhaseId], [s].[Status], [s].[SubmissionRound], [s].[SubmittedAt], [s].[SubmittedBy], [s].[TopicId], [s].[TopicVersionId], [p].[Id], [p].[CreatedAt], [p].[CreatedBy], [p].[DeletedAt], [p].[EndDate], [p].[IsActive], [p].[LastModifiedAt], [p].[LastModifiedBy], [p].[Name], [p].[PhaseTypeId], [p].[SemesterId], [p].[StartDate], [p].[SubmissionDeadline], [u].[Id], [u].[AccessFailedCount], [u].[ConcurrencyStamp], [u].[CreatedAt], [u].[DeletedAt], [u].[Email], [u].[EmailConfirmed], [u].[LastModifiedAt], [u].[LastModifiedBy], [u].[LockoutEnabled], [u].[LockoutEnd], [u].[NormalizedEmail], [u].[NormalizedUserName], [u].[PasswordHash], [u].[PhoneNumber], [u].[PhoneNumberConfirmed], [u].[SecurityStamp], [u].[TwoFactorEnabled], [u].[UserName], [r].[Id], [r].[AssignedAt], [r].[AssignedBy], [r].[AssignmentType], [r].[CompletedAt], [r].[Deadline], [r].[ReviewerId], [r].[SkillMatchScore], [r].[StartedAt], [r].[Status], [r].[SubmissionId]
+FROM [submissions] AS [s]
+INNER JOIN [phases] AS [p] ON [s].[PhaseId] = [p].[Id]
+INNER JOIN [users] AS [u] ON [s].[SubmittedBy] = [u].[Id]
+LEFT JOIN [reviewer_assignments] AS [r] ON [s].[Id] = [r].[SubmissionId]
+WHERE [s].[TopicId] = @__topicId_0 AND [s].[IsActive] = CAST(1 AS bit) AND [s].[DeletedAt] IS NULL
+ORDER BY [s].[Id], [p].[Id], [u].[Id]
+2025-10-04 02:54:20.653 +07:00 [DBG] Closing data reader to 'capbot_db' on server 'localhost'.
+2025-10-04 02:54:20.653 +07:00 [DBG] A data reader for 'capbot_db' on server 'localhost' is being disposed after spending 0ms reading results.
+2025-10-04 02:54:20.653 +07:00 [DBG] Closing connection to database 'capbot_db' on server 'localhost'.
+2025-10-04 02:54:20.654 +07:00 [DBG] Closed connection to database 'capbot_db' on server 'localhost' (0ms).
+2025-10-04 02:54:20.656 +07:00 [DBG] Opening connection to database 'capbot_db' on server 'localhost'.
+2025-10-04 02:54:20.656 +07:00 [DBG] Opened connection to database 'capbot_db' on server 'localhost'.
+2025-10-04 02:54:20.656 +07:00 [DBG] Creating DbCommand for 'ExecuteReader'.
+2025-10-04 02:54:20.657 +07:00 [DBG] Created DbCommand for 'ExecuteReader' (0ms).
+2025-10-04 02:54:20.657 +07:00 [DBG] Initialized DbCommand for 'ExecuteReader' (0ms).
+2025-10-04 02:54:20.657 +07:00 [DBG] Executing DbCommand [Parameters=[@__p_0='?' (DbType = Int64)], CommandType='"Text"', CommandTimeout='30']
+SELECT TOP(1) [e].[Id], [e].[Caption], [e].[CreatedAt], [e].[EntityId], [e].[EntityType], [e].[FileId], [e].[IsPrimary], [f].[Id], [f].[Alt], [f].[Checksum], [f].[CreatedAt], [f].[CreatedBy], [f].[DeletedAt], [f].[FileName], [f].[FilePath], [f].[FileSize], [f].[FileType], [f].[Height], [f].[IsActive], [f].[LastModifiedAt], [f].[LastModifiedBy], [f].[MimeType], [f].[ThumbnailUrl], [f].[Url], [f].[Width]
+FROM [entity_files] AS [e]
+INNER JOIN [files] AS [f] ON [e].[FileId] = [f].[Id]
+WHERE [e].[EntityId] = @__p_0 AND [e].[EntityType] = 1 AND [e].[IsPrimary] = CAST(1 AS bit)
+2025-10-04 02:54:20.665 +07:00 [INF] Executed DbCommand (8ms) [Parameters=[@__p_0='?' (DbType = Int64)], CommandType='"Text"', CommandTimeout='30']
+SELECT TOP(1) [e].[Id], [e].[Caption], [e].[CreatedAt], [e].[EntityId], [e].[EntityType], [e].[FileId], [e].[IsPrimary], [f].[Id], [f].[Alt], [f].[Checksum], [f].[CreatedAt], [f].[CreatedBy], [f].[DeletedAt], [f].[FileName], [f].[FilePath], [f].[FileSize], [f].[FileType], [f].[Height], [f].[IsActive], [f].[LastModifiedAt], [f].[LastModifiedBy], [f].[MimeType], [f].[ThumbnailUrl], [f].[Url], [f].[Width]
+FROM [entity_files] AS [e]
+INNER JOIN [files] AS [f] ON [e].[FileId] = [f].[Id]
+WHERE [e].[EntityId] = @__p_0 AND [e].[EntityType] = 1 AND [e].[IsPrimary] = CAST(1 AS bit)
+2025-10-04 02:54:20.665 +07:00 [DBG] Closing data reader to 'capbot_db' on server 'localhost'.
+2025-10-04 02:54:20.665 +07:00 [DBG] A data reader for 'capbot_db' on server 'localhost' is being disposed after spending 0ms reading results.
+2025-10-04 02:54:20.665 +07:00 [DBG] Closing connection to database 'capbot_db' on server 'localhost'.
+2025-10-04 02:54:20.666 +07:00 [DBG] Closed connection to database 'capbot_db' on server 'localhost' (0ms).
+2025-10-04 02:54:20.666 +07:00 [DBG] List of registered output formatters, in the following order: ["Microsoft.AspNetCore.OData.Formatter.ODataOutputFormatter","Microsoft.AspNetCore.OData.Formatter.ODataOutputFormatter","Microsoft.AspNetCore.OData.Formatter.ODataOutputFormatter","Microsoft.AspNetCore.Mvc.Formatters.HttpNoContentOutputFormatter","Microsoft.AspNetCore.Mvc.Formatters.StringOutputFormatter","Microsoft.AspNetCore.Mvc.Formatters.StreamOutputFormatter","Microsoft.AspNetCore.Mvc.Formatters.SystemTextJsonOutputFormatter"]
+2025-10-04 02:54:20.666 +07:00 [DBG] No information found on request to perform content negotiation.
+2025-10-04 02:54:20.666 +07:00 [DBG] Attempting to select the first output formatter in the output formatters list which supports a content type from the explicitly specified content types '["application/json"]'.
+2025-10-04 02:54:20.666 +07:00 [DBG] Selected output formatter 'Microsoft.AspNetCore.Mvc.Formatters.SystemTextJsonOutputFormatter' and content type 'application/json' to write the response.
+2025-10-04 02:54:20.666 +07:00 [INF] Executing ObjectResult, writing value of type 'FS.Commons.FSResponse'.
+2025-10-04 02:54:20.667 +07:00 [INF] Executed action CapBot.api.Controllers.TopicController.GetDetail (CapBot.api) in 78.3315ms
+2025-10-04 02:54:20.667 +07:00 [INF] Executed endpoint 'CapBot.api.Controllers.TopicController.GetDetail (CapBot.api)'
+2025-10-04 02:54:20.667 +07:00 [DBG] Connection id "0HNG2MQC634J8" completed keep alive response.
+2025-10-04 02:54:20.668 +07:00 [DBG] 'MyDbContext' disposed.
+2025-10-04 02:54:20.668 +07:00 [DBG] Disposing connection to database 'capbot_db' on server 'localhost'.
+2025-10-04 02:54:20.668 +07:00 [DBG] Disposed connection to database '' on server '' (0ms).
+2025-10-04 02:54:20.669 +07:00 [INF] Request finished HTTP/1.1 GET http://localhost:5207/api/topic/detail/104 - 200 null application/json; charset=utf-8 81.8708ms
+2025-10-04 02:54:20.895 +07:00 [INF] Request starting HTTP/1.1 GET http://localhost:5207/api/topic/detail/104 - null null
+2025-10-04 02:54:20.895 +07:00 [DBG] The request path /api/topic/detail/104 does not match a supported file type
+2025-10-04 02:54:20.895 +07:00 [DBG] The request path /api/topic/detail/104 does not match a supported file type
+2025-10-04 02:54:20.895 +07:00 [DBG] 1 candidate(s) found for the request path '/api/topic/detail/104'
+2025-10-04 02:54:20.895 +07:00 [DBG] Endpoint 'CapBot.api.Controllers.TopicController.GetDetail (CapBot.api)' with route pattern 'api/topic/detail/{topicId}' is valid for the request path '/api/topic/detail/104'
+2025-10-04 02:54:20.896 +07:00 [DBG] Request matched endpoint 'CapBot.api.Controllers.TopicController.GetDetail (CapBot.api)'
+2025-10-04 02:54:20.896 +07:00 [DBG] Successfully validated the token.
+2025-10-04 02:54:20.897 +07:00 [DBG] AuthenticationScheme: Bearer was successfully authenticated.
+2025-10-04 02:54:20.897 +07:00 [INF] Executing endpoint 'CapBot.api.Controllers.TopicController.GetDetail (CapBot.api)'
+2025-10-04 02:54:20.897 +07:00 [INF] Route matched with {action = "GetDetail", controller = "Topic"}. Executing controller action with signature System.Threading.Tasks.Task`1[Microsoft.AspNetCore.Mvc.IActionResult] GetDetail(Int32) on controller CapBot.api.Controllers.TopicController (CapBot.api).
+2025-10-04 02:54:20.897 +07:00 [DBG] Execution plan of authorization filters (in the following order): ["None"]
+2025-10-04 02:54:20.897 +07:00 [DBG] Execution plan of resource filters (in the following order): ["Microsoft.AspNetCore.Mvc.ConsumesAttribute"]
+2025-10-04 02:54:20.897 +07:00 [DBG] Execution plan of action filters (in the following order): ["Microsoft.AspNetCore.Mvc.ModelBinding.UnsupportedContentTypeFilter (Order: -3000)"]
+2025-10-04 02:54:20.897 +07:00 [DBG] Execution plan of exception filters (in the following order): ["None"]
+2025-10-04 02:54:20.897 +07:00 [DBG] Execution plan of result filters (in the following order): ["Microsoft.AspNetCore.Mvc.Infrastructure.ClientErrorResultFilter (Order: -2000)","Microsoft.AspNetCore.Mvc.ProducesAttribute (Order: 0)"]
+2025-10-04 02:54:20.897 +07:00 [DBG] Executing controller factory for controller CapBot.api.Controllers.TopicController (CapBot.api)
+2025-10-04 02:54:20.898 +07:00 [DBG] Executed controller factory for controller CapBot.api.Controllers.TopicController (CapBot.api)
+2025-10-04 02:54:20.898 +07:00 [DBG] Attempting to bind parameter 'topicId' of type 'System.Int32' ...
+2025-10-04 02:54:20.898 +07:00 [DBG] Attempting to bind parameter 'topicId' of type 'System.Int32' using the name 'topicId' in request data ...
+2025-10-04 02:54:20.898 +07:00 [DBG] Done attempting to bind parameter 'topicId' of type 'System.Int32'.
+2025-10-04 02:54:20.898 +07:00 [DBG] Done attempting to bind parameter 'topicId' of type 'System.Int32'.
+2025-10-04 02:54:20.898 +07:00 [DBG] Attempting to validate the bound parameter 'topicId' of type 'System.Int32' ...
+2025-10-04 02:54:20.898 +07:00 [DBG] Done attempting to validate the bound parameter 'topicId' of type 'System.Int32'.
+2025-10-04 02:54:20.899 +07:00 [DBG] Entity Framework Core 8.0.16 initialized 'MyDbContext' using provider 'Microsoft.EntityFrameworkCore.SqlServer:8.0.13' with options: MigrationsAssembly=App.DAL 
+2025-10-04 02:54:20.900 +07:00 [DBG] Creating DbConnection.
+2025-10-04 02:54:20.915 +07:00 [DBG] Created DbConnection. (14ms).
+2025-10-04 02:54:20.915 +07:00 [DBG] Opening connection to database 'capbot_db' on server 'localhost'.
+2025-10-04 02:54:20.915 +07:00 [DBG] Opened connection to database 'capbot_db' on server 'localhost'.
+2025-10-04 02:54:20.915 +07:00 [DBG] Creating DbCommand for 'ExecuteReader'.
+2025-10-04 02:54:20.915 +07:00 [DBG] Created DbCommand for 'ExecuteReader' (0ms).
+2025-10-04 02:54:20.916 +07:00 [DBG] Initialized DbCommand for 'ExecuteReader' (0ms).
+2025-10-04 02:54:20.916 +07:00 [DBG] Executing DbCommand [Parameters=[@__topicId_0='?' (DbType = Int32)], CommandType='"Text"', CommandTimeout='30']
+SELECT [t1].[Id], [t1].[Abbreviation], [t1].[CategoryId], [t1].[Content], [t1].[Context], [t1].[CreatedAt], [t1].[CreatedBy], [t1].[DeletedAt], [t1].[Description], [t1].[EN_Title], [t1].[IsActive], [t1].[IsApproved], [t1].[IsLegacy], [t1].[LastModifiedAt], [t1].[LastModifiedBy], [t1].[MaxStudents], [t1].[Objectives], [t1].[PotentialDuplicate], [t1].[Problem], [t1].[SemesterId], [t1].[SupervisorId], [t1].[VN_title], [t1].[Id0], [t1].[AccessFailedCount], [t1].[ConcurrencyStamp], [t1].[CreatedAt0], [t1].[DeletedAt0], [t1].[Email], [t1].[EmailConfirmed], [t1].[LastModifiedAt0], [t1].[LastModifiedBy0], [t1].[LockoutEnabled], [t1].[LockoutEnd], [t1].[NormalizedEmail], [t1].[NormalizedUserName], [t1].[PasswordHash], [t1].[PhoneNumber], [t1].[PhoneNumberConfirmed], [t1].[SecurityStamp], [t1].[TwoFactorEnabled], [t1].[UserName], [t1].[Id1], [t1].[CreatedAt1], [t1].[CreatedBy0], [t1].[DeletedAt1], [t1].[Description0], [t1].[IsActive0], [t1].[LastModifiedAt1], [t1].[LastModifiedBy1], [t1].[Name], [t1].[Id2], [t1].[CreatedAt2], [t1].[CreatedBy1], [t1].[DeletedAt2], [t1].[Description1], [t1].[EndDate], [t1].[IsActive1], [t1].[LastModifiedAt2], [t1].[LastModifiedBy2], [t1].[Name0], [t1].[StartDate], [t2].[Id], [t2].[Content], [t2].[Context], [t2].[CreatedAt], [t2].[CreatedBy], [t2].[DeletedAt], [t2].[Description], [t2].[DocumentUrl], [t2].[EN_Title], [t2].[ExpectedOutcomes], [t2].[IsActive], [t2].[LastModifiedAt], [t2].[LastModifiedBy], [t2].[Methodology], [t2].[Objectives], [t2].[PotentialDuplicate], [t2].[Problem], [t2].[Requirements], [t2].[Status], [t2].[SubmittedAt], [t2].[SubmittedBy], [t2].[TopicId], [t2].[VN_title], [t2].[VersionNumber]
+FROM (
+    SELECT TOP(1) [t].[Id], [t].[Abbreviation], [t].[CategoryId], [t].[Content], [t].[Context], [t].[CreatedAt], [t].[CreatedBy], [t].[DeletedAt], [t].[Description], [t].[EN_Title], [t].[IsActive], [t].[IsApproved], [t].[IsLegacy], [t].[LastModifiedAt], [t].[LastModifiedBy], [t].[MaxStudents], [t].[Objectives], [t].[PotentialDuplicate], [t].[Problem], [t].[SemesterId], [t].[SupervisorId], [t].[VN_title], [u].[Id] AS [Id0], [u].[AccessFailedCount], [u].[ConcurrencyStamp], [u].[CreatedAt] AS [CreatedAt0], [u].[DeletedAt] AS [DeletedAt0], [u].[Email], [u].[EmailConfirmed], [u].[LastModifiedAt] AS [LastModifiedAt0], [u].[LastModifiedBy] AS [LastModifiedBy0], [u].[LockoutEnabled], [u].[LockoutEnd], [u].[NormalizedEmail], [u].[NormalizedUserName], [u].[PasswordHash], [u].[PhoneNumber], [u].[PhoneNumberConfirmed], [u].[SecurityStamp], [u].[TwoFactorEnabled], [u].[UserName], [t0].[Id] AS [Id1], [t0].[CreatedAt] AS [CreatedAt1], [t0].[CreatedBy] AS [CreatedBy0], [t0].[DeletedAt] AS [DeletedAt1], [t0].[Description] AS [Description0], [t0].[IsActive] AS [IsActive0], [t0].[LastModifiedAt] AS [LastModifiedAt1], [t0].[LastModifiedBy] AS [LastModifiedBy1], [t0].[Name], [s].[Id] AS [Id2], [s].[CreatedAt] AS [CreatedAt2], [s].[CreatedBy] AS [CreatedBy1], [s].[DeletedAt] AS [DeletedAt2], [s].[Description] AS [Description1], [s].[EndDate], [s].[IsActive] AS [IsActive1], [s].[LastModifiedAt] AS [LastModifiedAt2], [s].[LastModifiedBy] AS [LastModifiedBy2], [s].[Name] AS [Name0], [s].[StartDate]
+    FROM [topics] AS [t]
+    INNER JOIN [users] AS [u] ON [t].[SupervisorId] = [u].[Id]
+    LEFT JOIN [topic_categories] AS [t0] ON [t].[CategoryId] = [t0].[Id]
+    INNER JOIN [semesters] AS [s] ON [t].[SemesterId] = [s].[Id]
+    WHERE [t].[Id] = @__topicId_0 AND [t].[IsActive] = CAST(1 AS bit) AND [t].[DeletedAt] IS NULL
+) AS [t1]
+LEFT JOIN [topic_versions] AS [t2] ON [t1].[Id] = [t2].[TopicId]
+ORDER BY [t1].[Id], [t1].[Id0], [t1].[Id1], [t1].[Id2]
+2025-10-04 02:54:20.949 +07:00 [INF] Executed DbCommand (33ms) [Parameters=[@__topicId_0='?' (DbType = Int32)], CommandType='"Text"', CommandTimeout='30']
+SELECT [t1].[Id], [t1].[Abbreviation], [t1].[CategoryId], [t1].[Content], [t1].[Context], [t1].[CreatedAt], [t1].[CreatedBy], [t1].[DeletedAt], [t1].[Description], [t1].[EN_Title], [t1].[IsActive], [t1].[IsApproved], [t1].[IsLegacy], [t1].[LastModifiedAt], [t1].[LastModifiedBy], [t1].[MaxStudents], [t1].[Objectives], [t1].[PotentialDuplicate], [t1].[Problem], [t1].[SemesterId], [t1].[SupervisorId], [t1].[VN_title], [t1].[Id0], [t1].[AccessFailedCount], [t1].[ConcurrencyStamp], [t1].[CreatedAt0], [t1].[DeletedAt0], [t1].[Email], [t1].[EmailConfirmed], [t1].[LastModifiedAt0], [t1].[LastModifiedBy0], [t1].[LockoutEnabled], [t1].[LockoutEnd], [t1].[NormalizedEmail], [t1].[NormalizedUserName], [t1].[PasswordHash], [t1].[PhoneNumber], [t1].[PhoneNumberConfirmed], [t1].[SecurityStamp], [t1].[TwoFactorEnabled], [t1].[UserName], [t1].[Id1], [t1].[CreatedAt1], [t1].[CreatedBy0], [t1].[DeletedAt1], [t1].[Description0], [t1].[IsActive0], [t1].[LastModifiedAt1], [t1].[LastModifiedBy1], [t1].[Name], [t1].[Id2], [t1].[CreatedAt2], [t1].[CreatedBy1], [t1].[DeletedAt2], [t1].[Description1], [t1].[EndDate], [t1].[IsActive1], [t1].[LastModifiedAt2], [t1].[LastModifiedBy2], [t1].[Name0], [t1].[StartDate], [t2].[Id], [t2].[Content], [t2].[Context], [t2].[CreatedAt], [t2].[CreatedBy], [t2].[DeletedAt], [t2].[Description], [t2].[DocumentUrl], [t2].[EN_Title], [t2].[ExpectedOutcomes], [t2].[IsActive], [t2].[LastModifiedAt], [t2].[LastModifiedBy], [t2].[Methodology], [t2].[Objectives], [t2].[PotentialDuplicate], [t2].[Problem], [t2].[Requirements], [t2].[Status], [t2].[SubmittedAt], [t2].[SubmittedBy], [t2].[TopicId], [t2].[VN_title], [t2].[VersionNumber]
+FROM (
+    SELECT TOP(1) [t].[Id], [t].[Abbreviation], [t].[CategoryId], [t].[Content], [t].[Context], [t].[CreatedAt], [t].[CreatedBy], [t].[DeletedAt], [t].[Description], [t].[EN_Title], [t].[IsActive], [t].[IsApproved], [t].[IsLegacy], [t].[LastModifiedAt], [t].[LastModifiedBy], [t].[MaxStudents], [t].[Objectives], [t].[PotentialDuplicate], [t].[Problem], [t].[SemesterId], [t].[SupervisorId], [t].[VN_title], [u].[Id] AS [Id0], [u].[AccessFailedCount], [u].[ConcurrencyStamp], [u].[CreatedAt] AS [CreatedAt0], [u].[DeletedAt] AS [DeletedAt0], [u].[Email], [u].[EmailConfirmed], [u].[LastModifiedAt] AS [LastModifiedAt0], [u].[LastModifiedBy] AS [LastModifiedBy0], [u].[LockoutEnabled], [u].[LockoutEnd], [u].[NormalizedEmail], [u].[NormalizedUserName], [u].[PasswordHash], [u].[PhoneNumber], [u].[PhoneNumberConfirmed], [u].[SecurityStamp], [u].[TwoFactorEnabled], [u].[UserName], [t0].[Id] AS [Id1], [t0].[CreatedAt] AS [CreatedAt1], [t0].[CreatedBy] AS [CreatedBy0], [t0].[DeletedAt] AS [DeletedAt1], [t0].[Description] AS [Description0], [t0].[IsActive] AS [IsActive0], [t0].[LastModifiedAt] AS [LastModifiedAt1], [t0].[LastModifiedBy] AS [LastModifiedBy1], [t0].[Name], [s].[Id] AS [Id2], [s].[CreatedAt] AS [CreatedAt2], [s].[CreatedBy] AS [CreatedBy1], [s].[DeletedAt] AS [DeletedAt2], [s].[Description] AS [Description1], [s].[EndDate], [s].[IsActive] AS [IsActive1], [s].[LastModifiedAt] AS [LastModifiedAt2], [s].[LastModifiedBy] AS [LastModifiedBy2], [s].[Name] AS [Name0], [s].[StartDate]
+    FROM [topics] AS [t]
+    INNER JOIN [users] AS [u] ON [t].[SupervisorId] = [u].[Id]
+    LEFT JOIN [topic_categories] AS [t0] ON [t].[CategoryId] = [t0].[Id]
+    INNER JOIN [semesters] AS [s] ON [t].[SemesterId] = [s].[Id]
+    WHERE [t].[Id] = @__topicId_0 AND [t].[IsActive] = CAST(1 AS bit) AND [t].[DeletedAt] IS NULL
+) AS [t1]
+LEFT JOIN [topic_versions] AS [t2] ON [t1].[Id] = [t2].[TopicId]
+ORDER BY [t1].[Id], [t1].[Id0], [t1].[Id1], [t1].[Id2]
+2025-10-04 02:54:20.949 +07:00 [DBG] Closing data reader to 'capbot_db' on server 'localhost'.
+2025-10-04 02:54:20.950 +07:00 [DBG] A data reader for 'capbot_db' on server 'localhost' is being disposed after spending 0ms reading results.
+2025-10-04 02:54:20.950 +07:00 [DBG] Closing connection to database 'capbot_db' on server 'localhost'.
+2025-10-04 02:54:20.950 +07:00 [DBG] Closed connection to database 'capbot_db' on server 'localhost' (0ms).
+2025-10-04 02:54:20.956 +07:00 [DBG] Opening connection to database 'capbot_db' on server 'localhost'.
+2025-10-04 02:54:20.956 +07:00 [DBG] Opened connection to database 'capbot_db' on server 'localhost'.
+2025-10-04 02:54:20.956 +07:00 [DBG] Creating DbCommand for 'ExecuteReader'.
+2025-10-04 02:54:20.956 +07:00 [DBG] Created DbCommand for 'ExecuteReader' (0ms).
+2025-10-04 02:54:20.956 +07:00 [DBG] Initialized DbCommand for 'ExecuteReader' (0ms).
+2025-10-04 02:54:20.956 +07:00 [DBG] Executing DbCommand [Parameters=[@__topicId_0='?' (DbType = Int32)], CommandType='"Text"', CommandTimeout='30']
+SELECT [s].[Id], [s].[AdditionalNotes], [s].[AiCheckDetails], [s].[AiCheckScore], [s].[AiCheckStatus], [s].[CreatedAt], [s].[CreatedBy], [s].[DeletedAt], [s].[DocumentUrl], [s].[IsActive], [s].[LastModifiedAt], [s].[LastModifiedBy], [s].[PhaseId], [s].[Status], [s].[SubmissionRound], [s].[SubmittedAt], [s].[SubmittedBy], [s].[TopicId], [s].[TopicVersionId], [p].[Id], [p].[CreatedAt], [p].[CreatedBy], [p].[DeletedAt], [p].[EndDate], [p].[IsActive], [p].[LastModifiedAt], [p].[LastModifiedBy], [p].[Name], [p].[PhaseTypeId], [p].[SemesterId], [p].[StartDate], [p].[SubmissionDeadline], [u].[Id], [u].[AccessFailedCount], [u].[ConcurrencyStamp], [u].[CreatedAt], [u].[DeletedAt], [u].[Email], [u].[EmailConfirmed], [u].[LastModifiedAt], [u].[LastModifiedBy], [u].[LockoutEnabled], [u].[LockoutEnd], [u].[NormalizedEmail], [u].[NormalizedUserName], [u].[PasswordHash], [u].[PhoneNumber], [u].[PhoneNumberConfirmed], [u].[SecurityStamp], [u].[TwoFactorEnabled], [u].[UserName], [r].[Id], [r].[AssignedAt], [r].[AssignedBy], [r].[AssignmentType], [r].[CompletedAt], [r].[Deadline], [r].[ReviewerId], [r].[SkillMatchScore], [r].[StartedAt], [r].[Status], [r].[SubmissionId]
+FROM [submissions] AS [s]
+INNER JOIN [phases] AS [p] ON [s].[PhaseId] = [p].[Id]
+INNER JOIN [users] AS [u] ON [s].[SubmittedBy] = [u].[Id]
+LEFT JOIN [reviewer_assignments] AS [r] ON [s].[Id] = [r].[SubmissionId]
+WHERE [s].[TopicId] = @__topicId_0 AND [s].[IsActive] = CAST(1 AS bit) AND [s].[DeletedAt] IS NULL
+ORDER BY [s].[Id], [p].[Id], [u].[Id]
+2025-10-04 02:54:20.965 +07:00 [INF] Executed DbCommand (9ms) [Parameters=[@__topicId_0='?' (DbType = Int32)], CommandType='"Text"', CommandTimeout='30']
+SELECT [s].[Id], [s].[AdditionalNotes], [s].[AiCheckDetails], [s].[AiCheckScore], [s].[AiCheckStatus], [s].[CreatedAt], [s].[CreatedBy], [s].[DeletedAt], [s].[DocumentUrl], [s].[IsActive], [s].[LastModifiedAt], [s].[LastModifiedBy], [s].[PhaseId], [s].[Status], [s].[SubmissionRound], [s].[SubmittedAt], [s].[SubmittedBy], [s].[TopicId], [s].[TopicVersionId], [p].[Id], [p].[CreatedAt], [p].[CreatedBy], [p].[DeletedAt], [p].[EndDate], [p].[IsActive], [p].[LastModifiedAt], [p].[LastModifiedBy], [p].[Name], [p].[PhaseTypeId], [p].[SemesterId], [p].[StartDate], [p].[SubmissionDeadline], [u].[Id], [u].[AccessFailedCount], [u].[ConcurrencyStamp], [u].[CreatedAt], [u].[DeletedAt], [u].[Email], [u].[EmailConfirmed], [u].[LastModifiedAt], [u].[LastModifiedBy], [u].[LockoutEnabled], [u].[LockoutEnd], [u].[NormalizedEmail], [u].[NormalizedUserName], [u].[PasswordHash], [u].[PhoneNumber], [u].[PhoneNumberConfirmed], [u].[SecurityStamp], [u].[TwoFactorEnabled], [u].[UserName], [r].[Id], [r].[AssignedAt], [r].[AssignedBy], [r].[AssignmentType], [r].[CompletedAt], [r].[Deadline], [r].[ReviewerId], [r].[SkillMatchScore], [r].[StartedAt], [r].[Status], [r].[SubmissionId]
+FROM [submissions] AS [s]
+INNER JOIN [phases] AS [p] ON [s].[PhaseId] = [p].[Id]
+INNER JOIN [users] AS [u] ON [s].[SubmittedBy] = [u].[Id]
+LEFT JOIN [reviewer_assignments] AS [r] ON [s].[Id] = [r].[SubmissionId]
+WHERE [s].[TopicId] = @__topicId_0 AND [s].[IsActive] = CAST(1 AS bit) AND [s].[DeletedAt] IS NULL
+ORDER BY [s].[Id], [p].[Id], [u].[Id]
+2025-10-04 02:54:20.965 +07:00 [DBG] Closing data reader to 'capbot_db' on server 'localhost'.
+2025-10-04 02:54:20.965 +07:00 [DBG] A data reader for 'capbot_db' on server 'localhost' is being disposed after spending 0ms reading results.
+2025-10-04 02:54:20.965 +07:00 [DBG] Closing connection to database 'capbot_db' on server 'localhost'.
+2025-10-04 02:54:20.966 +07:00 [DBG] Closed connection to database 'capbot_db' on server 'localhost' (0ms).
+2025-10-04 02:54:20.966 +07:00 [DBG] Opening connection to database 'capbot_db' on server 'localhost'.
+2025-10-04 02:54:20.966 +07:00 [DBG] Opened connection to database 'capbot_db' on server 'localhost'.
+2025-10-04 02:54:20.966 +07:00 [DBG] Creating DbCommand for 'ExecuteReader'.
+2025-10-04 02:54:20.967 +07:00 [DBG] Created DbCommand for 'ExecuteReader' (0ms).
+2025-10-04 02:54:20.967 +07:00 [DBG] Initialized DbCommand for 'ExecuteReader' (0ms).
+2025-10-04 02:54:20.967 +07:00 [DBG] Executing DbCommand [Parameters=[@__p_0='?' (DbType = Int64)], CommandType='"Text"', CommandTimeout='30']
+SELECT TOP(1) [e].[Id], [e].[Caption], [e].[CreatedAt], [e].[EntityId], [e].[EntityType], [e].[FileId], [e].[IsPrimary], [f].[Id], [f].[Alt], [f].[Checksum], [f].[CreatedAt], [f].[CreatedBy], [f].[DeletedAt], [f].[FileName], [f].[FilePath], [f].[FileSize], [f].[FileType], [f].[Height], [f].[IsActive], [f].[LastModifiedAt], [f].[LastModifiedBy], [f].[MimeType], [f].[ThumbnailUrl], [f].[Url], [f].[Width]
+FROM [entity_files] AS [e]
+INNER JOIN [files] AS [f] ON [e].[FileId] = [f].[Id]
+WHERE [e].[EntityId] = @__p_0 AND [e].[EntityType] = 1 AND [e].[IsPrimary] = CAST(1 AS bit)
+2025-10-04 02:54:20.977 +07:00 [INF] Executed DbCommand (10ms) [Parameters=[@__p_0='?' (DbType = Int64)], CommandType='"Text"', CommandTimeout='30']
+SELECT TOP(1) [e].[Id], [e].[Caption], [e].[CreatedAt], [e].[EntityId], [e].[EntityType], [e].[FileId], [e].[IsPrimary], [f].[Id], [f].[Alt], [f].[Checksum], [f].[CreatedAt], [f].[CreatedBy], [f].[DeletedAt], [f].[FileName], [f].[FilePath], [f].[FileSize], [f].[FileType], [f].[Height], [f].[IsActive], [f].[LastModifiedAt], [f].[LastModifiedBy], [f].[MimeType], [f].[ThumbnailUrl], [f].[Url], [f].[Width]
+FROM [entity_files] AS [e]
+INNER JOIN [files] AS [f] ON [e].[FileId] = [f].[Id]
+WHERE [e].[EntityId] = @__p_0 AND [e].[EntityType] = 1 AND [e].[IsPrimary] = CAST(1 AS bit)
+2025-10-04 02:54:20.977 +07:00 [DBG] Closing data reader to 'capbot_db' on server 'localhost'.
+2025-10-04 02:54:20.977 +07:00 [DBG] A data reader for 'capbot_db' on server 'localhost' is being disposed after spending 0ms reading results.
+2025-10-04 02:54:20.977 +07:00 [DBG] Closing connection to database 'capbot_db' on server 'localhost'.
+2025-10-04 02:54:20.977 +07:00 [DBG] Closed connection to database 'capbot_db' on server 'localhost' (0ms).
+2025-10-04 02:54:20.978 +07:00 [DBG] List of registered output formatters, in the following order: ["Microsoft.AspNetCore.OData.Formatter.ODataOutputFormatter","Microsoft.AspNetCore.OData.Formatter.ODataOutputFormatter","Microsoft.AspNetCore.OData.Formatter.ODataOutputFormatter","Microsoft.AspNetCore.Mvc.Formatters.HttpNoContentOutputFormatter","Microsoft.AspNetCore.Mvc.Formatters.StringOutputFormatter","Microsoft.AspNetCore.Mvc.Formatters.StreamOutputFormatter","Microsoft.AspNetCore.Mvc.Formatters.SystemTextJsonOutputFormatter"]
+2025-10-04 02:54:20.978 +07:00 [DBG] No information found on request to perform content negotiation.
+2025-10-04 02:54:20.978 +07:00 [DBG] Attempting to select the first output formatter in the output formatters list which supports a content type from the explicitly specified content types '["application/json"]'.
+2025-10-04 02:54:20.978 +07:00 [DBG] Selected output formatter 'Microsoft.AspNetCore.Mvc.Formatters.SystemTextJsonOutputFormatter' and content type 'application/json' to write the response.
+2025-10-04 02:54:20.978 +07:00 [INF] Executing ObjectResult, writing value of type 'FS.Commons.FSResponse'.
+2025-10-04 02:54:20.979 +07:00 [INF] Executed action CapBot.api.Controllers.TopicController.GetDetail (CapBot.api) in 81.4794ms
+2025-10-04 02:54:20.979 +07:00 [INF] Executed endpoint 'CapBot.api.Controllers.TopicController.GetDetail (CapBot.api)'
+2025-10-04 02:54:20.979 +07:00 [DBG] Connection id "0HNG2MQC634J8" completed keep alive response.
+2025-10-04 02:54:20.979 +07:00 [DBG] 'MyDbContext' disposed.
+2025-10-04 02:54:20.980 +07:00 [DBG] Disposing connection to database 'capbot_db' on server 'localhost'.
+2025-10-04 02:54:20.980 +07:00 [DBG] Disposed connection to database '' on server '' (0ms).
+2025-10-04 02:54:20.980 +07:00 [INF] Request finished HTTP/1.1 GET http://localhost:5207/api/topic/detail/104 - 200 null application/json; charset=utf-8 85.2753ms
+2025-10-04 02:54:21.096 +07:00 [INF] Request starting HTTP/1.1 GET http://localhost:5207/api/topic/detail/104 - null null
+2025-10-04 02:54:21.097 +07:00 [DBG] The request path /api/topic/detail/104 does not match a supported file type
+2025-10-04 02:54:21.097 +07:00 [DBG] The request path /api/topic/detail/104 does not match a supported file type
+2025-10-04 02:54:21.097 +07:00 [DBG] 1 candidate(s) found for the request path '/api/topic/detail/104'
+2025-10-04 02:54:21.097 +07:00 [DBG] Endpoint 'CapBot.api.Controllers.TopicController.GetDetail (CapBot.api)' with route pattern 'api/topic/detail/{topicId}' is valid for the request path '/api/topic/detail/104'
+2025-10-04 02:54:21.097 +07:00 [DBG] Request matched endpoint 'CapBot.api.Controllers.TopicController.GetDetail (CapBot.api)'
+2025-10-04 02:54:21.098 +07:00 [DBG] Successfully validated the token.
+2025-10-04 02:54:21.098 +07:00 [DBG] AuthenticationScheme: Bearer was successfully authenticated.
+2025-10-04 02:54:21.098 +07:00 [INF] Executing endpoint 'CapBot.api.Controllers.TopicController.GetDetail (CapBot.api)'
+2025-10-04 02:54:21.098 +07:00 [INF] Route matched with {action = "GetDetail", controller = "Topic"}. Executing controller action with signature System.Threading.Tasks.Task`1[Microsoft.AspNetCore.Mvc.IActionResult] GetDetail(Int32) on controller CapBot.api.Controllers.TopicController (CapBot.api).
+2025-10-04 02:54:21.098 +07:00 [DBG] Execution plan of authorization filters (in the following order): ["None"]
+2025-10-04 02:54:21.098 +07:00 [DBG] Execution plan of resource filters (in the following order): ["Microsoft.AspNetCore.Mvc.ConsumesAttribute"]
+2025-10-04 02:54:21.098 +07:00 [DBG] Execution plan of action filters (in the following order): ["Microsoft.AspNetCore.Mvc.ModelBinding.UnsupportedContentTypeFilter (Order: -3000)"]
+2025-10-04 02:54:21.099 +07:00 [DBG] Execution plan of exception filters (in the following order): ["None"]
+2025-10-04 02:54:21.099 +07:00 [DBG] Execution plan of result filters (in the following order): ["Microsoft.AspNetCore.Mvc.Infrastructure.ClientErrorResultFilter (Order: -2000)","Microsoft.AspNetCore.Mvc.ProducesAttribute (Order: 0)"]
+2025-10-04 02:54:21.099 +07:00 [DBG] Executing controller factory for controller CapBot.api.Controllers.TopicController (CapBot.api)
+2025-10-04 02:54:21.099 +07:00 [DBG] Executed controller factory for controller CapBot.api.Controllers.TopicController (CapBot.api)
+2025-10-04 02:54:21.099 +07:00 [DBG] Attempting to bind parameter 'topicId' of type 'System.Int32' ...
+2025-10-04 02:54:21.100 +07:00 [DBG] Attempting to bind parameter 'topicId' of type 'System.Int32' using the name 'topicId' in request data ...
+2025-10-04 02:54:21.100 +07:00 [DBG] Done attempting to bind parameter 'topicId' of type 'System.Int32'.
+2025-10-04 02:54:21.100 +07:00 [DBG] Done attempting to bind parameter 'topicId' of type 'System.Int32'.
+2025-10-04 02:54:21.100 +07:00 [DBG] Attempting to validate the bound parameter 'topicId' of type 'System.Int32' ...
+2025-10-04 02:54:21.100 +07:00 [DBG] Done attempting to validate the bound parameter 'topicId' of type 'System.Int32'.
+2025-10-04 02:54:21.102 +07:00 [DBG] Entity Framework Core 8.0.16 initialized 'MyDbContext' using provider 'Microsoft.EntityFrameworkCore.SqlServer:8.0.13' with options: MigrationsAssembly=App.DAL 
+2025-10-04 02:54:21.105 +07:00 [DBG] Creating DbConnection.
+2025-10-04 02:54:21.105 +07:00 [DBG] Created DbConnection. (0ms).
+2025-10-04 02:54:21.105 +07:00 [DBG] Opening connection to database 'capbot_db' on server 'localhost'.
+2025-10-04 02:54:21.106 +07:00 [DBG] Opened connection to database 'capbot_db' on server 'localhost'.
+2025-10-04 02:54:21.107 +07:00 [DBG] Creating DbCommand for 'ExecuteReader'.
+2025-10-04 02:54:21.107 +07:00 [DBG] Created DbCommand for 'ExecuteReader' (0ms).
+2025-10-04 02:54:21.107 +07:00 [DBG] Initialized DbCommand for 'ExecuteReader' (0ms).
+2025-10-04 02:54:21.107 +07:00 [DBG] Executing DbCommand [Parameters=[@__topicId_0='?' (DbType = Int32)], CommandType='"Text"', CommandTimeout='30']
+SELECT [t1].[Id], [t1].[Abbreviation], [t1].[CategoryId], [t1].[Content], [t1].[Context], [t1].[CreatedAt], [t1].[CreatedBy], [t1].[DeletedAt], [t1].[Description], [t1].[EN_Title], [t1].[IsActive], [t1].[IsApproved], [t1].[IsLegacy], [t1].[LastModifiedAt], [t1].[LastModifiedBy], [t1].[MaxStudents], [t1].[Objectives], [t1].[PotentialDuplicate], [t1].[Problem], [t1].[SemesterId], [t1].[SupervisorId], [t1].[VN_title], [t1].[Id0], [t1].[AccessFailedCount], [t1].[ConcurrencyStamp], [t1].[CreatedAt0], [t1].[DeletedAt0], [t1].[Email], [t1].[EmailConfirmed], [t1].[LastModifiedAt0], [t1].[LastModifiedBy0], [t1].[LockoutEnabled], [t1].[LockoutEnd], [t1].[NormalizedEmail], [t1].[NormalizedUserName], [t1].[PasswordHash], [t1].[PhoneNumber], [t1].[PhoneNumberConfirmed], [t1].[SecurityStamp], [t1].[TwoFactorEnabled], [t1].[UserName], [t1].[Id1], [t1].[CreatedAt1], [t1].[CreatedBy0], [t1].[DeletedAt1], [t1].[Description0], [t1].[IsActive0], [t1].[LastModifiedAt1], [t1].[LastModifiedBy1], [t1].[Name], [t1].[Id2], [t1].[CreatedAt2], [t1].[CreatedBy1], [t1].[DeletedAt2], [t1].[Description1], [t1].[EndDate], [t1].[IsActive1], [t1].[LastModifiedAt2], [t1].[LastModifiedBy2], [t1].[Name0], [t1].[StartDate], [t2].[Id], [t2].[Content], [t2].[Context], [t2].[CreatedAt], [t2].[CreatedBy], [t2].[DeletedAt], [t2].[Description], [t2].[DocumentUrl], [t2].[EN_Title], [t2].[ExpectedOutcomes], [t2].[IsActive], [t2].[LastModifiedAt], [t2].[LastModifiedBy], [t2].[Methodology], [t2].[Objectives], [t2].[PotentialDuplicate], [t2].[Problem], [t2].[Requirements], [t2].[Status], [t2].[SubmittedAt], [t2].[SubmittedBy], [t2].[TopicId], [t2].[VN_title], [t2].[VersionNumber]
+FROM (
+    SELECT TOP(1) [t].[Id], [t].[Abbreviation], [t].[CategoryId], [t].[Content], [t].[Context], [t].[CreatedAt], [t].[CreatedBy], [t].[DeletedAt], [t].[Description], [t].[EN_Title], [t].[IsActive], [t].[IsApproved], [t].[IsLegacy], [t].[LastModifiedAt], [t].[LastModifiedBy], [t].[MaxStudents], [t].[Objectives], [t].[PotentialDuplicate], [t].[Problem], [t].[SemesterId], [t].[SupervisorId], [t].[VN_title], [u].[Id] AS [Id0], [u].[AccessFailedCount], [u].[ConcurrencyStamp], [u].[CreatedAt] AS [CreatedAt0], [u].[DeletedAt] AS [DeletedAt0], [u].[Email], [u].[EmailConfirmed], [u].[LastModifiedAt] AS [LastModifiedAt0], [u].[LastModifiedBy] AS [LastModifiedBy0], [u].[LockoutEnabled], [u].[LockoutEnd], [u].[NormalizedEmail], [u].[NormalizedUserName], [u].[PasswordHash], [u].[PhoneNumber], [u].[PhoneNumberConfirmed], [u].[SecurityStamp], [u].[TwoFactorEnabled], [u].[UserName], [t0].[Id] AS [Id1], [t0].[CreatedAt] AS [CreatedAt1], [t0].[CreatedBy] AS [CreatedBy0], [t0].[DeletedAt] AS [DeletedAt1], [t0].[Description] AS [Description0], [t0].[IsActive] AS [IsActive0], [t0].[LastModifiedAt] AS [LastModifiedAt1], [t0].[LastModifiedBy] AS [LastModifiedBy1], [t0].[Name], [s].[Id] AS [Id2], [s].[CreatedAt] AS [CreatedAt2], [s].[CreatedBy] AS [CreatedBy1], [s].[DeletedAt] AS [DeletedAt2], [s].[Description] AS [Description1], [s].[EndDate], [s].[IsActive] AS [IsActive1], [s].[LastModifiedAt] AS [LastModifiedAt2], [s].[LastModifiedBy] AS [LastModifiedBy2], [s].[Name] AS [Name0], [s].[StartDate]
+    FROM [topics] AS [t]
+    INNER JOIN [users] AS [u] ON [t].[SupervisorId] = [u].[Id]
+    LEFT JOIN [topic_categories] AS [t0] ON [t].[CategoryId] = [t0].[Id]
+    INNER JOIN [semesters] AS [s] ON [t].[SemesterId] = [s].[Id]
+    WHERE [t].[Id] = @__topicId_0 AND [t].[IsActive] = CAST(1 AS bit) AND [t].[DeletedAt] IS NULL
+) AS [t1]
+LEFT JOIN [topic_versions] AS [t2] ON [t1].[Id] = [t2].[TopicId]
+ORDER BY [t1].[Id], [t1].[Id0], [t1].[Id1], [t1].[Id2]
+2025-10-04 02:54:21.131 +07:00 [INF] Executed DbCommand (24ms) [Parameters=[@__topicId_0='?' (DbType = Int32)], CommandType='"Text"', CommandTimeout='30']
+SELECT [t1].[Id], [t1].[Abbreviation], [t1].[CategoryId], [t1].[Content], [t1].[Context], [t1].[CreatedAt], [t1].[CreatedBy], [t1].[DeletedAt], [t1].[Description], [t1].[EN_Title], [t1].[IsActive], [t1].[IsApproved], [t1].[IsLegacy], [t1].[LastModifiedAt], [t1].[LastModifiedBy], [t1].[MaxStudents], [t1].[Objectives], [t1].[PotentialDuplicate], [t1].[Problem], [t1].[SemesterId], [t1].[SupervisorId], [t1].[VN_title], [t1].[Id0], [t1].[AccessFailedCount], [t1].[ConcurrencyStamp], [t1].[CreatedAt0], [t1].[DeletedAt0], [t1].[Email], [t1].[EmailConfirmed], [t1].[LastModifiedAt0], [t1].[LastModifiedBy0], [t1].[LockoutEnabled], [t1].[LockoutEnd], [t1].[NormalizedEmail], [t1].[NormalizedUserName], [t1].[PasswordHash], [t1].[PhoneNumber], [t1].[PhoneNumberConfirmed], [t1].[SecurityStamp], [t1].[TwoFactorEnabled], [t1].[UserName], [t1].[Id1], [t1].[CreatedAt1], [t1].[CreatedBy0], [t1].[DeletedAt1], [t1].[Description0], [t1].[IsActive0], [t1].[LastModifiedAt1], [t1].[LastModifiedBy1], [t1].[Name], [t1].[Id2], [t1].[CreatedAt2], [t1].[CreatedBy1], [t1].[DeletedAt2], [t1].[Description1], [t1].[EndDate], [t1].[IsActive1], [t1].[LastModifiedAt2], [t1].[LastModifiedBy2], [t1].[Name0], [t1].[StartDate], [t2].[Id], [t2].[Content], [t2].[Context], [t2].[CreatedAt], [t2].[CreatedBy], [t2].[DeletedAt], [t2].[Description], [t2].[DocumentUrl], [t2].[EN_Title], [t2].[ExpectedOutcomes], [t2].[IsActive], [t2].[LastModifiedAt], [t2].[LastModifiedBy], [t2].[Methodology], [t2].[Objectives], [t2].[PotentialDuplicate], [t2].[Problem], [t2].[Requirements], [t2].[Status], [t2].[SubmittedAt], [t2].[SubmittedBy], [t2].[TopicId], [t2].[VN_title], [t2].[VersionNumber]
+FROM (
+    SELECT TOP(1) [t].[Id], [t].[Abbreviation], [t].[CategoryId], [t].[Content], [t].[Context], [t].[CreatedAt], [t].[CreatedBy], [t].[DeletedAt], [t].[Description], [t].[EN_Title], [t].[IsActive], [t].[IsApproved], [t].[IsLegacy], [t].[LastModifiedAt], [t].[LastModifiedBy], [t].[MaxStudents], [t].[Objectives], [t].[PotentialDuplicate], [t].[Problem], [t].[SemesterId], [t].[SupervisorId], [t].[VN_title], [u].[Id] AS [Id0], [u].[AccessFailedCount], [u].[ConcurrencyStamp], [u].[CreatedAt] AS [CreatedAt0], [u].[DeletedAt] AS [DeletedAt0], [u].[Email], [u].[EmailConfirmed], [u].[LastModifiedAt] AS [LastModifiedAt0], [u].[LastModifiedBy] AS [LastModifiedBy0], [u].[LockoutEnabled], [u].[LockoutEnd], [u].[NormalizedEmail], [u].[NormalizedUserName], [u].[PasswordHash], [u].[PhoneNumber], [u].[PhoneNumberConfirmed], [u].[SecurityStamp], [u].[TwoFactorEnabled], [u].[UserName], [t0].[Id] AS [Id1], [t0].[CreatedAt] AS [CreatedAt1], [t0].[CreatedBy] AS [CreatedBy0], [t0].[DeletedAt] AS [DeletedAt1], [t0].[Description] AS [Description0], [t0].[IsActive] AS [IsActive0], [t0].[LastModifiedAt] AS [LastModifiedAt1], [t0].[LastModifiedBy] AS [LastModifiedBy1], [t0].[Name], [s].[Id] AS [Id2], [s].[CreatedAt] AS [CreatedAt2], [s].[CreatedBy] AS [CreatedBy1], [s].[DeletedAt] AS [DeletedAt2], [s].[Description] AS [Description1], [s].[EndDate], [s].[IsActive] AS [IsActive1], [s].[LastModifiedAt] AS [LastModifiedAt2], [s].[LastModifiedBy] AS [LastModifiedBy2], [s].[Name] AS [Name0], [s].[StartDate]
+    FROM [topics] AS [t]
+    INNER JOIN [users] AS [u] ON [t].[SupervisorId] = [u].[Id]
+    LEFT JOIN [topic_categories] AS [t0] ON [t].[CategoryId] = [t0].[Id]
+    INNER JOIN [semesters] AS [s] ON [t].[SemesterId] = [s].[Id]
+    WHERE [t].[Id] = @__topicId_0 AND [t].[IsActive] = CAST(1 AS bit) AND [t].[DeletedAt] IS NULL
+) AS [t1]
+LEFT JOIN [topic_versions] AS [t2] ON [t1].[Id] = [t2].[TopicId]
+ORDER BY [t1].[Id], [t1].[Id0], [t1].[Id1], [t1].[Id2]
+2025-10-04 02:54:21.132 +07:00 [DBG] Closing data reader to 'capbot_db' on server 'localhost'.
+2025-10-04 02:54:21.132 +07:00 [DBG] A data reader for 'capbot_db' on server 'localhost' is being disposed after spending 0ms reading results.
+2025-10-04 02:54:21.132 +07:00 [DBG] Closing connection to database 'capbot_db' on server 'localhost'.
+2025-10-04 02:54:21.132 +07:00 [DBG] Closed connection to database 'capbot_db' on server 'localhost' (0ms).
+2025-10-04 02:54:21.133 +07:00 [DBG] Opening connection to database 'capbot_db' on server 'localhost'.
+2025-10-04 02:54:21.133 +07:00 [DBG] Opened connection to database 'capbot_db' on server 'localhost'.
+2025-10-04 02:54:21.133 +07:00 [DBG] Creating DbCommand for 'ExecuteReader'.
+2025-10-04 02:54:21.133 +07:00 [DBG] Created DbCommand for 'ExecuteReader' (0ms).
+2025-10-04 02:54:21.134 +07:00 [DBG] Initialized DbCommand for 'ExecuteReader' (0ms).
+2025-10-04 02:54:21.140 +07:00 [DBG] Executing DbCommand [Parameters=[@__topicId_0='?' (DbType = Int32)], CommandType='"Text"', CommandTimeout='30']
+SELECT [s].[Id], [s].[AdditionalNotes], [s].[AiCheckDetails], [s].[AiCheckScore], [s].[AiCheckStatus], [s].[CreatedAt], [s].[CreatedBy], [s].[DeletedAt], [s].[DocumentUrl], [s].[IsActive], [s].[LastModifiedAt], [s].[LastModifiedBy], [s].[PhaseId], [s].[Status], [s].[SubmissionRound], [s].[SubmittedAt], [s].[SubmittedBy], [s].[TopicId], [s].[TopicVersionId], [p].[Id], [p].[CreatedAt], [p].[CreatedBy], [p].[DeletedAt], [p].[EndDate], [p].[IsActive], [p].[LastModifiedAt], [p].[LastModifiedBy], [p].[Name], [p].[PhaseTypeId], [p].[SemesterId], [p].[StartDate], [p].[SubmissionDeadline], [u].[Id], [u].[AccessFailedCount], [u].[ConcurrencyStamp], [u].[CreatedAt], [u].[DeletedAt], [u].[Email], [u].[EmailConfirmed], [u].[LastModifiedAt], [u].[LastModifiedBy], [u].[LockoutEnabled], [u].[LockoutEnd], [u].[NormalizedEmail], [u].[NormalizedUserName], [u].[PasswordHash], [u].[PhoneNumber], [u].[PhoneNumberConfirmed], [u].[SecurityStamp], [u].[TwoFactorEnabled], [u].[UserName], [r].[Id], [r].[AssignedAt], [r].[AssignedBy], [r].[AssignmentType], [r].[CompletedAt], [r].[Deadline], [r].[ReviewerId], [r].[SkillMatchScore], [r].[StartedAt], [r].[Status], [r].[SubmissionId]
+FROM [submissions] AS [s]
+INNER JOIN [phases] AS [p] ON [s].[PhaseId] = [p].[Id]
+INNER JOIN [users] AS [u] ON [s].[SubmittedBy] = [u].[Id]
+LEFT JOIN [reviewer_assignments] AS [r] ON [s].[Id] = [r].[SubmissionId]
+WHERE [s].[TopicId] = @__topicId_0 AND [s].[IsActive] = CAST(1 AS bit) AND [s].[DeletedAt] IS NULL
+ORDER BY [s].[Id], [p].[Id], [u].[Id]
+2025-10-04 02:54:21.160 +07:00 [INF] Executed DbCommand (26ms) [Parameters=[@__topicId_0='?' (DbType = Int32)], CommandType='"Text"', CommandTimeout='30']
+SELECT [s].[Id], [s].[AdditionalNotes], [s].[AiCheckDetails], [s].[AiCheckScore], [s].[AiCheckStatus], [s].[CreatedAt], [s].[CreatedBy], [s].[DeletedAt], [s].[DocumentUrl], [s].[IsActive], [s].[LastModifiedAt], [s].[LastModifiedBy], [s].[PhaseId], [s].[Status], [s].[SubmissionRound], [s].[SubmittedAt], [s].[SubmittedBy], [s].[TopicId], [s].[TopicVersionId], [p].[Id], [p].[CreatedAt], [p].[CreatedBy], [p].[DeletedAt], [p].[EndDate], [p].[IsActive], [p].[LastModifiedAt], [p].[LastModifiedBy], [p].[Name], [p].[PhaseTypeId], [p].[SemesterId], [p].[StartDate], [p].[SubmissionDeadline], [u].[Id], [u].[AccessFailedCount], [u].[ConcurrencyStamp], [u].[CreatedAt], [u].[DeletedAt], [u].[Email], [u].[EmailConfirmed], [u].[LastModifiedAt], [u].[LastModifiedBy], [u].[LockoutEnabled], [u].[LockoutEnd], [u].[NormalizedEmail], [u].[NormalizedUserName], [u].[PasswordHash], [u].[PhoneNumber], [u].[PhoneNumberConfirmed], [u].[SecurityStamp], [u].[TwoFactorEnabled], [u].[UserName], [r].[Id], [r].[AssignedAt], [r].[AssignedBy], [r].[AssignmentType], [r].[CompletedAt], [r].[Deadline], [r].[ReviewerId], [r].[SkillMatchScore], [r].[StartedAt], [r].[Status], [r].[SubmissionId]
+FROM [submissions] AS [s]
+INNER JOIN [phases] AS [p] ON [s].[PhaseId] = [p].[Id]
+INNER JOIN [users] AS [u] ON [s].[SubmittedBy] = [u].[Id]
+LEFT JOIN [reviewer_assignments] AS [r] ON [s].[Id] = [r].[SubmissionId]
+WHERE [s].[TopicId] = @__topicId_0 AND [s].[IsActive] = CAST(1 AS bit) AND [s].[DeletedAt] IS NULL
+ORDER BY [s].[Id], [p].[Id], [u].[Id]
+2025-10-04 02:54:21.160 +07:00 [DBG] Closing data reader to 'capbot_db' on server 'localhost'.
+2025-10-04 02:54:21.160 +07:00 [DBG] A data reader for 'capbot_db' on server 'localhost' is being disposed after spending 0ms reading results.
+2025-10-04 02:54:21.160 +07:00 [DBG] Closing connection to database 'capbot_db' on server 'localhost'.
+2025-10-04 02:54:21.161 +07:00 [DBG] Closed connection to database 'capbot_db' on server 'localhost' (0ms).
+2025-10-04 02:54:21.161 +07:00 [DBG] Opening connection to database 'capbot_db' on server 'localhost'.
+2025-10-04 02:54:21.161 +07:00 [DBG] Opened connection to database 'capbot_db' on server 'localhost'.
+2025-10-04 02:54:21.161 +07:00 [DBG] Creating DbCommand for 'ExecuteReader'.
+2025-10-04 02:54:21.161 +07:00 [DBG] Created DbCommand for 'ExecuteReader' (0ms).
+2025-10-04 02:54:21.161 +07:00 [DBG] Initialized DbCommand for 'ExecuteReader' (0ms).
+2025-10-04 02:54:21.161 +07:00 [DBG] Executing DbCommand [Parameters=[@__p_0='?' (DbType = Int64)], CommandType='"Text"', CommandTimeout='30']
+SELECT TOP(1) [e].[Id], [e].[Caption], [e].[CreatedAt], [e].[EntityId], [e].[EntityType], [e].[FileId], [e].[IsPrimary], [f].[Id], [f].[Alt], [f].[Checksum], [f].[CreatedAt], [f].[CreatedBy], [f].[DeletedAt], [f].[FileName], [f].[FilePath], [f].[FileSize], [f].[FileType], [f].[Height], [f].[IsActive], [f].[LastModifiedAt], [f].[LastModifiedBy], [f].[MimeType], [f].[ThumbnailUrl], [f].[Url], [f].[Width]
+FROM [entity_files] AS [e]
+INNER JOIN [files] AS [f] ON [e].[FileId] = [f].[Id]
+WHERE [e].[EntityId] = @__p_0 AND [e].[EntityType] = 1 AND [e].[IsPrimary] = CAST(1 AS bit)
+2025-10-04 02:54:21.166 +07:00 [INF] Executed DbCommand (5ms) [Parameters=[@__p_0='?' (DbType = Int64)], CommandType='"Text"', CommandTimeout='30']
+SELECT TOP(1) [e].[Id], [e].[Caption], [e].[CreatedAt], [e].[EntityId], [e].[EntityType], [e].[FileId], [e].[IsPrimary], [f].[Id], [f].[Alt], [f].[Checksum], [f].[CreatedAt], [f].[CreatedBy], [f].[DeletedAt], [f].[FileName], [f].[FilePath], [f].[FileSize], [f].[FileType], [f].[Height], [f].[IsActive], [f].[LastModifiedAt], [f].[LastModifiedBy], [f].[MimeType], [f].[ThumbnailUrl], [f].[Url], [f].[Width]
+FROM [entity_files] AS [e]
+INNER JOIN [files] AS [f] ON [e].[FileId] = [f].[Id]
+WHERE [e].[EntityId] = @__p_0 AND [e].[EntityType] = 1 AND [e].[IsPrimary] = CAST(1 AS bit)
+2025-10-04 02:54:21.167 +07:00 [DBG] Closing data reader to 'capbot_db' on server 'localhost'.
+2025-10-04 02:54:21.167 +07:00 [DBG] A data reader for 'capbot_db' on server 'localhost' is being disposed after spending 0ms reading results.
+2025-10-04 02:54:21.167 +07:00 [DBG] Closing connection to database 'capbot_db' on server 'localhost'.
+2025-10-04 02:54:21.167 +07:00 [DBG] Closed connection to database 'capbot_db' on server 'localhost' (0ms).
+2025-10-04 02:54:21.170 +07:00 [DBG] List of registered output formatters, in the following order: ["Microsoft.AspNetCore.OData.Formatter.ODataOutputFormatter","Microsoft.AspNetCore.OData.Formatter.ODataOutputFormatter","Microsoft.AspNetCore.OData.Formatter.ODataOutputFormatter","Microsoft.AspNetCore.Mvc.Formatters.HttpNoContentOutputFormatter","Microsoft.AspNetCore.Mvc.Formatters.StringOutputFormatter","Microsoft.AspNetCore.Mvc.Formatters.StreamOutputFormatter","Microsoft.AspNetCore.Mvc.Formatters.SystemTextJsonOutputFormatter"]
+2025-10-04 02:54:21.171 +07:00 [DBG] No information found on request to perform content negotiation.
+2025-10-04 02:54:21.171 +07:00 [DBG] Attempting to select the first output formatter in the output formatters list which supports a content type from the explicitly specified content types '["application/json"]'.
+2025-10-04 02:54:21.171 +07:00 [DBG] Selected output formatter 'Microsoft.AspNetCore.Mvc.Formatters.SystemTextJsonOutputFormatter' and content type 'application/json' to write the response.
+2025-10-04 02:54:21.171 +07:00 [INF] Executing ObjectResult, writing value of type 'FS.Commons.FSResponse'.
+2025-10-04 02:54:21.172 +07:00 [INF] Executed action CapBot.api.Controllers.TopicController.GetDetail (CapBot.api) in 73.0796ms
+2025-10-04 02:54:21.172 +07:00 [INF] Executed endpoint 'CapBot.api.Controllers.TopicController.GetDetail (CapBot.api)'
+2025-10-04 02:54:21.172 +07:00 [DBG] Connection id "0HNG2MQC634J8" completed keep alive response.
+2025-10-04 02:54:21.172 +07:00 [DBG] 'MyDbContext' disposed.
+2025-10-04 02:54:21.172 +07:00 [DBG] Disposing connection to database 'capbot_db' on server 'localhost'.
+2025-10-04 02:54:21.172 +07:00 [DBG] Disposed connection to database '' on server '' (0ms).
+2025-10-04 02:54:21.173 +07:00 [INF] Request finished HTTP/1.1 GET http://localhost:5207/api/topic/detail/104 - 200 null application/json; charset=utf-8 76.5371ms
+2025-10-04 02:54:21.286 +07:00 [INF] Request starting HTTP/1.1 GET http://localhost:5207/api/topic/detail/104 - null null
+2025-10-04 02:54:21.287 +07:00 [DBG] The request path /api/topic/detail/104 does not match a supported file type
+2025-10-04 02:54:21.287 +07:00 [DBG] The request path /api/topic/detail/104 does not match a supported file type
+2025-10-04 02:54:21.287 +07:00 [DBG] 1 candidate(s) found for the request path '/api/topic/detail/104'
+2025-10-04 02:54:21.287 +07:00 [DBG] Endpoint 'CapBot.api.Controllers.TopicController.GetDetail (CapBot.api)' with route pattern 'api/topic/detail/{topicId}' is valid for the request path '/api/topic/detail/104'
+2025-10-04 02:54:21.287 +07:00 [DBG] Request matched endpoint 'CapBot.api.Controllers.TopicController.GetDetail (CapBot.api)'
+2025-10-04 02:54:21.288 +07:00 [DBG] Successfully validated the token.
+2025-10-04 02:54:21.289 +07:00 [DBG] AuthenticationScheme: Bearer was successfully authenticated.
+2025-10-04 02:54:21.289 +07:00 [INF] Executing endpoint 'CapBot.api.Controllers.TopicController.GetDetail (CapBot.api)'
+2025-10-04 02:54:21.289 +07:00 [INF] Route matched with {action = "GetDetail", controller = "Topic"}. Executing controller action with signature System.Threading.Tasks.Task`1[Microsoft.AspNetCore.Mvc.IActionResult] GetDetail(Int32) on controller CapBot.api.Controllers.TopicController (CapBot.api).
+2025-10-04 02:54:21.290 +07:00 [DBG] Execution plan of authorization filters (in the following order): ["None"]
+2025-10-04 02:54:21.290 +07:00 [DBG] Execution plan of resource filters (in the following order): ["Microsoft.AspNetCore.Mvc.ConsumesAttribute"]
+2025-10-04 02:54:21.290 +07:00 [DBG] Execution plan of action filters (in the following order): ["Microsoft.AspNetCore.Mvc.ModelBinding.UnsupportedContentTypeFilter (Order: -3000)"]
+2025-10-04 02:54:21.290 +07:00 [DBG] Execution plan of exception filters (in the following order): ["None"]
+2025-10-04 02:54:21.290 +07:00 [DBG] Execution plan of result filters (in the following order): ["Microsoft.AspNetCore.Mvc.Infrastructure.ClientErrorResultFilter (Order: -2000)","Microsoft.AspNetCore.Mvc.ProducesAttribute (Order: 0)"]
+2025-10-04 02:54:21.290 +07:00 [DBG] Executing controller factory for controller CapBot.api.Controllers.TopicController (CapBot.api)
+2025-10-04 02:54:21.292 +07:00 [DBG] Executed controller factory for controller CapBot.api.Controllers.TopicController (CapBot.api)
+2025-10-04 02:54:21.292 +07:00 [DBG] Attempting to bind parameter 'topicId' of type 'System.Int32' ...
+2025-10-04 02:54:21.293 +07:00 [DBG] Attempting to bind parameter 'topicId' of type 'System.Int32' using the name 'topicId' in request data ...
+2025-10-04 02:54:21.294 +07:00 [DBG] Done attempting to bind parameter 'topicId' of type 'System.Int32'.
+2025-10-04 02:54:21.295 +07:00 [DBG] Done attempting to bind parameter 'topicId' of type 'System.Int32'.
+2025-10-04 02:54:21.295 +07:00 [DBG] Attempting to validate the bound parameter 'topicId' of type 'System.Int32' ...
+2025-10-04 02:54:21.296 +07:00 [DBG] Done attempting to validate the bound parameter 'topicId' of type 'System.Int32'.
+2025-10-04 02:54:21.299 +07:00 [DBG] Entity Framework Core 8.0.16 initialized 'MyDbContext' using provider 'Microsoft.EntityFrameworkCore.SqlServer:8.0.13' with options: MigrationsAssembly=App.DAL 
+2025-10-04 02:54:21.303 +07:00 [DBG] Creating DbConnection.
+2025-10-04 02:54:21.303 +07:00 [DBG] Created DbConnection. (0ms).
+2025-10-04 02:54:21.304 +07:00 [DBG] Opening connection to database 'capbot_db' on server 'localhost'.
+2025-10-04 02:54:21.305 +07:00 [DBG] Opened connection to database 'capbot_db' on server 'localhost'.
+2025-10-04 02:54:21.306 +07:00 [DBG] Creating DbCommand for 'ExecuteReader'.
+2025-10-04 02:54:21.306 +07:00 [DBG] Created DbCommand for 'ExecuteReader' (0ms).
+2025-10-04 02:54:21.306 +07:00 [DBG] Initialized DbCommand for 'ExecuteReader' (0ms).
+2025-10-04 02:54:21.306 +07:00 [DBG] Executing DbCommand [Parameters=[@__topicId_0='?' (DbType = Int32)], CommandType='"Text"', CommandTimeout='30']
+SELECT [t1].[Id], [t1].[Abbreviation], [t1].[CategoryId], [t1].[Content], [t1].[Context], [t1].[CreatedAt], [t1].[CreatedBy], [t1].[DeletedAt], [t1].[Description], [t1].[EN_Title], [t1].[IsActive], [t1].[IsApproved], [t1].[IsLegacy], [t1].[LastModifiedAt], [t1].[LastModifiedBy], [t1].[MaxStudents], [t1].[Objectives], [t1].[PotentialDuplicate], [t1].[Problem], [t1].[SemesterId], [t1].[SupervisorId], [t1].[VN_title], [t1].[Id0], [t1].[AccessFailedCount], [t1].[ConcurrencyStamp], [t1].[CreatedAt0], [t1].[DeletedAt0], [t1].[Email], [t1].[EmailConfirmed], [t1].[LastModifiedAt0], [t1].[LastModifiedBy0], [t1].[LockoutEnabled], [t1].[LockoutEnd], [t1].[NormalizedEmail], [t1].[NormalizedUserName], [t1].[PasswordHash], [t1].[PhoneNumber], [t1].[PhoneNumberConfirmed], [t1].[SecurityStamp], [t1].[TwoFactorEnabled], [t1].[UserName], [t1].[Id1], [t1].[CreatedAt1], [t1].[CreatedBy0], [t1].[DeletedAt1], [t1].[Description0], [t1].[IsActive0], [t1].[LastModifiedAt1], [t1].[LastModifiedBy1], [t1].[Name], [t1].[Id2], [t1].[CreatedAt2], [t1].[CreatedBy1], [t1].[DeletedAt2], [t1].[Description1], [t1].[EndDate], [t1].[IsActive1], [t1].[LastModifiedAt2], [t1].[LastModifiedBy2], [t1].[Name0], [t1].[StartDate], [t2].[Id], [t2].[Content], [t2].[Context], [t2].[CreatedAt], [t2].[CreatedBy], [t2].[DeletedAt], [t2].[Description], [t2].[DocumentUrl], [t2].[EN_Title], [t2].[ExpectedOutcomes], [t2].[IsActive], [t2].[LastModifiedAt], [t2].[LastModifiedBy], [t2].[Methodology], [t2].[Objectives], [t2].[PotentialDuplicate], [t2].[Problem], [t2].[Requirements], [t2].[Status], [t2].[SubmittedAt], [t2].[SubmittedBy], [t2].[TopicId], [t2].[VN_title], [t2].[VersionNumber]
+FROM (
+    SELECT TOP(1) [t].[Id], [t].[Abbreviation], [t].[CategoryId], [t].[Content], [t].[Context], [t].[CreatedAt], [t].[CreatedBy], [t].[DeletedAt], [t].[Description], [t].[EN_Title], [t].[IsActive], [t].[IsApproved], [t].[IsLegacy], [t].[LastModifiedAt], [t].[LastModifiedBy], [t].[MaxStudents], [t].[Objectives], [t].[PotentialDuplicate], [t].[Problem], [t].[SemesterId], [t].[SupervisorId], [t].[VN_title], [u].[Id] AS [Id0], [u].[AccessFailedCount], [u].[ConcurrencyStamp], [u].[CreatedAt] AS [CreatedAt0], [u].[DeletedAt] AS [DeletedAt0], [u].[Email], [u].[EmailConfirmed], [u].[LastModifiedAt] AS [LastModifiedAt0], [u].[LastModifiedBy] AS [LastModifiedBy0], [u].[LockoutEnabled], [u].[LockoutEnd], [u].[NormalizedEmail], [u].[NormalizedUserName], [u].[PasswordHash], [u].[PhoneNumber], [u].[PhoneNumberConfirmed], [u].[SecurityStamp], [u].[TwoFactorEnabled], [u].[UserName], [t0].[Id] AS [Id1], [t0].[CreatedAt] AS [CreatedAt1], [t0].[CreatedBy] AS [CreatedBy0], [t0].[DeletedAt] AS [DeletedAt1], [t0].[Description] AS [Description0], [t0].[IsActive] AS [IsActive0], [t0].[LastModifiedAt] AS [LastModifiedAt1], [t0].[LastModifiedBy] AS [LastModifiedBy1], [t0].[Name], [s].[Id] AS [Id2], [s].[CreatedAt] AS [CreatedAt2], [s].[CreatedBy] AS [CreatedBy1], [s].[DeletedAt] AS [DeletedAt2], [s].[Description] AS [Description1], [s].[EndDate], [s].[IsActive] AS [IsActive1], [s].[LastModifiedAt] AS [LastModifiedAt2], [s].[LastModifiedBy] AS [LastModifiedBy2], [s].[Name] AS [Name0], [s].[StartDate]
+    FROM [topics] AS [t]
+    INNER JOIN [users] AS [u] ON [t].[SupervisorId] = [u].[Id]
+    LEFT JOIN [topic_categories] AS [t0] ON [t].[CategoryId] = [t0].[Id]
+    INNER JOIN [semesters] AS [s] ON [t].[SemesterId] = [s].[Id]
+    WHERE [t].[Id] = @__topicId_0 AND [t].[IsActive] = CAST(1 AS bit) AND [t].[DeletedAt] IS NULL
+) AS [t1]
+LEFT JOIN [topic_versions] AS [t2] ON [t1].[Id] = [t2].[TopicId]
+ORDER BY [t1].[Id], [t1].[Id0], [t1].[Id1], [t1].[Id2]
+2025-10-04 02:54:21.341 +07:00 [INF] Executed DbCommand (35ms) [Parameters=[@__topicId_0='?' (DbType = Int32)], CommandType='"Text"', CommandTimeout='30']
+SELECT [t1].[Id], [t1].[Abbreviation], [t1].[CategoryId], [t1].[Content], [t1].[Context], [t1].[CreatedAt], [t1].[CreatedBy], [t1].[DeletedAt], [t1].[Description], [t1].[EN_Title], [t1].[IsActive], [t1].[IsApproved], [t1].[IsLegacy], [t1].[LastModifiedAt], [t1].[LastModifiedBy], [t1].[MaxStudents], [t1].[Objectives], [t1].[PotentialDuplicate], [t1].[Problem], [t1].[SemesterId], [t1].[SupervisorId], [t1].[VN_title], [t1].[Id0], [t1].[AccessFailedCount], [t1].[ConcurrencyStamp], [t1].[CreatedAt0], [t1].[DeletedAt0], [t1].[Email], [t1].[EmailConfirmed], [t1].[LastModifiedAt0], [t1].[LastModifiedBy0], [t1].[LockoutEnabled], [t1].[LockoutEnd], [t1].[NormalizedEmail], [t1].[NormalizedUserName], [t1].[PasswordHash], [t1].[PhoneNumber], [t1].[PhoneNumberConfirmed], [t1].[SecurityStamp], [t1].[TwoFactorEnabled], [t1].[UserName], [t1].[Id1], [t1].[CreatedAt1], [t1].[CreatedBy0], [t1].[DeletedAt1], [t1].[Description0], [t1].[IsActive0], [t1].[LastModifiedAt1], [t1].[LastModifiedBy1], [t1].[Name], [t1].[Id2], [t1].[CreatedAt2], [t1].[CreatedBy1], [t1].[DeletedAt2], [t1].[Description1], [t1].[EndDate], [t1].[IsActive1], [t1].[LastModifiedAt2], [t1].[LastModifiedBy2], [t1].[Name0], [t1].[StartDate], [t2].[Id], [t2].[Content], [t2].[Context], [t2].[CreatedAt], [t2].[CreatedBy], [t2].[DeletedAt], [t2].[Description], [t2].[DocumentUrl], [t2].[EN_Title], [t2].[ExpectedOutcomes], [t2].[IsActive], [t2].[LastModifiedAt], [t2].[LastModifiedBy], [t2].[Methodology], [t2].[Objectives], [t2].[PotentialDuplicate], [t2].[Problem], [t2].[Requirements], [t2].[Status], [t2].[SubmittedAt], [t2].[SubmittedBy], [t2].[TopicId], [t2].[VN_title], [t2].[VersionNumber]
+FROM (
+    SELECT TOP(1) [t].[Id], [t].[Abbreviation], [t].[CategoryId], [t].[Content], [t].[Context], [t].[CreatedAt], [t].[CreatedBy], [t].[DeletedAt], [t].[Description], [t].[EN_Title], [t].[IsActive], [t].[IsApproved], [t].[IsLegacy], [t].[LastModifiedAt], [t].[LastModifiedBy], [t].[MaxStudents], [t].[Objectives], [t].[PotentialDuplicate], [t].[Problem], [t].[SemesterId], [t].[SupervisorId], [t].[VN_title], [u].[Id] AS [Id0], [u].[AccessFailedCount], [u].[ConcurrencyStamp], [u].[CreatedAt] AS [CreatedAt0], [u].[DeletedAt] AS [DeletedAt0], [u].[Email], [u].[EmailConfirmed], [u].[LastModifiedAt] AS [LastModifiedAt0], [u].[LastModifiedBy] AS [LastModifiedBy0], [u].[LockoutEnabled], [u].[LockoutEnd], [u].[NormalizedEmail], [u].[NormalizedUserName], [u].[PasswordHash], [u].[PhoneNumber], [u].[PhoneNumberConfirmed], [u].[SecurityStamp], [u].[TwoFactorEnabled], [u].[UserName], [t0].[Id] AS [Id1], [t0].[CreatedAt] AS [CreatedAt1], [t0].[CreatedBy] AS [CreatedBy0], [t0].[DeletedAt] AS [DeletedAt1], [t0].[Description] AS [Description0], [t0].[IsActive] AS [IsActive0], [t0].[LastModifiedAt] AS [LastModifiedAt1], [t0].[LastModifiedBy] AS [LastModifiedBy1], [t0].[Name], [s].[Id] AS [Id2], [s].[CreatedAt] AS [CreatedAt2], [s].[CreatedBy] AS [CreatedBy1], [s].[DeletedAt] AS [DeletedAt2], [s].[Description] AS [Description1], [s].[EndDate], [s].[IsActive] AS [IsActive1], [s].[LastModifiedAt] AS [LastModifiedAt2], [s].[LastModifiedBy] AS [LastModifiedBy2], [s].[Name] AS [Name0], [s].[StartDate]
+    FROM [topics] AS [t]
+    INNER JOIN [users] AS [u] ON [t].[SupervisorId] = [u].[Id]
+    LEFT JOIN [topic_categories] AS [t0] ON [t].[CategoryId] = [t0].[Id]
+    INNER JOIN [semesters] AS [s] ON [t].[SemesterId] = [s].[Id]
+    WHERE [t].[Id] = @__topicId_0 AND [t].[IsActive] = CAST(1 AS bit) AND [t].[DeletedAt] IS NULL
+) AS [t1]
+LEFT JOIN [topic_versions] AS [t2] ON [t1].[Id] = [t2].[TopicId]
+ORDER BY [t1].[Id], [t1].[Id0], [t1].[Id1], [t1].[Id2]
+2025-10-04 02:54:21.342 +07:00 [DBG] Closing data reader to 'capbot_db' on server 'localhost'.
+2025-10-04 02:54:21.342 +07:00 [DBG] A data reader for 'capbot_db' on server 'localhost' is being disposed after spending 0ms reading results.
+2025-10-04 02:54:21.342 +07:00 [DBG] Closing connection to database 'capbot_db' on server 'localhost'.
+2025-10-04 02:54:21.342 +07:00 [DBG] Closed connection to database 'capbot_db' on server 'localhost' (0ms).
+2025-10-04 02:54:21.343 +07:00 [DBG] Opening connection to database 'capbot_db' on server 'localhost'.
+2025-10-04 02:54:21.344 +07:00 [DBG] Opened connection to database 'capbot_db' on server 'localhost'.
+2025-10-04 02:54:21.344 +07:00 [DBG] Creating DbCommand for 'ExecuteReader'.
+2025-10-04 02:54:21.344 +07:00 [DBG] Created DbCommand for 'ExecuteReader' (0ms).
+2025-10-04 02:54:21.344 +07:00 [DBG] Initialized DbCommand for 'ExecuteReader' (0ms).
+2025-10-04 02:54:21.344 +07:00 [DBG] Executing DbCommand [Parameters=[@__topicId_0='?' (DbType = Int32)], CommandType='"Text"', CommandTimeout='30']
+SELECT [s].[Id], [s].[AdditionalNotes], [s].[AiCheckDetails], [s].[AiCheckScore], [s].[AiCheckStatus], [s].[CreatedAt], [s].[CreatedBy], [s].[DeletedAt], [s].[DocumentUrl], [s].[IsActive], [s].[LastModifiedAt], [s].[LastModifiedBy], [s].[PhaseId], [s].[Status], [s].[SubmissionRound], [s].[SubmittedAt], [s].[SubmittedBy], [s].[TopicId], [s].[TopicVersionId], [p].[Id], [p].[CreatedAt], [p].[CreatedBy], [p].[DeletedAt], [p].[EndDate], [p].[IsActive], [p].[LastModifiedAt], [p].[LastModifiedBy], [p].[Name], [p].[PhaseTypeId], [p].[SemesterId], [p].[StartDate], [p].[SubmissionDeadline], [u].[Id], [u].[AccessFailedCount], [u].[ConcurrencyStamp], [u].[CreatedAt], [u].[DeletedAt], [u].[Email], [u].[EmailConfirmed], [u].[LastModifiedAt], [u].[LastModifiedBy], [u].[LockoutEnabled], [u].[LockoutEnd], [u].[NormalizedEmail], [u].[NormalizedUserName], [u].[PasswordHash], [u].[PhoneNumber], [u].[PhoneNumberConfirmed], [u].[SecurityStamp], [u].[TwoFactorEnabled], [u].[UserName], [r].[Id], [r].[AssignedAt], [r].[AssignedBy], [r].[AssignmentType], [r].[CompletedAt], [r].[Deadline], [r].[ReviewerId], [r].[SkillMatchScore], [r].[StartedAt], [r].[Status], [r].[SubmissionId]
+FROM [submissions] AS [s]
+INNER JOIN [phases] AS [p] ON [s].[PhaseId] = [p].[Id]
+INNER JOIN [users] AS [u] ON [s].[SubmittedBy] = [u].[Id]
+LEFT JOIN [reviewer_assignments] AS [r] ON [s].[Id] = [r].[SubmissionId]
+WHERE [s].[TopicId] = @__topicId_0 AND [s].[IsActive] = CAST(1 AS bit) AND [s].[DeletedAt] IS NULL
+ORDER BY [s].[Id], [p].[Id], [u].[Id]
+2025-10-04 02:54:21.362 +07:00 [INF] Executed DbCommand (18ms) [Parameters=[@__topicId_0='?' (DbType = Int32)], CommandType='"Text"', CommandTimeout='30']
+SELECT [s].[Id], [s].[AdditionalNotes], [s].[AiCheckDetails], [s].[AiCheckScore], [s].[AiCheckStatus], [s].[CreatedAt], [s].[CreatedBy], [s].[DeletedAt], [s].[DocumentUrl], [s].[IsActive], [s].[LastModifiedAt], [s].[LastModifiedBy], [s].[PhaseId], [s].[Status], [s].[SubmissionRound], [s].[SubmittedAt], [s].[SubmittedBy], [s].[TopicId], [s].[TopicVersionId], [p].[Id], [p].[CreatedAt], [p].[CreatedBy], [p].[DeletedAt], [p].[EndDate], [p].[IsActive], [p].[LastModifiedAt], [p].[LastModifiedBy], [p].[Name], [p].[PhaseTypeId], [p].[SemesterId], [p].[StartDate], [p].[SubmissionDeadline], [u].[Id], [u].[AccessFailedCount], [u].[ConcurrencyStamp], [u].[CreatedAt], [u].[DeletedAt], [u].[Email], [u].[EmailConfirmed], [u].[LastModifiedAt], [u].[LastModifiedBy], [u].[LockoutEnabled], [u].[LockoutEnd], [u].[NormalizedEmail], [u].[NormalizedUserName], [u].[PasswordHash], [u].[PhoneNumber], [u].[PhoneNumberConfirmed], [u].[SecurityStamp], [u].[TwoFactorEnabled], [u].[UserName], [r].[Id], [r].[AssignedAt], [r].[AssignedBy], [r].[AssignmentType], [r].[CompletedAt], [r].[Deadline], [r].[ReviewerId], [r].[SkillMatchScore], [r].[StartedAt], [r].[Status], [r].[SubmissionId]
+FROM [submissions] AS [s]
+INNER JOIN [phases] AS [p] ON [s].[PhaseId] = [p].[Id]
+INNER JOIN [users] AS [u] ON [s].[SubmittedBy] = [u].[Id]
+LEFT JOIN [reviewer_assignments] AS [r] ON [s].[Id] = [r].[SubmissionId]
+WHERE [s].[TopicId] = @__topicId_0 AND [s].[IsActive] = CAST(1 AS bit) AND [s].[DeletedAt] IS NULL
+ORDER BY [s].[Id], [p].[Id], [u].[Id]
+2025-10-04 02:54:21.363 +07:00 [DBG] Closing data reader to 'capbot_db' on server 'localhost'.
+2025-10-04 02:54:21.363 +07:00 [DBG] A data reader for 'capbot_db' on server 'localhost' is being disposed after spending 0ms reading results.
+2025-10-04 02:54:21.363 +07:00 [DBG] Closing connection to database 'capbot_db' on server 'localhost'.
+2025-10-04 02:54:21.363 +07:00 [DBG] Closed connection to database 'capbot_db' on server 'localhost' (0ms).
+2025-10-04 02:54:21.364 +07:00 [DBG] Opening connection to database 'capbot_db' on server 'localhost'.
+2025-10-04 02:54:21.364 +07:00 [DBG] Opened connection to database 'capbot_db' on server 'localhost'.
+2025-10-04 02:54:21.364 +07:00 [DBG] Creating DbCommand for 'ExecuteReader'.
+2025-10-04 02:54:21.364 +07:00 [DBG] Created DbCommand for 'ExecuteReader' (0ms).
+2025-10-04 02:54:21.364 +07:00 [DBG] Initialized DbCommand for 'ExecuteReader' (0ms).
+2025-10-04 02:54:21.364 +07:00 [DBG] Executing DbCommand [Parameters=[@__p_0='?' (DbType = Int64)], CommandType='"Text"', CommandTimeout='30']
+SELECT TOP(1) [e].[Id], [e].[Caption], [e].[CreatedAt], [e].[EntityId], [e].[EntityType], [e].[FileId], [e].[IsPrimary], [f].[Id], [f].[Alt], [f].[Checksum], [f].[CreatedAt], [f].[CreatedBy], [f].[DeletedAt], [f].[FileName], [f].[FilePath], [f].[FileSize], [f].[FileType], [f].[Height], [f].[IsActive], [f].[LastModifiedAt], [f].[LastModifiedBy], [f].[MimeType], [f].[ThumbnailUrl], [f].[Url], [f].[Width]
+FROM [entity_files] AS [e]
+INNER JOIN [files] AS [f] ON [e].[FileId] = [f].[Id]
+WHERE [e].[EntityId] = @__p_0 AND [e].[EntityType] = 1 AND [e].[IsPrimary] = CAST(1 AS bit)
+2025-10-04 02:54:21.376 +07:00 [INF] Executed DbCommand (12ms) [Parameters=[@__p_0='?' (DbType = Int64)], CommandType='"Text"', CommandTimeout='30']
+SELECT TOP(1) [e].[Id], [e].[Caption], [e].[CreatedAt], [e].[EntityId], [e].[EntityType], [e].[FileId], [e].[IsPrimary], [f].[Id], [f].[Alt], [f].[Checksum], [f].[CreatedAt], [f].[CreatedBy], [f].[DeletedAt], [f].[FileName], [f].[FilePath], [f].[FileSize], [f].[FileType], [f].[Height], [f].[IsActive], [f].[LastModifiedAt], [f].[LastModifiedBy], [f].[MimeType], [f].[ThumbnailUrl], [f].[Url], [f].[Width]
+FROM [entity_files] AS [e]
+INNER JOIN [files] AS [f] ON [e].[FileId] = [f].[Id]
+WHERE [e].[EntityId] = @__p_0 AND [e].[EntityType] = 1 AND [e].[IsPrimary] = CAST(1 AS bit)
+2025-10-04 02:54:21.377 +07:00 [DBG] Closing data reader to 'capbot_db' on server 'localhost'.
+2025-10-04 02:54:21.377 +07:00 [DBG] A data reader for 'capbot_db' on server 'localhost' is being disposed after spending 0ms reading results.
+2025-10-04 02:54:21.377 +07:00 [DBG] Closing connection to database 'capbot_db' on server 'localhost'.
+2025-10-04 02:54:21.377 +07:00 [DBG] Closed connection to database 'capbot_db' on server 'localhost' (0ms).
+2025-10-04 02:54:21.377 +07:00 [DBG] List of registered output formatters, in the following order: ["Microsoft.AspNetCore.OData.Formatter.ODataOutputFormatter","Microsoft.AspNetCore.OData.Formatter.ODataOutputFormatter","Microsoft.AspNetCore.OData.Formatter.ODataOutputFormatter","Microsoft.AspNetCore.Mvc.Formatters.HttpNoContentOutputFormatter","Microsoft.AspNetCore.Mvc.Formatters.StringOutputFormatter","Microsoft.AspNetCore.Mvc.Formatters.StreamOutputFormatter","Microsoft.AspNetCore.Mvc.Formatters.SystemTextJsonOutputFormatter"]
+2025-10-04 02:54:21.377 +07:00 [DBG] No information found on request to perform content negotiation.
+2025-10-04 02:54:21.378 +07:00 [DBG] Attempting to select the first output formatter in the output formatters list which supports a content type from the explicitly specified content types '["application/json"]'.
+2025-10-04 02:54:21.378 +07:00 [DBG] Selected output formatter 'Microsoft.AspNetCore.Mvc.Formatters.SystemTextJsonOutputFormatter' and content type 'application/json' to write the response.
+2025-10-04 02:54:21.378 +07:00 [INF] Executing ObjectResult, writing value of type 'FS.Commons.FSResponse'.
+2025-10-04 02:54:21.378 +07:00 [INF] Executed action CapBot.api.Controllers.TopicController.GetDetail (CapBot.api) in 87.7831ms
+2025-10-04 02:54:21.378 +07:00 [INF] Executed endpoint 'CapBot.api.Controllers.TopicController.GetDetail (CapBot.api)'
+2025-10-04 02:54:21.378 +07:00 [DBG] Connection id "0HNG2MQC634J8" completed keep alive response.
+2025-10-04 02:54:21.378 +07:00 [DBG] 'MyDbContext' disposed.
+2025-10-04 02:54:21.379 +07:00 [DBG] Disposing connection to database 'capbot_db' on server 'localhost'.
+2025-10-04 02:54:21.379 +07:00 [DBG] Disposed connection to database '' on server '' (0ms).
+2025-10-04 02:54:21.379 +07:00 [INF] Request finished HTTP/1.1 GET http://localhost:5207/api/topic/detail/104 - 200 null application/json; charset=utf-8 92.8987ms
+2025-10-04 02:54:21.607 +07:00 [INF] Request starting HTTP/1.1 GET http://localhost:5207/api/topic/detail/104 - null null
+2025-10-04 02:54:21.607 +07:00 [DBG] The request path /api/topic/detail/104 does not match a supported file type
+2025-10-04 02:54:21.607 +07:00 [DBG] The request path /api/topic/detail/104 does not match a supported file type
+2025-10-04 02:54:21.607 +07:00 [DBG] 1 candidate(s) found for the request path '/api/topic/detail/104'
+2025-10-04 02:54:21.608 +07:00 [DBG] Endpoint 'CapBot.api.Controllers.TopicController.GetDetail (CapBot.api)' with route pattern 'api/topic/detail/{topicId}' is valid for the request path '/api/topic/detail/104'
+2025-10-04 02:54:21.608 +07:00 [DBG] Request matched endpoint 'CapBot.api.Controllers.TopicController.GetDetail (CapBot.api)'
+2025-10-04 02:54:21.608 +07:00 [DBG] Successfully validated the token.
+2025-10-04 02:54:21.608 +07:00 [DBG] AuthenticationScheme: Bearer was successfully authenticated.
+2025-10-04 02:54:21.608 +07:00 [INF] Executing endpoint 'CapBot.api.Controllers.TopicController.GetDetail (CapBot.api)'
+2025-10-04 02:54:21.609 +07:00 [INF] Route matched with {action = "GetDetail", controller = "Topic"}. Executing controller action with signature System.Threading.Tasks.Task`1[Microsoft.AspNetCore.Mvc.IActionResult] GetDetail(Int32) on controller CapBot.api.Controllers.TopicController (CapBot.api).
+2025-10-04 02:54:21.609 +07:00 [DBG] Execution plan of authorization filters (in the following order): ["None"]
+2025-10-04 02:54:21.609 +07:00 [DBG] Execution plan of resource filters (in the following order): ["Microsoft.AspNetCore.Mvc.ConsumesAttribute"]
+2025-10-04 02:54:21.609 +07:00 [DBG] Execution plan of action filters (in the following order): ["Microsoft.AspNetCore.Mvc.ModelBinding.UnsupportedContentTypeFilter (Order: -3000)"]
+2025-10-04 02:54:21.609 +07:00 [DBG] Execution plan of exception filters (in the following order): ["None"]
+2025-10-04 02:54:21.609 +07:00 [DBG] Execution plan of result filters (in the following order): ["Microsoft.AspNetCore.Mvc.Infrastructure.ClientErrorResultFilter (Order: -2000)","Microsoft.AspNetCore.Mvc.ProducesAttribute (Order: 0)"]
+2025-10-04 02:54:21.609 +07:00 [DBG] Executing controller factory for controller CapBot.api.Controllers.TopicController (CapBot.api)
+2025-10-04 02:54:21.610 +07:00 [DBG] Executed controller factory for controller CapBot.api.Controllers.TopicController (CapBot.api)
+2025-10-04 02:54:21.610 +07:00 [DBG] Attempting to bind parameter 'topicId' of type 'System.Int32' ...
+2025-10-04 02:54:21.610 +07:00 [DBG] Attempting to bind parameter 'topicId' of type 'System.Int32' using the name 'topicId' in request data ...
+2025-10-04 02:54:21.610 +07:00 [DBG] Done attempting to bind parameter 'topicId' of type 'System.Int32'.
+2025-10-04 02:54:21.610 +07:00 [DBG] Done attempting to bind parameter 'topicId' of type 'System.Int32'.
+2025-10-04 02:54:21.610 +07:00 [DBG] Attempting to validate the bound parameter 'topicId' of type 'System.Int32' ...
+2025-10-04 02:54:21.610 +07:00 [DBG] Done attempting to validate the bound parameter 'topicId' of type 'System.Int32'.
+2025-10-04 02:54:21.611 +07:00 [DBG] Entity Framework Core 8.0.16 initialized 'MyDbContext' using provider 'Microsoft.EntityFrameworkCore.SqlServer:8.0.13' with options: MigrationsAssembly=App.DAL 
+2025-10-04 02:54:21.612 +07:00 [DBG] Creating DbConnection.
+2025-10-04 02:54:21.613 +07:00 [DBG] Created DbConnection. (0ms).
+2025-10-04 02:54:21.613 +07:00 [DBG] Opening connection to database 'capbot_db' on server 'localhost'.
+2025-10-04 02:54:21.613 +07:00 [DBG] Opened connection to database 'capbot_db' on server 'localhost'.
+2025-10-04 02:54:21.613 +07:00 [DBG] Creating DbCommand for 'ExecuteReader'.
+2025-10-04 02:54:21.613 +07:00 [DBG] Created DbCommand for 'ExecuteReader' (0ms).
+2025-10-04 02:54:21.613 +07:00 [DBG] Initialized DbCommand for 'ExecuteReader' (0ms).
+2025-10-04 02:54:21.615 +07:00 [DBG] Executing DbCommand [Parameters=[@__topicId_0='?' (DbType = Int32)], CommandType='"Text"', CommandTimeout='30']
+SELECT [t1].[Id], [t1].[Abbreviation], [t1].[CategoryId], [t1].[Content], [t1].[Context], [t1].[CreatedAt], [t1].[CreatedBy], [t1].[DeletedAt], [t1].[Description], [t1].[EN_Title], [t1].[IsActive], [t1].[IsApproved], [t1].[IsLegacy], [t1].[LastModifiedAt], [t1].[LastModifiedBy], [t1].[MaxStudents], [t1].[Objectives], [t1].[PotentialDuplicate], [t1].[Problem], [t1].[SemesterId], [t1].[SupervisorId], [t1].[VN_title], [t1].[Id0], [t1].[AccessFailedCount], [t1].[ConcurrencyStamp], [t1].[CreatedAt0], [t1].[DeletedAt0], [t1].[Email], [t1].[EmailConfirmed], [t1].[LastModifiedAt0], [t1].[LastModifiedBy0], [t1].[LockoutEnabled], [t1].[LockoutEnd], [t1].[NormalizedEmail], [t1].[NormalizedUserName], [t1].[PasswordHash], [t1].[PhoneNumber], [t1].[PhoneNumberConfirmed], [t1].[SecurityStamp], [t1].[TwoFactorEnabled], [t1].[UserName], [t1].[Id1], [t1].[CreatedAt1], [t1].[CreatedBy0], [t1].[DeletedAt1], [t1].[Description0], [t1].[IsActive0], [t1].[LastModifiedAt1], [t1].[LastModifiedBy1], [t1].[Name], [t1].[Id2], [t1].[CreatedAt2], [t1].[CreatedBy1], [t1].[DeletedAt2], [t1].[Description1], [t1].[EndDate], [t1].[IsActive1], [t1].[LastModifiedAt2], [t1].[LastModifiedBy2], [t1].[Name0], [t1].[StartDate], [t2].[Id], [t2].[Content], [t2].[Context], [t2].[CreatedAt], [t2].[CreatedBy], [t2].[DeletedAt], [t2].[Description], [t2].[DocumentUrl], [t2].[EN_Title], [t2].[ExpectedOutcomes], [t2].[IsActive], [t2].[LastModifiedAt], [t2].[LastModifiedBy], [t2].[Methodology], [t2].[Objectives], [t2].[PotentialDuplicate], [t2].[Problem], [t2].[Requirements], [t2].[Status], [t2].[SubmittedAt], [t2].[SubmittedBy], [t2].[TopicId], [t2].[VN_title], [t2].[VersionNumber]
+FROM (
+    SELECT TOP(1) [t].[Id], [t].[Abbreviation], [t].[CategoryId], [t].[Content], [t].[Context], [t].[CreatedAt], [t].[CreatedBy], [t].[DeletedAt], [t].[Description], [t].[EN_Title], [t].[IsActive], [t].[IsApproved], [t].[IsLegacy], [t].[LastModifiedAt], [t].[LastModifiedBy], [t].[MaxStudents], [t].[Objectives], [t].[PotentialDuplicate], [t].[Problem], [t].[SemesterId], [t].[SupervisorId], [t].[VN_title], [u].[Id] AS [Id0], [u].[AccessFailedCount], [u].[ConcurrencyStamp], [u].[CreatedAt] AS [CreatedAt0], [u].[DeletedAt] AS [DeletedAt0], [u].[Email], [u].[EmailConfirmed], [u].[LastModifiedAt] AS [LastModifiedAt0], [u].[LastModifiedBy] AS [LastModifiedBy0], [u].[LockoutEnabled], [u].[LockoutEnd], [u].[NormalizedEmail], [u].[NormalizedUserName], [u].[PasswordHash], [u].[PhoneNumber], [u].[PhoneNumberConfirmed], [u].[SecurityStamp], [u].[TwoFactorEnabled], [u].[UserName], [t0].[Id] AS [Id1], [t0].[CreatedAt] AS [CreatedAt1], [t0].[CreatedBy] AS [CreatedBy0], [t0].[DeletedAt] AS [DeletedAt1], [t0].[Description] AS [Description0], [t0].[IsActive] AS [IsActive0], [t0].[LastModifiedAt] AS [LastModifiedAt1], [t0].[LastModifiedBy] AS [LastModifiedBy1], [t0].[Name], [s].[Id] AS [Id2], [s].[CreatedAt] AS [CreatedAt2], [s].[CreatedBy] AS [CreatedBy1], [s].[DeletedAt] AS [DeletedAt2], [s].[Description] AS [Description1], [s].[EndDate], [s].[IsActive] AS [IsActive1], [s].[LastModifiedAt] AS [LastModifiedAt2], [s].[LastModifiedBy] AS [LastModifiedBy2], [s].[Name] AS [Name0], [s].[StartDate]
+    FROM [topics] AS [t]
+    INNER JOIN [users] AS [u] ON [t].[SupervisorId] = [u].[Id]
+    LEFT JOIN [topic_categories] AS [t0] ON [t].[CategoryId] = [t0].[Id]
+    INNER JOIN [semesters] AS [s] ON [t].[SemesterId] = [s].[Id]
+    WHERE [t].[Id] = @__topicId_0 AND [t].[IsActive] = CAST(1 AS bit) AND [t].[DeletedAt] IS NULL
+) AS [t1]
+LEFT JOIN [topic_versions] AS [t2] ON [t1].[Id] = [t2].[TopicId]
+ORDER BY [t1].[Id], [t1].[Id0], [t1].[Id1], [t1].[Id2]
+2025-10-04 02:54:21.641 +07:00 [INF] Executed DbCommand (26ms) [Parameters=[@__topicId_0='?' (DbType = Int32)], CommandType='"Text"', CommandTimeout='30']
+SELECT [t1].[Id], [t1].[Abbreviation], [t1].[CategoryId], [t1].[Content], [t1].[Context], [t1].[CreatedAt], [t1].[CreatedBy], [t1].[DeletedAt], [t1].[Description], [t1].[EN_Title], [t1].[IsActive], [t1].[IsApproved], [t1].[IsLegacy], [t1].[LastModifiedAt], [t1].[LastModifiedBy], [t1].[MaxStudents], [t1].[Objectives], [t1].[PotentialDuplicate], [t1].[Problem], [t1].[SemesterId], [t1].[SupervisorId], [t1].[VN_title], [t1].[Id0], [t1].[AccessFailedCount], [t1].[ConcurrencyStamp], [t1].[CreatedAt0], [t1].[DeletedAt0], [t1].[Email], [t1].[EmailConfirmed], [t1].[LastModifiedAt0], [t1].[LastModifiedBy0], [t1].[LockoutEnabled], [t1].[LockoutEnd], [t1].[NormalizedEmail], [t1].[NormalizedUserName], [t1].[PasswordHash], [t1].[PhoneNumber], [t1].[PhoneNumberConfirmed], [t1].[SecurityStamp], [t1].[TwoFactorEnabled], [t1].[UserName], [t1].[Id1], [t1].[CreatedAt1], [t1].[CreatedBy0], [t1].[DeletedAt1], [t1].[Description0], [t1].[IsActive0], [t1].[LastModifiedAt1], [t1].[LastModifiedBy1], [t1].[Name], [t1].[Id2], [t1].[CreatedAt2], [t1].[CreatedBy1], [t1].[DeletedAt2], [t1].[Description1], [t1].[EndDate], [t1].[IsActive1], [t1].[LastModifiedAt2], [t1].[LastModifiedBy2], [t1].[Name0], [t1].[StartDate], [t2].[Id], [t2].[Content], [t2].[Context], [t2].[CreatedAt], [t2].[CreatedBy], [t2].[DeletedAt], [t2].[Description], [t2].[DocumentUrl], [t2].[EN_Title], [t2].[ExpectedOutcomes], [t2].[IsActive], [t2].[LastModifiedAt], [t2].[LastModifiedBy], [t2].[Methodology], [t2].[Objectives], [t2].[PotentialDuplicate], [t2].[Problem], [t2].[Requirements], [t2].[Status], [t2].[SubmittedAt], [t2].[SubmittedBy], [t2].[TopicId], [t2].[VN_title], [t2].[VersionNumber]
+FROM (
+    SELECT TOP(1) [t].[Id], [t].[Abbreviation], [t].[CategoryId], [t].[Content], [t].[Context], [t].[CreatedAt], [t].[CreatedBy], [t].[DeletedAt], [t].[Description], [t].[EN_Title], [t].[IsActive], [t].[IsApproved], [t].[IsLegacy], [t].[LastModifiedAt], [t].[LastModifiedBy], [t].[MaxStudents], [t].[Objectives], [t].[PotentialDuplicate], [t].[Problem], [t].[SemesterId], [t].[SupervisorId], [t].[VN_title], [u].[Id] AS [Id0], [u].[AccessFailedCount], [u].[ConcurrencyStamp], [u].[CreatedAt] AS [CreatedAt0], [u].[DeletedAt] AS [DeletedAt0], [u].[Email], [u].[EmailConfirmed], [u].[LastModifiedAt] AS [LastModifiedAt0], [u].[LastModifiedBy] AS [LastModifiedBy0], [u].[LockoutEnabled], [u].[LockoutEnd], [u].[NormalizedEmail], [u].[NormalizedUserName], [u].[PasswordHash], [u].[PhoneNumber], [u].[PhoneNumberConfirmed], [u].[SecurityStamp], [u].[TwoFactorEnabled], [u].[UserName], [t0].[Id] AS [Id1], [t0].[CreatedAt] AS [CreatedAt1], [t0].[CreatedBy] AS [CreatedBy0], [t0].[DeletedAt] AS [DeletedAt1], [t0].[Description] AS [Description0], [t0].[IsActive] AS [IsActive0], [t0].[LastModifiedAt] AS [LastModifiedAt1], [t0].[LastModifiedBy] AS [LastModifiedBy1], [t0].[Name], [s].[Id] AS [Id2], [s].[CreatedAt] AS [CreatedAt2], [s].[CreatedBy] AS [CreatedBy1], [s].[DeletedAt] AS [DeletedAt2], [s].[Description] AS [Description1], [s].[EndDate], [s].[IsActive] AS [IsActive1], [s].[LastModifiedAt] AS [LastModifiedAt2], [s].[LastModifiedBy] AS [LastModifiedBy2], [s].[Name] AS [Name0], [s].[StartDate]
+    FROM [topics] AS [t]
+    INNER JOIN [users] AS [u] ON [t].[SupervisorId] = [u].[Id]
+    LEFT JOIN [topic_categories] AS [t0] ON [t].[CategoryId] = [t0].[Id]
+    INNER JOIN [semesters] AS [s] ON [t].[SemesterId] = [s].[Id]
+    WHERE [t].[Id] = @__topicId_0 AND [t].[IsActive] = CAST(1 AS bit) AND [t].[DeletedAt] IS NULL
+) AS [t1]
+LEFT JOIN [topic_versions] AS [t2] ON [t1].[Id] = [t2].[TopicId]
+ORDER BY [t1].[Id], [t1].[Id0], [t1].[Id1], [t1].[Id2]
+2025-10-04 02:54:21.643 +07:00 [DBG] Closing data reader to 'capbot_db' on server 'localhost'.
+2025-10-04 02:54:21.643 +07:00 [DBG] A data reader for 'capbot_db' on server 'localhost' is being disposed after spending 0ms reading results.
+2025-10-04 02:54:21.643 +07:00 [DBG] Closing connection to database 'capbot_db' on server 'localhost'.
+2025-10-04 02:54:21.643 +07:00 [DBG] Closed connection to database 'capbot_db' on server 'localhost' (0ms).
+2025-10-04 02:54:21.644 +07:00 [DBG] Opening connection to database 'capbot_db' on server 'localhost'.
+2025-10-04 02:54:21.644 +07:00 [DBG] Opened connection to database 'capbot_db' on server 'localhost'.
+2025-10-04 02:54:21.644 +07:00 [DBG] Creating DbCommand for 'ExecuteReader'.
+2025-10-04 02:54:21.644 +07:00 [DBG] Created DbCommand for 'ExecuteReader' (0ms).
+2025-10-04 02:54:21.644 +07:00 [DBG] Initialized DbCommand for 'ExecuteReader' (0ms).
+2025-10-04 02:54:21.644 +07:00 [DBG] Executing DbCommand [Parameters=[@__topicId_0='?' (DbType = Int32)], CommandType='"Text"', CommandTimeout='30']
+SELECT [s].[Id], [s].[AdditionalNotes], [s].[AiCheckDetails], [s].[AiCheckScore], [s].[AiCheckStatus], [s].[CreatedAt], [s].[CreatedBy], [s].[DeletedAt], [s].[DocumentUrl], [s].[IsActive], [s].[LastModifiedAt], [s].[LastModifiedBy], [s].[PhaseId], [s].[Status], [s].[SubmissionRound], [s].[SubmittedAt], [s].[SubmittedBy], [s].[TopicId], [s].[TopicVersionId], [p].[Id], [p].[CreatedAt], [p].[CreatedBy], [p].[DeletedAt], [p].[EndDate], [p].[IsActive], [p].[LastModifiedAt], [p].[LastModifiedBy], [p].[Name], [p].[PhaseTypeId], [p].[SemesterId], [p].[StartDate], [p].[SubmissionDeadline], [u].[Id], [u].[AccessFailedCount], [u].[ConcurrencyStamp], [u].[CreatedAt], [u].[DeletedAt], [u].[Email], [u].[EmailConfirmed], [u].[LastModifiedAt], [u].[LastModifiedBy], [u].[LockoutEnabled], [u].[LockoutEnd], [u].[NormalizedEmail], [u].[NormalizedUserName], [u].[PasswordHash], [u].[PhoneNumber], [u].[PhoneNumberConfirmed], [u].[SecurityStamp], [u].[TwoFactorEnabled], [u].[UserName], [r].[Id], [r].[AssignedAt], [r].[AssignedBy], [r].[AssignmentType], [r].[CompletedAt], [r].[Deadline], [r].[ReviewerId], [r].[SkillMatchScore], [r].[StartedAt], [r].[Status], [r].[SubmissionId]
+FROM [submissions] AS [s]
+INNER JOIN [phases] AS [p] ON [s].[PhaseId] = [p].[Id]
+INNER JOIN [users] AS [u] ON [s].[SubmittedBy] = [u].[Id]
+LEFT JOIN [reviewer_assignments] AS [r] ON [s].[Id] = [r].[SubmissionId]
+WHERE [s].[TopicId] = @__topicId_0 AND [s].[IsActive] = CAST(1 AS bit) AND [s].[DeletedAt] IS NULL
+ORDER BY [s].[Id], [p].[Id], [u].[Id]
+2025-10-04 02:54:21.658 +07:00 [INF] Executed DbCommand (14ms) [Parameters=[@__topicId_0='?' (DbType = Int32)], CommandType='"Text"', CommandTimeout='30']
+SELECT [s].[Id], [s].[AdditionalNotes], [s].[AiCheckDetails], [s].[AiCheckScore], [s].[AiCheckStatus], [s].[CreatedAt], [s].[CreatedBy], [s].[DeletedAt], [s].[DocumentUrl], [s].[IsActive], [s].[LastModifiedAt], [s].[LastModifiedBy], [s].[PhaseId], [s].[Status], [s].[SubmissionRound], [s].[SubmittedAt], [s].[SubmittedBy], [s].[TopicId], [s].[TopicVersionId], [p].[Id], [p].[CreatedAt], [p].[CreatedBy], [p].[DeletedAt], [p].[EndDate], [p].[IsActive], [p].[LastModifiedAt], [p].[LastModifiedBy], [p].[Name], [p].[PhaseTypeId], [p].[SemesterId], [p].[StartDate], [p].[SubmissionDeadline], [u].[Id], [u].[AccessFailedCount], [u].[ConcurrencyStamp], [u].[CreatedAt], [u].[DeletedAt], [u].[Email], [u].[EmailConfirmed], [u].[LastModifiedAt], [u].[LastModifiedBy], [u].[LockoutEnabled], [u].[LockoutEnd], [u].[NormalizedEmail], [u].[NormalizedUserName], [u].[PasswordHash], [u].[PhoneNumber], [u].[PhoneNumberConfirmed], [u].[SecurityStamp], [u].[TwoFactorEnabled], [u].[UserName], [r].[Id], [r].[AssignedAt], [r].[AssignedBy], [r].[AssignmentType], [r].[CompletedAt], [r].[Deadline], [r].[ReviewerId], [r].[SkillMatchScore], [r].[StartedAt], [r].[Status], [r].[SubmissionId]
+FROM [submissions] AS [s]
+INNER JOIN [phases] AS [p] ON [s].[PhaseId] = [p].[Id]
+INNER JOIN [users] AS [u] ON [s].[SubmittedBy] = [u].[Id]
+LEFT JOIN [reviewer_assignments] AS [r] ON [s].[Id] = [r].[SubmissionId]
+WHERE [s].[TopicId] = @__topicId_0 AND [s].[IsActive] = CAST(1 AS bit) AND [s].[DeletedAt] IS NULL
+ORDER BY [s].[Id], [p].[Id], [u].[Id]
+2025-10-04 02:54:21.659 +07:00 [DBG] Closing data reader to 'capbot_db' on server 'localhost'.
+2025-10-04 02:54:21.659 +07:00 [DBG] A data reader for 'capbot_db' on server 'localhost' is being disposed after spending 0ms reading results.
+2025-10-04 02:54:21.659 +07:00 [DBG] Closing connection to database 'capbot_db' on server 'localhost'.
+2025-10-04 02:54:21.659 +07:00 [DBG] Closed connection to database 'capbot_db' on server 'localhost' (0ms).
+2025-10-04 02:54:21.660 +07:00 [DBG] Opening connection to database 'capbot_db' on server 'localhost'.
+2025-10-04 02:54:21.660 +07:00 [DBG] Opened connection to database 'capbot_db' on server 'localhost'.
+2025-10-04 02:54:21.660 +07:00 [DBG] Creating DbCommand for 'ExecuteReader'.
+2025-10-04 02:54:21.660 +07:00 [DBG] Created DbCommand for 'ExecuteReader' (0ms).
+2025-10-04 02:54:21.661 +07:00 [DBG] Initialized DbCommand for 'ExecuteReader' (0ms).
+2025-10-04 02:54:21.661 +07:00 [DBG] Executing DbCommand [Parameters=[@__p_0='?' (DbType = Int64)], CommandType='"Text"', CommandTimeout='30']
+SELECT TOP(1) [e].[Id], [e].[Caption], [e].[CreatedAt], [e].[EntityId], [e].[EntityType], [e].[FileId], [e].[IsPrimary], [f].[Id], [f].[Alt], [f].[Checksum], [f].[CreatedAt], [f].[CreatedBy], [f].[DeletedAt], [f].[FileName], [f].[FilePath], [f].[FileSize], [f].[FileType], [f].[Height], [f].[IsActive], [f].[LastModifiedAt], [f].[LastModifiedBy], [f].[MimeType], [f].[ThumbnailUrl], [f].[Url], [f].[Width]
+FROM [entity_files] AS [e]
+INNER JOIN [files] AS [f] ON [e].[FileId] = [f].[Id]
+WHERE [e].[EntityId] = @__p_0 AND [e].[EntityType] = 1 AND [e].[IsPrimary] = CAST(1 AS bit)
+2025-10-04 02:54:21.663 +07:00 [INF] Executed DbCommand (2ms) [Parameters=[@__p_0='?' (DbType = Int64)], CommandType='"Text"', CommandTimeout='30']
+SELECT TOP(1) [e].[Id], [e].[Caption], [e].[CreatedAt], [e].[EntityId], [e].[EntityType], [e].[FileId], [e].[IsPrimary], [f].[Id], [f].[Alt], [f].[Checksum], [f].[CreatedAt], [f].[CreatedBy], [f].[DeletedAt], [f].[FileName], [f].[FilePath], [f].[FileSize], [f].[FileType], [f].[Height], [f].[IsActive], [f].[LastModifiedAt], [f].[LastModifiedBy], [f].[MimeType], [f].[ThumbnailUrl], [f].[Url], [f].[Width]
+FROM [entity_files] AS [e]
+INNER JOIN [files] AS [f] ON [e].[FileId] = [f].[Id]
+WHERE [e].[EntityId] = @__p_0 AND [e].[EntityType] = 1 AND [e].[IsPrimary] = CAST(1 AS bit)
+2025-10-04 02:54:21.663 +07:00 [DBG] Closing data reader to 'capbot_db' on server 'localhost'.
+2025-10-04 02:54:21.663 +07:00 [DBG] A data reader for 'capbot_db' on server 'localhost' is being disposed after spending 0ms reading results.
+2025-10-04 02:54:21.663 +07:00 [DBG] Closing connection to database 'capbot_db' on server 'localhost'.
+2025-10-04 02:54:21.663 +07:00 [DBG] Closed connection to database 'capbot_db' on server 'localhost' (0ms).
+2025-10-04 02:54:21.663 +07:00 [DBG] List of registered output formatters, in the following order: ["Microsoft.AspNetCore.OData.Formatter.ODataOutputFormatter","Microsoft.AspNetCore.OData.Formatter.ODataOutputFormatter","Microsoft.AspNetCore.OData.Formatter.ODataOutputFormatter","Microsoft.AspNetCore.Mvc.Formatters.HttpNoContentOutputFormatter","Microsoft.AspNetCore.Mvc.Formatters.StringOutputFormatter","Microsoft.AspNetCore.Mvc.Formatters.StreamOutputFormatter","Microsoft.AspNetCore.Mvc.Formatters.SystemTextJsonOutputFormatter"]
+2025-10-04 02:54:21.664 +07:00 [DBG] No information found on request to perform content negotiation.
+2025-10-04 02:54:21.664 +07:00 [DBG] Attempting to select the first output formatter in the output formatters list which supports a content type from the explicitly specified content types '["application/json"]'.
+2025-10-04 02:54:21.664 +07:00 [DBG] Selected output formatter 'Microsoft.AspNetCore.Mvc.Formatters.SystemTextJsonOutputFormatter' and content type 'application/json' to write the response.
+2025-10-04 02:54:21.664 +07:00 [INF] Executing ObjectResult, writing value of type 'FS.Commons.FSResponse'.
+2025-10-04 02:54:21.664 +07:00 [INF] Executed action CapBot.api.Controllers.TopicController.GetDetail (CapBot.api) in 55.1827ms
+2025-10-04 02:54:21.664 +07:00 [INF] Executed endpoint 'CapBot.api.Controllers.TopicController.GetDetail (CapBot.api)'
+2025-10-04 02:54:21.665 +07:00 [DBG] Connection id "0HNG2MQC634J8" completed keep alive response.
+2025-10-04 02:54:21.665 +07:00 [DBG] 'MyDbContext' disposed.
+2025-10-04 02:54:21.665 +07:00 [DBG] Disposing connection to database 'capbot_db' on server 'localhost'.
+2025-10-04 02:54:21.665 +07:00 [DBG] Disposed connection to database '' on server '' (0ms).
+2025-10-04 02:54:21.665 +07:00 [INF] Request finished HTTP/1.1 GET http://localhost:5207/api/topic/detail/104 - 200 null application/json; charset=utf-8 58.4499ms
+2025-10-04 02:54:21.798 +07:00 [INF] Request starting HTTP/1.1 GET http://localhost:5207/api/topic/detail/104 - null null
+2025-10-04 02:54:21.799 +07:00 [DBG] The request path /api/topic/detail/104 does not match a supported file type
+2025-10-04 02:54:21.799 +07:00 [DBG] The request path /api/topic/detail/104 does not match a supported file type
+2025-10-04 02:54:21.799 +07:00 [DBG] 1 candidate(s) found for the request path '/api/topic/detail/104'
+2025-10-04 02:54:21.800 +07:00 [DBG] Endpoint 'CapBot.api.Controllers.TopicController.GetDetail (CapBot.api)' with route pattern 'api/topic/detail/{topicId}' is valid for the request path '/api/topic/detail/104'
+2025-10-04 02:54:21.800 +07:00 [DBG] Request matched endpoint 'CapBot.api.Controllers.TopicController.GetDetail (CapBot.api)'
+2025-10-04 02:54:21.803 +07:00 [DBG] Successfully validated the token.
+2025-10-04 02:54:21.803 +07:00 [DBG] AuthenticationScheme: Bearer was successfully authenticated.
+2025-10-04 02:54:21.804 +07:00 [INF] Executing endpoint 'CapBot.api.Controllers.TopicController.GetDetail (CapBot.api)'
+2025-10-04 02:54:21.804 +07:00 [INF] Route matched with {action = "GetDetail", controller = "Topic"}. Executing controller action with signature System.Threading.Tasks.Task`1[Microsoft.AspNetCore.Mvc.IActionResult] GetDetail(Int32) on controller CapBot.api.Controllers.TopicController (CapBot.api).
+2025-10-04 02:54:21.804 +07:00 [DBG] Execution plan of authorization filters (in the following order): ["None"]
+2025-10-04 02:54:21.804 +07:00 [DBG] Execution plan of resource filters (in the following order): ["Microsoft.AspNetCore.Mvc.ConsumesAttribute"]
+2025-10-04 02:54:21.804 +07:00 [DBG] Execution plan of action filters (in the following order): ["Microsoft.AspNetCore.Mvc.ModelBinding.UnsupportedContentTypeFilter (Order: -3000)"]
+2025-10-04 02:54:21.804 +07:00 [DBG] Execution plan of exception filters (in the following order): ["None"]
+2025-10-04 02:54:21.804 +07:00 [DBG] Execution plan of result filters (in the following order): ["Microsoft.AspNetCore.Mvc.Infrastructure.ClientErrorResultFilter (Order: -2000)","Microsoft.AspNetCore.Mvc.ProducesAttribute (Order: 0)"]
+2025-10-04 02:54:21.805 +07:00 [DBG] Executing controller factory for controller CapBot.api.Controllers.TopicController (CapBot.api)
+2025-10-04 02:54:21.806 +07:00 [DBG] Executed controller factory for controller CapBot.api.Controllers.TopicController (CapBot.api)
+2025-10-04 02:54:21.806 +07:00 [DBG] Attempting to bind parameter 'topicId' of type 'System.Int32' ...
+2025-10-04 02:54:21.806 +07:00 [DBG] Attempting to bind parameter 'topicId' of type 'System.Int32' using the name 'topicId' in request data ...
+2025-10-04 02:54:21.806 +07:00 [DBG] Done attempting to bind parameter 'topicId' of type 'System.Int32'.
+2025-10-04 02:54:21.807 +07:00 [DBG] Done attempting to bind parameter 'topicId' of type 'System.Int32'.
+2025-10-04 02:54:21.807 +07:00 [DBG] Attempting to validate the bound parameter 'topicId' of type 'System.Int32' ...
+2025-10-04 02:54:21.807 +07:00 [DBG] Done attempting to validate the bound parameter 'topicId' of type 'System.Int32'.
+2025-10-04 02:54:21.809 +07:00 [DBG] Entity Framework Core 8.0.16 initialized 'MyDbContext' using provider 'Microsoft.EntityFrameworkCore.SqlServer:8.0.13' with options: MigrationsAssembly=App.DAL 
+2025-10-04 02:54:21.810 +07:00 [DBG] Creating DbConnection.
+2025-10-04 02:54:21.810 +07:00 [DBG] Created DbConnection. (0ms).
+2025-10-04 02:54:21.810 +07:00 [DBG] Opening connection to database 'capbot_db' on server 'localhost'.
+2025-10-04 02:54:21.810 +07:00 [DBG] Opened connection to database 'capbot_db' on server 'localhost'.
+2025-10-04 02:54:21.811 +07:00 [DBG] Creating DbCommand for 'ExecuteReader'.
+2025-10-04 02:54:21.811 +07:00 [DBG] Created DbCommand for 'ExecuteReader' (0ms).
+2025-10-04 02:54:21.811 +07:00 [DBG] Initialized DbCommand for 'ExecuteReader' (0ms).
+2025-10-04 02:54:21.811 +07:00 [DBG] Executing DbCommand [Parameters=[@__topicId_0='?' (DbType = Int32)], CommandType='"Text"', CommandTimeout='30']
+SELECT [t1].[Id], [t1].[Abbreviation], [t1].[CategoryId], [t1].[Content], [t1].[Context], [t1].[CreatedAt], [t1].[CreatedBy], [t1].[DeletedAt], [t1].[Description], [t1].[EN_Title], [t1].[IsActive], [t1].[IsApproved], [t1].[IsLegacy], [t1].[LastModifiedAt], [t1].[LastModifiedBy], [t1].[MaxStudents], [t1].[Objectives], [t1].[PotentialDuplicate], [t1].[Problem], [t1].[SemesterId], [t1].[SupervisorId], [t1].[VN_title], [t1].[Id0], [t1].[AccessFailedCount], [t1].[ConcurrencyStamp], [t1].[CreatedAt0], [t1].[DeletedAt0], [t1].[Email], [t1].[EmailConfirmed], [t1].[LastModifiedAt0], [t1].[LastModifiedBy0], [t1].[LockoutEnabled], [t1].[LockoutEnd], [t1].[NormalizedEmail], [t1].[NormalizedUserName], [t1].[PasswordHash], [t1].[PhoneNumber], [t1].[PhoneNumberConfirmed], [t1].[SecurityStamp], [t1].[TwoFactorEnabled], [t1].[UserName], [t1].[Id1], [t1].[CreatedAt1], [t1].[CreatedBy0], [t1].[DeletedAt1], [t1].[Description0], [t1].[IsActive0], [t1].[LastModifiedAt1], [t1].[LastModifiedBy1], [t1].[Name], [t1].[Id2], [t1].[CreatedAt2], [t1].[CreatedBy1], [t1].[DeletedAt2], [t1].[Description1], [t1].[EndDate], [t1].[IsActive1], [t1].[LastModifiedAt2], [t1].[LastModifiedBy2], [t1].[Name0], [t1].[StartDate], [t2].[Id], [t2].[Content], [t2].[Context], [t2].[CreatedAt], [t2].[CreatedBy], [t2].[DeletedAt], [t2].[Description], [t2].[DocumentUrl], [t2].[EN_Title], [t2].[ExpectedOutcomes], [t2].[IsActive], [t2].[LastModifiedAt], [t2].[LastModifiedBy], [t2].[Methodology], [t2].[Objectives], [t2].[PotentialDuplicate], [t2].[Problem], [t2].[Requirements], [t2].[Status], [t2].[SubmittedAt], [t2].[SubmittedBy], [t2].[TopicId], [t2].[VN_title], [t2].[VersionNumber]
+FROM (
+    SELECT TOP(1) [t].[Id], [t].[Abbreviation], [t].[CategoryId], [t].[Content], [t].[Context], [t].[CreatedAt], [t].[CreatedBy], [t].[DeletedAt], [t].[Description], [t].[EN_Title], [t].[IsActive], [t].[IsApproved], [t].[IsLegacy], [t].[LastModifiedAt], [t].[LastModifiedBy], [t].[MaxStudents], [t].[Objectives], [t].[PotentialDuplicate], [t].[Problem], [t].[SemesterId], [t].[SupervisorId], [t].[VN_title], [u].[Id] AS [Id0], [u].[AccessFailedCount], [u].[ConcurrencyStamp], [u].[CreatedAt] AS [CreatedAt0], [u].[DeletedAt] AS [DeletedAt0], [u].[Email], [u].[EmailConfirmed], [u].[LastModifiedAt] AS [LastModifiedAt0], [u].[LastModifiedBy] AS [LastModifiedBy0], [u].[LockoutEnabled], [u].[LockoutEnd], [u].[NormalizedEmail], [u].[NormalizedUserName], [u].[PasswordHash], [u].[PhoneNumber], [u].[PhoneNumberConfirmed], [u].[SecurityStamp], [u].[TwoFactorEnabled], [u].[UserName], [t0].[Id] AS [Id1], [t0].[CreatedAt] AS [CreatedAt1], [t0].[CreatedBy] AS [CreatedBy0], [t0].[DeletedAt] AS [DeletedAt1], [t0].[Description] AS [Description0], [t0].[IsActive] AS [IsActive0], [t0].[LastModifiedAt] AS [LastModifiedAt1], [t0].[LastModifiedBy] AS [LastModifiedBy1], [t0].[Name], [s].[Id] AS [Id2], [s].[CreatedAt] AS [CreatedAt2], [s].[CreatedBy] AS [CreatedBy1], [s].[DeletedAt] AS [DeletedAt2], [s].[Description] AS [Description1], [s].[EndDate], [s].[IsActive] AS [IsActive1], [s].[LastModifiedAt] AS [LastModifiedAt2], [s].[LastModifiedBy] AS [LastModifiedBy2], [s].[Name] AS [Name0], [s].[StartDate]
+    FROM [topics] AS [t]
+    INNER JOIN [users] AS [u] ON [t].[SupervisorId] = [u].[Id]
+    LEFT JOIN [topic_categories] AS [t0] ON [t].[CategoryId] = [t0].[Id]
+    INNER JOIN [semesters] AS [s] ON [t].[SemesterId] = [s].[Id]
+    WHERE [t].[Id] = @__topicId_0 AND [t].[IsActive] = CAST(1 AS bit) AND [t].[DeletedAt] IS NULL
+) AS [t1]
+LEFT JOIN [topic_versions] AS [t2] ON [t1].[Id] = [t2].[TopicId]
+ORDER BY [t1].[Id], [t1].[Id0], [t1].[Id1], [t1].[Id2]
+2025-10-04 02:54:21.813 +07:00 [INF] Executed DbCommand (2ms) [Parameters=[@__topicId_0='?' (DbType = Int32)], CommandType='"Text"', CommandTimeout='30']
+SELECT [t1].[Id], [t1].[Abbreviation], [t1].[CategoryId], [t1].[Content], [t1].[Context], [t1].[CreatedAt], [t1].[CreatedBy], [t1].[DeletedAt], [t1].[Description], [t1].[EN_Title], [t1].[IsActive], [t1].[IsApproved], [t1].[IsLegacy], [t1].[LastModifiedAt], [t1].[LastModifiedBy], [t1].[MaxStudents], [t1].[Objectives], [t1].[PotentialDuplicate], [t1].[Problem], [t1].[SemesterId], [t1].[SupervisorId], [t1].[VN_title], [t1].[Id0], [t1].[AccessFailedCount], [t1].[ConcurrencyStamp], [t1].[CreatedAt0], [t1].[DeletedAt0], [t1].[Email], [t1].[EmailConfirmed], [t1].[LastModifiedAt0], [t1].[LastModifiedBy0], [t1].[LockoutEnabled], [t1].[LockoutEnd], [t1].[NormalizedEmail], [t1].[NormalizedUserName], [t1].[PasswordHash], [t1].[PhoneNumber], [t1].[PhoneNumberConfirmed], [t1].[SecurityStamp], [t1].[TwoFactorEnabled], [t1].[UserName], [t1].[Id1], [t1].[CreatedAt1], [t1].[CreatedBy0], [t1].[DeletedAt1], [t1].[Description0], [t1].[IsActive0], [t1].[LastModifiedAt1], [t1].[LastModifiedBy1], [t1].[Name], [t1].[Id2], [t1].[CreatedAt2], [t1].[CreatedBy1], [t1].[DeletedAt2], [t1].[Description1], [t1].[EndDate], [t1].[IsActive1], [t1].[LastModifiedAt2], [t1].[LastModifiedBy2], [t1].[Name0], [t1].[StartDate], [t2].[Id], [t2].[Content], [t2].[Context], [t2].[CreatedAt], [t2].[CreatedBy], [t2].[DeletedAt], [t2].[Description], [t2].[DocumentUrl], [t2].[EN_Title], [t2].[ExpectedOutcomes], [t2].[IsActive], [t2].[LastModifiedAt], [t2].[LastModifiedBy], [t2].[Methodology], [t2].[Objectives], [t2].[PotentialDuplicate], [t2].[Problem], [t2].[Requirements], [t2].[Status], [t2].[SubmittedAt], [t2].[SubmittedBy], [t2].[TopicId], [t2].[VN_title], [t2].[VersionNumber]
+FROM (
+    SELECT TOP(1) [t].[Id], [t].[Abbreviation], [t].[CategoryId], [t].[Content], [t].[Context], [t].[CreatedAt], [t].[CreatedBy], [t].[DeletedAt], [t].[Description], [t].[EN_Title], [t].[IsActive], [t].[IsApproved], [t].[IsLegacy], [t].[LastModifiedAt], [t].[LastModifiedBy], [t].[MaxStudents], [t].[Objectives], [t].[PotentialDuplicate], [t].[Problem], [t].[SemesterId], [t].[SupervisorId], [t].[VN_title], [u].[Id] AS [Id0], [u].[AccessFailedCount], [u].[ConcurrencyStamp], [u].[CreatedAt] AS [CreatedAt0], [u].[DeletedAt] AS [DeletedAt0], [u].[Email], [u].[EmailConfirmed], [u].[LastModifiedAt] AS [LastModifiedAt0], [u].[LastModifiedBy] AS [LastModifiedBy0], [u].[LockoutEnabled], [u].[LockoutEnd], [u].[NormalizedEmail], [u].[NormalizedUserName], [u].[PasswordHash], [u].[PhoneNumber], [u].[PhoneNumberConfirmed], [u].[SecurityStamp], [u].[TwoFactorEnabled], [u].[UserName], [t0].[Id] AS [Id1], [t0].[CreatedAt] AS [CreatedAt1], [t0].[CreatedBy] AS [CreatedBy0], [t0].[DeletedAt] AS [DeletedAt1], [t0].[Description] AS [Description0], [t0].[IsActive] AS [IsActive0], [t0].[LastModifiedAt] AS [LastModifiedAt1], [t0].[LastModifiedBy] AS [LastModifiedBy1], [t0].[Name], [s].[Id] AS [Id2], [s].[CreatedAt] AS [CreatedAt2], [s].[CreatedBy] AS [CreatedBy1], [s].[DeletedAt] AS [DeletedAt2], [s].[Description] AS [Description1], [s].[EndDate], [s].[IsActive] AS [IsActive1], [s].[LastModifiedAt] AS [LastModifiedAt2], [s].[LastModifiedBy] AS [LastModifiedBy2], [s].[Name] AS [Name0], [s].[StartDate]
+    FROM [topics] AS [t]
+    INNER JOIN [users] AS [u] ON [t].[SupervisorId] = [u].[Id]
+    LEFT JOIN [topic_categories] AS [t0] ON [t].[CategoryId] = [t0].[Id]
+    INNER JOIN [semesters] AS [s] ON [t].[SemesterId] = [s].[Id]
+    WHERE [t].[Id] = @__topicId_0 AND [t].[IsActive] = CAST(1 AS bit) AND [t].[DeletedAt] IS NULL
+) AS [t1]
+LEFT JOIN [topic_versions] AS [t2] ON [t1].[Id] = [t2].[TopicId]
+ORDER BY [t1].[Id], [t1].[Id0], [t1].[Id1], [t1].[Id2]
+2025-10-04 02:54:21.815 +07:00 [DBG] Closing data reader to 'capbot_db' on server 'localhost'.
+2025-10-04 02:54:21.815 +07:00 [DBG] A data reader for 'capbot_db' on server 'localhost' is being disposed after spending 0ms reading results.
+2025-10-04 02:54:21.815 +07:00 [DBG] Closing connection to database 'capbot_db' on server 'localhost'.
+2025-10-04 02:54:21.815 +07:00 [DBG] Closed connection to database 'capbot_db' on server 'localhost' (0ms).
+2025-10-04 02:54:21.818 +07:00 [DBG] Opening connection to database 'capbot_db' on server 'localhost'.
+2025-10-04 02:54:21.818 +07:00 [DBG] Opened connection to database 'capbot_db' on server 'localhost'.
+2025-10-04 02:54:21.819 +07:00 [DBG] Creating DbCommand for 'ExecuteReader'.
+2025-10-04 02:54:21.819 +07:00 [DBG] Created DbCommand for 'ExecuteReader' (0ms).
+2025-10-04 02:54:21.819 +07:00 [DBG] Initialized DbCommand for 'ExecuteReader' (0ms).
+2025-10-04 02:54:21.819 +07:00 [DBG] Executing DbCommand [Parameters=[@__topicId_0='?' (DbType = Int32)], CommandType='"Text"', CommandTimeout='30']
+SELECT [s].[Id], [s].[AdditionalNotes], [s].[AiCheckDetails], [s].[AiCheckScore], [s].[AiCheckStatus], [s].[CreatedAt], [s].[CreatedBy], [s].[DeletedAt], [s].[DocumentUrl], [s].[IsActive], [s].[LastModifiedAt], [s].[LastModifiedBy], [s].[PhaseId], [s].[Status], [s].[SubmissionRound], [s].[SubmittedAt], [s].[SubmittedBy], [s].[TopicId], [s].[TopicVersionId], [p].[Id], [p].[CreatedAt], [p].[CreatedBy], [p].[DeletedAt], [p].[EndDate], [p].[IsActive], [p].[LastModifiedAt], [p].[LastModifiedBy], [p].[Name], [p].[PhaseTypeId], [p].[SemesterId], [p].[StartDate], [p].[SubmissionDeadline], [u].[Id], [u].[AccessFailedCount], [u].[ConcurrencyStamp], [u].[CreatedAt], [u].[DeletedAt], [u].[Email], [u].[EmailConfirmed], [u].[LastModifiedAt], [u].[LastModifiedBy], [u].[LockoutEnabled], [u].[LockoutEnd], [u].[NormalizedEmail], [u].[NormalizedUserName], [u].[PasswordHash], [u].[PhoneNumber], [u].[PhoneNumberConfirmed], [u].[SecurityStamp], [u].[TwoFactorEnabled], [u].[UserName], [r].[Id], [r].[AssignedAt], [r].[AssignedBy], [r].[AssignmentType], [r].[CompletedAt], [r].[Deadline], [r].[ReviewerId], [r].[SkillMatchScore], [r].[StartedAt], [r].[Status], [r].[SubmissionId]
+FROM [submissions] AS [s]
+INNER JOIN [phases] AS [p] ON [s].[PhaseId] = [p].[Id]
+INNER JOIN [users] AS [u] ON [s].[SubmittedBy] = [u].[Id]
+LEFT JOIN [reviewer_assignments] AS [r] ON [s].[Id] = [r].[SubmissionId]
+WHERE [s].[TopicId] = @__topicId_0 AND [s].[IsActive] = CAST(1 AS bit) AND [s].[DeletedAt] IS NULL
+ORDER BY [s].[Id], [p].[Id], [u].[Id]
+2025-10-04 02:54:21.831 +07:00 [INF] Executed DbCommand (12ms) [Parameters=[@__topicId_0='?' (DbType = Int32)], CommandType='"Text"', CommandTimeout='30']
+SELECT [s].[Id], [s].[AdditionalNotes], [s].[AiCheckDetails], [s].[AiCheckScore], [s].[AiCheckStatus], [s].[CreatedAt], [s].[CreatedBy], [s].[DeletedAt], [s].[DocumentUrl], [s].[IsActive], [s].[LastModifiedAt], [s].[LastModifiedBy], [s].[PhaseId], [s].[Status], [s].[SubmissionRound], [s].[SubmittedAt], [s].[SubmittedBy], [s].[TopicId], [s].[TopicVersionId], [p].[Id], [p].[CreatedAt], [p].[CreatedBy], [p].[DeletedAt], [p].[EndDate], [p].[IsActive], [p].[LastModifiedAt], [p].[LastModifiedBy], [p].[Name], [p].[PhaseTypeId], [p].[SemesterId], [p].[StartDate], [p].[SubmissionDeadline], [u].[Id], [u].[AccessFailedCount], [u].[ConcurrencyStamp], [u].[CreatedAt], [u].[DeletedAt], [u].[Email], [u].[EmailConfirmed], [u].[LastModifiedAt], [u].[LastModifiedBy], [u].[LockoutEnabled], [u].[LockoutEnd], [u].[NormalizedEmail], [u].[NormalizedUserName], [u].[PasswordHash], [u].[PhoneNumber], [u].[PhoneNumberConfirmed], [u].[SecurityStamp], [u].[TwoFactorEnabled], [u].[UserName], [r].[Id], [r].[AssignedAt], [r].[AssignedBy], [r].[AssignmentType], [r].[CompletedAt], [r].[Deadline], [r].[ReviewerId], [r].[SkillMatchScore], [r].[StartedAt], [r].[Status], [r].[SubmissionId]
+FROM [submissions] AS [s]
+INNER JOIN [phases] AS [p] ON [s].[PhaseId] = [p].[Id]
+INNER JOIN [users] AS [u] ON [s].[SubmittedBy] = [u].[Id]
+LEFT JOIN [reviewer_assignments] AS [r] ON [s].[Id] = [r].[SubmissionId]
+WHERE [s].[TopicId] = @__topicId_0 AND [s].[IsActive] = CAST(1 AS bit) AND [s].[DeletedAt] IS NULL
+ORDER BY [s].[Id], [p].[Id], [u].[Id]
+2025-10-04 02:54:21.834 +07:00 [DBG] Closing data reader to 'capbot_db' on server 'localhost'.
+2025-10-04 02:54:21.835 +07:00 [DBG] A data reader for 'capbot_db' on server 'localhost' is being disposed after spending 0ms reading results.
+2025-10-04 02:54:21.835 +07:00 [DBG] Closing connection to database 'capbot_db' on server 'localhost'.
+2025-10-04 02:54:21.835 +07:00 [DBG] Closed connection to database 'capbot_db' on server 'localhost' (0ms).
+2025-10-04 02:54:21.838 +07:00 [DBG] Opening connection to database 'capbot_db' on server 'localhost'.
+2025-10-04 02:54:21.841 +07:00 [DBG] Opened connection to database 'capbot_db' on server 'localhost'.
+2025-10-04 02:54:21.842 +07:00 [DBG] Creating DbCommand for 'ExecuteReader'.
+2025-10-04 02:54:21.843 +07:00 [DBG] Created DbCommand for 'ExecuteReader' (1ms).
+2025-10-04 02:54:21.843 +07:00 [DBG] Initialized DbCommand for 'ExecuteReader' (1ms).
+2025-10-04 02:54:21.843 +07:00 [DBG] Executing DbCommand [Parameters=[@__p_0='?' (DbType = Int64)], CommandType='"Text"', CommandTimeout='30']
+SELECT TOP(1) [e].[Id], [e].[Caption], [e].[CreatedAt], [e].[EntityId], [e].[EntityType], [e].[FileId], [e].[IsPrimary], [f].[Id], [f].[Alt], [f].[Checksum], [f].[CreatedAt], [f].[CreatedBy], [f].[DeletedAt], [f].[FileName], [f].[FilePath], [f].[FileSize], [f].[FileType], [f].[Height], [f].[IsActive], [f].[LastModifiedAt], [f].[LastModifiedBy], [f].[MimeType], [f].[ThumbnailUrl], [f].[Url], [f].[Width]
+FROM [entity_files] AS [e]
+INNER JOIN [files] AS [f] ON [e].[FileId] = [f].[Id]
+WHERE [e].[EntityId] = @__p_0 AND [e].[EntityType] = 1 AND [e].[IsPrimary] = CAST(1 AS bit)
+2025-10-04 02:54:21.849 +07:00 [INF] Executed DbCommand (5ms) [Parameters=[@__p_0='?' (DbType = Int64)], CommandType='"Text"', CommandTimeout='30']
+SELECT TOP(1) [e].[Id], [e].[Caption], [e].[CreatedAt], [e].[EntityId], [e].[EntityType], [e].[FileId], [e].[IsPrimary], [f].[Id], [f].[Alt], [f].[Checksum], [f].[CreatedAt], [f].[CreatedBy], [f].[DeletedAt], [f].[FileName], [f].[FilePath], [f].[FileSize], [f].[FileType], [f].[Height], [f].[IsActive], [f].[LastModifiedAt], [f].[LastModifiedBy], [f].[MimeType], [f].[ThumbnailUrl], [f].[Url], [f].[Width]
+FROM [entity_files] AS [e]
+INNER JOIN [files] AS [f] ON [e].[FileId] = [f].[Id]
+WHERE [e].[EntityId] = @__p_0 AND [e].[EntityType] = 1 AND [e].[IsPrimary] = CAST(1 AS bit)
+2025-10-04 02:54:21.849 +07:00 [DBG] Closing data reader to 'capbot_db' on server 'localhost'.
+2025-10-04 02:54:21.850 +07:00 [DBG] A data reader for 'capbot_db' on server 'localhost' is being disposed after spending 0ms reading results.
+2025-10-04 02:54:21.850 +07:00 [DBG] Closing connection to database 'capbot_db' on server 'localhost'.
+2025-10-04 02:54:21.851 +07:00 [DBG] Closed connection to database 'capbot_db' on server 'localhost' (0ms).
+2025-10-04 02:54:21.852 +07:00 [DBG] List of registered output formatters, in the following order: ["Microsoft.AspNetCore.OData.Formatter.ODataOutputFormatter","Microsoft.AspNetCore.OData.Formatter.ODataOutputFormatter","Microsoft.AspNetCore.OData.Formatter.ODataOutputFormatter","Microsoft.AspNetCore.Mvc.Formatters.HttpNoContentOutputFormatter","Microsoft.AspNetCore.Mvc.Formatters.StringOutputFormatter","Microsoft.AspNetCore.Mvc.Formatters.StreamOutputFormatter","Microsoft.AspNetCore.Mvc.Formatters.SystemTextJsonOutputFormatter"]
+2025-10-04 02:54:21.853 +07:00 [DBG] No information found on request to perform content negotiation.
+2025-10-04 02:54:21.856 +07:00 [DBG] Attempting to select the first output formatter in the output formatters list which supports a content type from the explicitly specified content types '["application/json"]'.
+2025-10-04 02:54:21.856 +07:00 [DBG] Selected output formatter 'Microsoft.AspNetCore.Mvc.Formatters.SystemTextJsonOutputFormatter' and content type 'application/json' to write the response.
+2025-10-04 02:54:21.857 +07:00 [INF] Executing ObjectResult, writing value of type 'FS.Commons.FSResponse'.
+2025-10-04 02:54:21.858 +07:00 [INF] Executed action CapBot.api.Controllers.TopicController.GetDetail (CapBot.api) in 54.0625ms
+2025-10-04 02:54:21.859 +07:00 [INF] Executed endpoint 'CapBot.api.Controllers.TopicController.GetDetail (CapBot.api)'
+2025-10-04 02:54:21.859 +07:00 [DBG] Connection id "0HNG2MQC634J8" completed keep alive response.
+2025-10-04 02:54:21.859 +07:00 [DBG] 'MyDbContext' disposed.
+2025-10-04 02:54:21.859 +07:00 [DBG] Disposing connection to database 'capbot_db' on server 'localhost'.
+2025-10-04 02:54:21.859 +07:00 [DBG] Disposed connection to database '' on server '' (0ms).
+2025-10-04 02:54:21.859 +07:00 [INF] Request finished HTTP/1.1 GET http://localhost:5207/api/topic/detail/104 - 200 null application/json; charset=utf-8 61.536ms
+2025-10-04 02:54:22.030 +07:00 [INF] Request starting HTTP/1.1 GET http://localhost:5207/api/topic/detail/104 - null null
+2025-10-04 02:54:22.030 +07:00 [DBG] The request path /api/topic/detail/104 does not match a supported file type
+2025-10-04 02:54:22.030 +07:00 [DBG] The request path /api/topic/detail/104 does not match a supported file type
+2025-10-04 02:54:22.030 +07:00 [DBG] 1 candidate(s) found for the request path '/api/topic/detail/104'
+2025-10-04 02:54:22.030 +07:00 [DBG] Endpoint 'CapBot.api.Controllers.TopicController.GetDetail (CapBot.api)' with route pattern 'api/topic/detail/{topicId}' is valid for the request path '/api/topic/detail/104'
+2025-10-04 02:54:22.031 +07:00 [DBG] Request matched endpoint 'CapBot.api.Controllers.TopicController.GetDetail (CapBot.api)'
+2025-10-04 02:54:22.031 +07:00 [DBG] Successfully validated the token.
+2025-10-04 02:54:22.031 +07:00 [DBG] AuthenticationScheme: Bearer was successfully authenticated.
+2025-10-04 02:54:22.032 +07:00 [INF] Executing endpoint 'CapBot.api.Controllers.TopicController.GetDetail (CapBot.api)'
+2025-10-04 02:54:22.032 +07:00 [INF] Route matched with {action = "GetDetail", controller = "Topic"}. Executing controller action with signature System.Threading.Tasks.Task`1[Microsoft.AspNetCore.Mvc.IActionResult] GetDetail(Int32) on controller CapBot.api.Controllers.TopicController (CapBot.api).
+2025-10-04 02:54:22.032 +07:00 [DBG] Execution plan of authorization filters (in the following order): ["None"]
+2025-10-04 02:54:22.032 +07:00 [DBG] Execution plan of resource filters (in the following order): ["Microsoft.AspNetCore.Mvc.ConsumesAttribute"]
+2025-10-04 02:54:22.032 +07:00 [DBG] Execution plan of action filters (in the following order): ["Microsoft.AspNetCore.Mvc.ModelBinding.UnsupportedContentTypeFilter (Order: -3000)"]
+2025-10-04 02:54:22.032 +07:00 [DBG] Execution plan of exception filters (in the following order): ["None"]
+2025-10-04 02:54:22.032 +07:00 [DBG] Execution plan of result filters (in the following order): ["Microsoft.AspNetCore.Mvc.Infrastructure.ClientErrorResultFilter (Order: -2000)","Microsoft.AspNetCore.Mvc.ProducesAttribute (Order: 0)"]
+2025-10-04 02:54:22.032 +07:00 [DBG] Executing controller factory for controller CapBot.api.Controllers.TopicController (CapBot.api)
+2025-10-04 02:54:22.033 +07:00 [DBG] Executed controller factory for controller CapBot.api.Controllers.TopicController (CapBot.api)
+2025-10-04 02:54:22.034 +07:00 [DBG] Attempting to bind parameter 'topicId' of type 'System.Int32' ...
+2025-10-04 02:54:22.034 +07:00 [DBG] Attempting to bind parameter 'topicId' of type 'System.Int32' using the name 'topicId' in request data ...
+2025-10-04 02:54:22.035 +07:00 [DBG] Done attempting to bind parameter 'topicId' of type 'System.Int32'.
+2025-10-04 02:54:22.035 +07:00 [DBG] Done attempting to bind parameter 'topicId' of type 'System.Int32'.
+2025-10-04 02:54:22.035 +07:00 [DBG] Attempting to validate the bound parameter 'topicId' of type 'System.Int32' ...
+2025-10-04 02:54:22.035 +07:00 [DBG] Done attempting to validate the bound parameter 'topicId' of type 'System.Int32'.
+2025-10-04 02:54:22.036 +07:00 [DBG] Entity Framework Core 8.0.16 initialized 'MyDbContext' using provider 'Microsoft.EntityFrameworkCore.SqlServer:8.0.13' with options: MigrationsAssembly=App.DAL 
+2025-10-04 02:54:22.038 +07:00 [DBG] Creating DbConnection.
+2025-10-04 02:54:22.038 +07:00 [DBG] Created DbConnection. (0ms).
+2025-10-04 02:54:22.038 +07:00 [DBG] Opening connection to database 'capbot_db' on server 'localhost'.
+2025-10-04 02:54:22.038 +07:00 [DBG] Opened connection to database 'capbot_db' on server 'localhost'.
+2025-10-04 02:54:22.038 +07:00 [DBG] Creating DbCommand for 'ExecuteReader'.
+2025-10-04 02:54:22.038 +07:00 [DBG] Created DbCommand for 'ExecuteReader' (0ms).
+2025-10-04 02:54:22.039 +07:00 [DBG] Initialized DbCommand for 'ExecuteReader' (0ms).
+2025-10-04 02:54:22.039 +07:00 [DBG] Executing DbCommand [Parameters=[@__topicId_0='?' (DbType = Int32)], CommandType='"Text"', CommandTimeout='30']
+SELECT [t1].[Id], [t1].[Abbreviation], [t1].[CategoryId], [t1].[Content], [t1].[Context], [t1].[CreatedAt], [t1].[CreatedBy], [t1].[DeletedAt], [t1].[Description], [t1].[EN_Title], [t1].[IsActive], [t1].[IsApproved], [t1].[IsLegacy], [t1].[LastModifiedAt], [t1].[LastModifiedBy], [t1].[MaxStudents], [t1].[Objectives], [t1].[PotentialDuplicate], [t1].[Problem], [t1].[SemesterId], [t1].[SupervisorId], [t1].[VN_title], [t1].[Id0], [t1].[AccessFailedCount], [t1].[ConcurrencyStamp], [t1].[CreatedAt0], [t1].[DeletedAt0], [t1].[Email], [t1].[EmailConfirmed], [t1].[LastModifiedAt0], [t1].[LastModifiedBy0], [t1].[LockoutEnabled], [t1].[LockoutEnd], [t1].[NormalizedEmail], [t1].[NormalizedUserName], [t1].[PasswordHash], [t1].[PhoneNumber], [t1].[PhoneNumberConfirmed], [t1].[SecurityStamp], [t1].[TwoFactorEnabled], [t1].[UserName], [t1].[Id1], [t1].[CreatedAt1], [t1].[CreatedBy0], [t1].[DeletedAt1], [t1].[Description0], [t1].[IsActive0], [t1].[LastModifiedAt1], [t1].[LastModifiedBy1], [t1].[Name], [t1].[Id2], [t1].[CreatedAt2], [t1].[CreatedBy1], [t1].[DeletedAt2], [t1].[Description1], [t1].[EndDate], [t1].[IsActive1], [t1].[LastModifiedAt2], [t1].[LastModifiedBy2], [t1].[Name0], [t1].[StartDate], [t2].[Id], [t2].[Content], [t2].[Context], [t2].[CreatedAt], [t2].[CreatedBy], [t2].[DeletedAt], [t2].[Description], [t2].[DocumentUrl], [t2].[EN_Title], [t2].[ExpectedOutcomes], [t2].[IsActive], [t2].[LastModifiedAt], [t2].[LastModifiedBy], [t2].[Methodology], [t2].[Objectives], [t2].[PotentialDuplicate], [t2].[Problem], [t2].[Requirements], [t2].[Status], [t2].[SubmittedAt], [t2].[SubmittedBy], [t2].[TopicId], [t2].[VN_title], [t2].[VersionNumber]
+FROM (
+    SELECT TOP(1) [t].[Id], [t].[Abbreviation], [t].[CategoryId], [t].[Content], [t].[Context], [t].[CreatedAt], [t].[CreatedBy], [t].[DeletedAt], [t].[Description], [t].[EN_Title], [t].[IsActive], [t].[IsApproved], [t].[IsLegacy], [t].[LastModifiedAt], [t].[LastModifiedBy], [t].[MaxStudents], [t].[Objectives], [t].[PotentialDuplicate], [t].[Problem], [t].[SemesterId], [t].[SupervisorId], [t].[VN_title], [u].[Id] AS [Id0], [u].[AccessFailedCount], [u].[ConcurrencyStamp], [u].[CreatedAt] AS [CreatedAt0], [u].[DeletedAt] AS [DeletedAt0], [u].[Email], [u].[EmailConfirmed], [u].[LastModifiedAt] AS [LastModifiedAt0], [u].[LastModifiedBy] AS [LastModifiedBy0], [u].[LockoutEnabled], [u].[LockoutEnd], [u].[NormalizedEmail], [u].[NormalizedUserName], [u].[PasswordHash], [u].[PhoneNumber], [u].[PhoneNumberConfirmed], [u].[SecurityStamp], [u].[TwoFactorEnabled], [u].[UserName], [t0].[Id] AS [Id1], [t0].[CreatedAt] AS [CreatedAt1], [t0].[CreatedBy] AS [CreatedBy0], [t0].[DeletedAt] AS [DeletedAt1], [t0].[Description] AS [Description0], [t0].[IsActive] AS [IsActive0], [t0].[LastModifiedAt] AS [LastModifiedAt1], [t0].[LastModifiedBy] AS [LastModifiedBy1], [t0].[Name], [s].[Id] AS [Id2], [s].[CreatedAt] AS [CreatedAt2], [s].[CreatedBy] AS [CreatedBy1], [s].[DeletedAt] AS [DeletedAt2], [s].[Description] AS [Description1], [s].[EndDate], [s].[IsActive] AS [IsActive1], [s].[LastModifiedAt] AS [LastModifiedAt2], [s].[LastModifiedBy] AS [LastModifiedBy2], [s].[Name] AS [Name0], [s].[StartDate]
+    FROM [topics] AS [t]
+    INNER JOIN [users] AS [u] ON [t].[SupervisorId] = [u].[Id]
+    LEFT JOIN [topic_categories] AS [t0] ON [t].[CategoryId] = [t0].[Id]
+    INNER JOIN [semesters] AS [s] ON [t].[SemesterId] = [s].[Id]
+    WHERE [t].[Id] = @__topicId_0 AND [t].[IsActive] = CAST(1 AS bit) AND [t].[DeletedAt] IS NULL
+) AS [t1]
+LEFT JOIN [topic_versions] AS [t2] ON [t1].[Id] = [t2].[TopicId]
+ORDER BY [t1].[Id], [t1].[Id0], [t1].[Id1], [t1].[Id2]
+2025-10-04 02:54:22.045 +07:00 [INF] Executed DbCommand (6ms) [Parameters=[@__topicId_0='?' (DbType = Int32)], CommandType='"Text"', CommandTimeout='30']
+SELECT [t1].[Id], [t1].[Abbreviation], [t1].[CategoryId], [t1].[Content], [t1].[Context], [t1].[CreatedAt], [t1].[CreatedBy], [t1].[DeletedAt], [t1].[Description], [t1].[EN_Title], [t1].[IsActive], [t1].[IsApproved], [t1].[IsLegacy], [t1].[LastModifiedAt], [t1].[LastModifiedBy], [t1].[MaxStudents], [t1].[Objectives], [t1].[PotentialDuplicate], [t1].[Problem], [t1].[SemesterId], [t1].[SupervisorId], [t1].[VN_title], [t1].[Id0], [t1].[AccessFailedCount], [t1].[ConcurrencyStamp], [t1].[CreatedAt0], [t1].[DeletedAt0], [t1].[Email], [t1].[EmailConfirmed], [t1].[LastModifiedAt0], [t1].[LastModifiedBy0], [t1].[LockoutEnabled], [t1].[LockoutEnd], [t1].[NormalizedEmail], [t1].[NormalizedUserName], [t1].[PasswordHash], [t1].[PhoneNumber], [t1].[PhoneNumberConfirmed], [t1].[SecurityStamp], [t1].[TwoFactorEnabled], [t1].[UserName], [t1].[Id1], [t1].[CreatedAt1], [t1].[CreatedBy0], [t1].[DeletedAt1], [t1].[Description0], [t1].[IsActive0], [t1].[LastModifiedAt1], [t1].[LastModifiedBy1], [t1].[Name], [t1].[Id2], [t1].[CreatedAt2], [t1].[CreatedBy1], [t1].[DeletedAt2], [t1].[Description1], [t1].[EndDate], [t1].[IsActive1], [t1].[LastModifiedAt2], [t1].[LastModifiedBy2], [t1].[Name0], [t1].[StartDate], [t2].[Id], [t2].[Content], [t2].[Context], [t2].[CreatedAt], [t2].[CreatedBy], [t2].[DeletedAt], [t2].[Description], [t2].[DocumentUrl], [t2].[EN_Title], [t2].[ExpectedOutcomes], [t2].[IsActive], [t2].[LastModifiedAt], [t2].[LastModifiedBy], [t2].[Methodology], [t2].[Objectives], [t2].[PotentialDuplicate], [t2].[Problem], [t2].[Requirements], [t2].[Status], [t2].[SubmittedAt], [t2].[SubmittedBy], [t2].[TopicId], [t2].[VN_title], [t2].[VersionNumber]
+FROM (
+    SELECT TOP(1) [t].[Id], [t].[Abbreviation], [t].[CategoryId], [t].[Content], [t].[Context], [t].[CreatedAt], [t].[CreatedBy], [t].[DeletedAt], [t].[Description], [t].[EN_Title], [t].[IsActive], [t].[IsApproved], [t].[IsLegacy], [t].[LastModifiedAt], [t].[LastModifiedBy], [t].[MaxStudents], [t].[Objectives], [t].[PotentialDuplicate], [t].[Problem], [t].[SemesterId], [t].[SupervisorId], [t].[VN_title], [u].[Id] AS [Id0], [u].[AccessFailedCount], [u].[ConcurrencyStamp], [u].[CreatedAt] AS [CreatedAt0], [u].[DeletedAt] AS [DeletedAt0], [u].[Email], [u].[EmailConfirmed], [u].[LastModifiedAt] AS [LastModifiedAt0], [u].[LastModifiedBy] AS [LastModifiedBy0], [u].[LockoutEnabled], [u].[LockoutEnd], [u].[NormalizedEmail], [u].[NormalizedUserName], [u].[PasswordHash], [u].[PhoneNumber], [u].[PhoneNumberConfirmed], [u].[SecurityStamp], [u].[TwoFactorEnabled], [u].[UserName], [t0].[Id] AS [Id1], [t0].[CreatedAt] AS [CreatedAt1], [t0].[CreatedBy] AS [CreatedBy0], [t0].[DeletedAt] AS [DeletedAt1], [t0].[Description] AS [Description0], [t0].[IsActive] AS [IsActive0], [t0].[LastModifiedAt] AS [LastModifiedAt1], [t0].[LastModifiedBy] AS [LastModifiedBy1], [t0].[Name], [s].[Id] AS [Id2], [s].[CreatedAt] AS [CreatedAt2], [s].[CreatedBy] AS [CreatedBy1], [s].[DeletedAt] AS [DeletedAt2], [s].[Description] AS [Description1], [s].[EndDate], [s].[IsActive] AS [IsActive1], [s].[LastModifiedAt] AS [LastModifiedAt2], [s].[LastModifiedBy] AS [LastModifiedBy2], [s].[Name] AS [Name0], [s].[StartDate]
+    FROM [topics] AS [t]
+    INNER JOIN [users] AS [u] ON [t].[SupervisorId] = [u].[Id]
+    LEFT JOIN [topic_categories] AS [t0] ON [t].[CategoryId] = [t0].[Id]
+    INNER JOIN [semesters] AS [s] ON [t].[SemesterId] = [s].[Id]
+    WHERE [t].[Id] = @__topicId_0 AND [t].[IsActive] = CAST(1 AS bit) AND [t].[DeletedAt] IS NULL
+) AS [t1]
+LEFT JOIN [topic_versions] AS [t2] ON [t1].[Id] = [t2].[TopicId]
+ORDER BY [t1].[Id], [t1].[Id0], [t1].[Id1], [t1].[Id2]
+2025-10-04 02:54:22.045 +07:00 [DBG] Closing data reader to 'capbot_db' on server 'localhost'.
+2025-10-04 02:54:22.045 +07:00 [DBG] A data reader for 'capbot_db' on server 'localhost' is being disposed after spending 0ms reading results.
+2025-10-04 02:54:22.045 +07:00 [DBG] Closing connection to database 'capbot_db' on server 'localhost'.
+2025-10-04 02:54:22.045 +07:00 [DBG] Closed connection to database 'capbot_db' on server 'localhost' (0ms).
+2025-10-04 02:54:22.046 +07:00 [DBG] Opening connection to database 'capbot_db' on server 'localhost'.
+2025-10-04 02:54:22.046 +07:00 [DBG] Opened connection to database 'capbot_db' on server 'localhost'.
+2025-10-04 02:54:22.046 +07:00 [DBG] Creating DbCommand for 'ExecuteReader'.
+2025-10-04 02:54:22.046 +07:00 [DBG] Created DbCommand for 'ExecuteReader' (0ms).
+2025-10-04 02:54:22.046 +07:00 [DBG] Initialized DbCommand for 'ExecuteReader' (0ms).
+2025-10-04 02:54:22.046 +07:00 [DBG] Executing DbCommand [Parameters=[@__topicId_0='?' (DbType = Int32)], CommandType='"Text"', CommandTimeout='30']
+SELECT [s].[Id], [s].[AdditionalNotes], [s].[AiCheckDetails], [s].[AiCheckScore], [s].[AiCheckStatus], [s].[CreatedAt], [s].[CreatedBy], [s].[DeletedAt], [s].[DocumentUrl], [s].[IsActive], [s].[LastModifiedAt], [s].[LastModifiedBy], [s].[PhaseId], [s].[Status], [s].[SubmissionRound], [s].[SubmittedAt], [s].[SubmittedBy], [s].[TopicId], [s].[TopicVersionId], [p].[Id], [p].[CreatedAt], [p].[CreatedBy], [p].[DeletedAt], [p].[EndDate], [p].[IsActive], [p].[LastModifiedAt], [p].[LastModifiedBy], [p].[Name], [p].[PhaseTypeId], [p].[SemesterId], [p].[StartDate], [p].[SubmissionDeadline], [u].[Id], [u].[AccessFailedCount], [u].[ConcurrencyStamp], [u].[CreatedAt], [u].[DeletedAt], [u].[Email], [u].[EmailConfirmed], [u].[LastModifiedAt], [u].[LastModifiedBy], [u].[LockoutEnabled], [u].[LockoutEnd], [u].[NormalizedEmail], [u].[NormalizedUserName], [u].[PasswordHash], [u].[PhoneNumber], [u].[PhoneNumberConfirmed], [u].[SecurityStamp], [u].[TwoFactorEnabled], [u].[UserName], [r].[Id], [r].[AssignedAt], [r].[AssignedBy], [r].[AssignmentType], [r].[CompletedAt], [r].[Deadline], [r].[ReviewerId], [r].[SkillMatchScore], [r].[StartedAt], [r].[Status], [r].[SubmissionId]
+FROM [submissions] AS [s]
+INNER JOIN [phases] AS [p] ON [s].[PhaseId] = [p].[Id]
+INNER JOIN [users] AS [u] ON [s].[SubmittedBy] = [u].[Id]
+LEFT JOIN [reviewer_assignments] AS [r] ON [s].[Id] = [r].[SubmissionId]
+WHERE [s].[TopicId] = @__topicId_0 AND [s].[IsActive] = CAST(1 AS bit) AND [s].[DeletedAt] IS NULL
+ORDER BY [s].[Id], [p].[Id], [u].[Id]
+2025-10-04 02:54:22.047 +07:00 [INF] Executed DbCommand (1ms) [Parameters=[@__topicId_0='?' (DbType = Int32)], CommandType='"Text"', CommandTimeout='30']
+SELECT [s].[Id], [s].[AdditionalNotes], [s].[AiCheckDetails], [s].[AiCheckScore], [s].[AiCheckStatus], [s].[CreatedAt], [s].[CreatedBy], [s].[DeletedAt], [s].[DocumentUrl], [s].[IsActive], [s].[LastModifiedAt], [s].[LastModifiedBy], [s].[PhaseId], [s].[Status], [s].[SubmissionRound], [s].[SubmittedAt], [s].[SubmittedBy], [s].[TopicId], [s].[TopicVersionId], [p].[Id], [p].[CreatedAt], [p].[CreatedBy], [p].[DeletedAt], [p].[EndDate], [p].[IsActive], [p].[LastModifiedAt], [p].[LastModifiedBy], [p].[Name], [p].[PhaseTypeId], [p].[SemesterId], [p].[StartDate], [p].[SubmissionDeadline], [u].[Id], [u].[AccessFailedCount], [u].[ConcurrencyStamp], [u].[CreatedAt], [u].[DeletedAt], [u].[Email], [u].[EmailConfirmed], [u].[LastModifiedAt], [u].[LastModifiedBy], [u].[LockoutEnabled], [u].[LockoutEnd], [u].[NormalizedEmail], [u].[NormalizedUserName], [u].[PasswordHash], [u].[PhoneNumber], [u].[PhoneNumberConfirmed], [u].[SecurityStamp], [u].[TwoFactorEnabled], [u].[UserName], [r].[Id], [r].[AssignedAt], [r].[AssignedBy], [r].[AssignmentType], [r].[CompletedAt], [r].[Deadline], [r].[ReviewerId], [r].[SkillMatchScore], [r].[StartedAt], [r].[Status], [r].[SubmissionId]
+FROM [submissions] AS [s]
+INNER JOIN [phases] AS [p] ON [s].[PhaseId] = [p].[Id]
+INNER JOIN [users] AS [u] ON [s].[SubmittedBy] = [u].[Id]
+LEFT JOIN [reviewer_assignments] AS [r] ON [s].[Id] = [r].[SubmissionId]
+WHERE [s].[TopicId] = @__topicId_0 AND [s].[IsActive] = CAST(1 AS bit) AND [s].[DeletedAt] IS NULL
+ORDER BY [s].[Id], [p].[Id], [u].[Id]
+2025-10-04 02:54:22.048 +07:00 [DBG] Closing data reader to 'capbot_db' on server 'localhost'.
+2025-10-04 02:54:22.048 +07:00 [DBG] A data reader for 'capbot_db' on server 'localhost' is being disposed after spending 0ms reading results.
+2025-10-04 02:54:22.048 +07:00 [DBG] Closing connection to database 'capbot_db' on server 'localhost'.
+2025-10-04 02:54:22.048 +07:00 [DBG] Closed connection to database 'capbot_db' on server 'localhost' (0ms).
+2025-10-04 02:54:22.049 +07:00 [DBG] Opening connection to database 'capbot_db' on server 'localhost'.
+2025-10-04 02:54:22.049 +07:00 [DBG] Opened connection to database 'capbot_db' on server 'localhost'.
+2025-10-04 02:54:22.049 +07:00 [DBG] Creating DbCommand for 'ExecuteReader'.
+2025-10-04 02:54:22.049 +07:00 [DBG] Created DbCommand for 'ExecuteReader' (0ms).
+2025-10-04 02:54:22.049 +07:00 [DBG] Initialized DbCommand for 'ExecuteReader' (0ms).
+2025-10-04 02:54:22.049 +07:00 [DBG] Executing DbCommand [Parameters=[@__p_0='?' (DbType = Int64)], CommandType='"Text"', CommandTimeout='30']
+SELECT TOP(1) [e].[Id], [e].[Caption], [e].[CreatedAt], [e].[EntityId], [e].[EntityType], [e].[FileId], [e].[IsPrimary], [f].[Id], [f].[Alt], [f].[Checksum], [f].[CreatedAt], [f].[CreatedBy], [f].[DeletedAt], [f].[FileName], [f].[FilePath], [f].[FileSize], [f].[FileType], [f].[Height], [f].[IsActive], [f].[LastModifiedAt], [f].[LastModifiedBy], [f].[MimeType], [f].[ThumbnailUrl], [f].[Url], [f].[Width]
+FROM [entity_files] AS [e]
+INNER JOIN [files] AS [f] ON [e].[FileId] = [f].[Id]
+WHERE [e].[EntityId] = @__p_0 AND [e].[EntityType] = 1 AND [e].[IsPrimary] = CAST(1 AS bit)
+2025-10-04 02:54:22.051 +07:00 [INF] Executed DbCommand (2ms) [Parameters=[@__p_0='?' (DbType = Int64)], CommandType='"Text"', CommandTimeout='30']
+SELECT TOP(1) [e].[Id], [e].[Caption], [e].[CreatedAt], [e].[EntityId], [e].[EntityType], [e].[FileId], [e].[IsPrimary], [f].[Id], [f].[Alt], [f].[Checksum], [f].[CreatedAt], [f].[CreatedBy], [f].[DeletedAt], [f].[FileName], [f].[FilePath], [f].[FileSize], [f].[FileType], [f].[Height], [f].[IsActive], [f].[LastModifiedAt], [f].[LastModifiedBy], [f].[MimeType], [f].[ThumbnailUrl], [f].[Url], [f].[Width]
+FROM [entity_files] AS [e]
+INNER JOIN [files] AS [f] ON [e].[FileId] = [f].[Id]
+WHERE [e].[EntityId] = @__p_0 AND [e].[EntityType] = 1 AND [e].[IsPrimary] = CAST(1 AS bit)
+2025-10-04 02:54:22.051 +07:00 [DBG] Closing data reader to 'capbot_db' on server 'localhost'.
+2025-10-04 02:54:22.052 +07:00 [DBG] A data reader for 'capbot_db' on server 'localhost' is being disposed after spending 0ms reading results.
+2025-10-04 02:54:22.052 +07:00 [DBG] Closing connection to database 'capbot_db' on server 'localhost'.
+2025-10-04 02:54:22.052 +07:00 [DBG] Closed connection to database 'capbot_db' on server 'localhost' (0ms).
+2025-10-04 02:54:22.053 +07:00 [DBG] List of registered output formatters, in the following order: ["Microsoft.AspNetCore.OData.Formatter.ODataOutputFormatter","Microsoft.AspNetCore.OData.Formatter.ODataOutputFormatter","Microsoft.AspNetCore.OData.Formatter.ODataOutputFormatter","Microsoft.AspNetCore.Mvc.Formatters.HttpNoContentOutputFormatter","Microsoft.AspNetCore.Mvc.Formatters.StringOutputFormatter","Microsoft.AspNetCore.Mvc.Formatters.StreamOutputFormatter","Microsoft.AspNetCore.Mvc.Formatters.SystemTextJsonOutputFormatter"]
+2025-10-04 02:54:22.053 +07:00 [DBG] No information found on request to perform content negotiation.
+2025-10-04 02:54:22.053 +07:00 [DBG] Attempting to select the first output formatter in the output formatters list which supports a content type from the explicitly specified content types '["application/json"]'.
+2025-10-04 02:54:22.054 +07:00 [DBG] Selected output formatter 'Microsoft.AspNetCore.Mvc.Formatters.SystemTextJsonOutputFormatter' and content type 'application/json' to write the response.
+2025-10-04 02:54:22.054 +07:00 [INF] Executing ObjectResult, writing value of type 'FS.Commons.FSResponse'.
+2025-10-04 02:54:22.054 +07:00 [INF] Executed action CapBot.api.Controllers.TopicController.GetDetail (CapBot.api) in 21.9439ms
+2025-10-04 02:54:22.054 +07:00 [INF] Executed endpoint 'CapBot.api.Controllers.TopicController.GetDetail (CapBot.api)'
+2025-10-04 02:54:22.055 +07:00 [DBG] Connection id "0HNG2MQC634J8" completed keep alive response.
+2025-10-04 02:54:22.055 +07:00 [DBG] 'MyDbContext' disposed.
+2025-10-04 02:54:22.055 +07:00 [DBG] Disposing connection to database 'capbot_db' on server 'localhost'.
+2025-10-04 02:54:22.055 +07:00 [DBG] Disposed connection to database '' on server '' (0ms).
+2025-10-04 02:54:22.055 +07:00 [INF] Request finished HTTP/1.1 GET http://localhost:5207/api/topic/detail/104 - 200 null application/json; charset=utf-8 25.337ms
+2025-10-04 02:55:06.881 +07:00 [DBG] Connection id "0HNG2MQC634J8" received FIN.
+2025-10-04 02:55:06.881 +07:00 [DBG] Connection id "0HNG2MQC634J8" sending FIN because: "The Socket transport's send loop completed gracefully."
+2025-10-04 02:55:06.881 +07:00 [DBG] Connection id "0HNG2MQC634J8" disconnecting.
+2025-10-04 02:55:06.881 +07:00 [DBG] Connection id "0HNG2MQC634J8" stopped.
+2025-10-04 02:55:47.011 +07:00 [DBG] Connection id "0HNG2MQC634J9" accepted.
+2025-10-04 02:55:47.011 +07:00 [DBG] Connection id "0HNG2MQC634J9" started.
+2025-10-04 02:55:47.012 +07:00 [INF] Request starting HTTP/1.1 GET http://localhost:5207/api/topic/detail/104 - null null
+2025-10-04 02:55:47.012 +07:00 [DBG] The request path /api/topic/detail/104 does not match a supported file type
+2025-10-04 02:55:47.012 +07:00 [DBG] The request path /api/topic/detail/104 does not match a supported file type
+2025-10-04 02:55:47.013 +07:00 [DBG] 1 candidate(s) found for the request path '/api/topic/detail/104'
+2025-10-04 02:55:47.013 +07:00 [DBG] Endpoint 'CapBot.api.Controllers.TopicController.GetDetail (CapBot.api)' with route pattern 'api/topic/detail/{topicId}' is valid for the request path '/api/topic/detail/104'
+2025-10-04 02:55:47.013 +07:00 [DBG] Request matched endpoint 'CapBot.api.Controllers.TopicController.GetDetail (CapBot.api)'
+2025-10-04 02:55:47.014 +07:00 [DBG] Successfully validated the token.
+2025-10-04 02:55:47.014 +07:00 [DBG] AuthenticationScheme: Bearer was successfully authenticated.
+2025-10-04 02:55:47.014 +07:00 [INF] Executing endpoint 'CapBot.api.Controllers.TopicController.GetDetail (CapBot.api)'
+2025-10-04 02:55:47.014 +07:00 [INF] Route matched with {action = "GetDetail", controller = "Topic"}. Executing controller action with signature System.Threading.Tasks.Task`1[Microsoft.AspNetCore.Mvc.IActionResult] GetDetail(Int32) on controller CapBot.api.Controllers.TopicController (CapBot.api).
+2025-10-04 02:55:47.014 +07:00 [DBG] Execution plan of authorization filters (in the following order): ["None"]
+2025-10-04 02:55:47.015 +07:00 [DBG] Execution plan of resource filters (in the following order): ["Microsoft.AspNetCore.Mvc.ConsumesAttribute"]
+2025-10-04 02:55:47.015 +07:00 [DBG] Execution plan of action filters (in the following order): ["Microsoft.AspNetCore.Mvc.ModelBinding.UnsupportedContentTypeFilter (Order: -3000)"]
+2025-10-04 02:55:47.015 +07:00 [DBG] Execution plan of exception filters (in the following order): ["None"]
+2025-10-04 02:55:47.015 +07:00 [DBG] Execution plan of result filters (in the following order): ["Microsoft.AspNetCore.Mvc.Infrastructure.ClientErrorResultFilter (Order: -2000)","Microsoft.AspNetCore.Mvc.ProducesAttribute (Order: 0)"]
+2025-10-04 02:55:47.015 +07:00 [DBG] Executing controller factory for controller CapBot.api.Controllers.TopicController (CapBot.api)
+2025-10-04 02:55:47.016 +07:00 [DBG] Executed controller factory for controller CapBot.api.Controllers.TopicController (CapBot.api)
+2025-10-04 02:55:47.016 +07:00 [DBG] Attempting to bind parameter 'topicId' of type 'System.Int32' ...
+2025-10-04 02:55:47.017 +07:00 [DBG] Attempting to bind parameter 'topicId' of type 'System.Int32' using the name 'topicId' in request data ...
+2025-10-04 02:55:47.017 +07:00 [DBG] Done attempting to bind parameter 'topicId' of type 'System.Int32'.
+2025-10-04 02:55:47.017 +07:00 [DBG] Done attempting to bind parameter 'topicId' of type 'System.Int32'.
+2025-10-04 02:55:47.017 +07:00 [DBG] Attempting to validate the bound parameter 'topicId' of type 'System.Int32' ...
+2025-10-04 02:55:47.017 +07:00 [DBG] Done attempting to validate the bound parameter 'topicId' of type 'System.Int32'.
+2025-10-04 02:55:47.020 +07:00 [DBG] Entity Framework Core 8.0.16 initialized 'MyDbContext' using provider 'Microsoft.EntityFrameworkCore.SqlServer:8.0.13' with options: MigrationsAssembly=App.DAL 
+2025-10-04 02:55:47.021 +07:00 [DBG] Creating DbConnection.
+2025-10-04 02:55:47.022 +07:00 [DBG] Created DbConnection. (0ms).
+2025-10-04 02:55:47.022 +07:00 [DBG] Opening connection to database 'capbot_db' on server 'localhost'.
+2025-10-04 02:55:47.022 +07:00 [DBG] Opened connection to database 'capbot_db' on server 'localhost'.
+2025-10-04 02:55:47.022 +07:00 [DBG] Creating DbCommand for 'ExecuteReader'.
+2025-10-04 02:55:47.022 +07:00 [DBG] Created DbCommand for 'ExecuteReader' (0ms).
+2025-10-04 02:55:47.023 +07:00 [DBG] Initialized DbCommand for 'ExecuteReader' (0ms).
+2025-10-04 02:55:47.023 +07:00 [DBG] Executing DbCommand [Parameters=[@__topicId_0='?' (DbType = Int32)], CommandType='"Text"', CommandTimeout='30']
+SELECT [t1].[Id], [t1].[Abbreviation], [t1].[CategoryId], [t1].[Content], [t1].[Context], [t1].[CreatedAt], [t1].[CreatedBy], [t1].[DeletedAt], [t1].[Description], [t1].[EN_Title], [t1].[IsActive], [t1].[IsApproved], [t1].[IsLegacy], [t1].[LastModifiedAt], [t1].[LastModifiedBy], [t1].[MaxStudents], [t1].[Objectives], [t1].[PotentialDuplicate], [t1].[Problem], [t1].[SemesterId], [t1].[SupervisorId], [t1].[VN_title], [t1].[Id0], [t1].[AccessFailedCount], [t1].[ConcurrencyStamp], [t1].[CreatedAt0], [t1].[DeletedAt0], [t1].[Email], [t1].[EmailConfirmed], [t1].[LastModifiedAt0], [t1].[LastModifiedBy0], [t1].[LockoutEnabled], [t1].[LockoutEnd], [t1].[NormalizedEmail], [t1].[NormalizedUserName], [t1].[PasswordHash], [t1].[PhoneNumber], [t1].[PhoneNumberConfirmed], [t1].[SecurityStamp], [t1].[TwoFactorEnabled], [t1].[UserName], [t1].[Id1], [t1].[CreatedAt1], [t1].[CreatedBy0], [t1].[DeletedAt1], [t1].[Description0], [t1].[IsActive0], [t1].[LastModifiedAt1], [t1].[LastModifiedBy1], [t1].[Name], [t1].[Id2], [t1].[CreatedAt2], [t1].[CreatedBy1], [t1].[DeletedAt2], [t1].[Description1], [t1].[EndDate], [t1].[IsActive1], [t1].[LastModifiedAt2], [t1].[LastModifiedBy2], [t1].[Name0], [t1].[StartDate], [t2].[Id], [t2].[Content], [t2].[Context], [t2].[CreatedAt], [t2].[CreatedBy], [t2].[DeletedAt], [t2].[Description], [t2].[DocumentUrl], [t2].[EN_Title], [t2].[ExpectedOutcomes], [t2].[IsActive], [t2].[LastModifiedAt], [t2].[LastModifiedBy], [t2].[Methodology], [t2].[Objectives], [t2].[PotentialDuplicate], [t2].[Problem], [t2].[Requirements], [t2].[Status], [t2].[SubmittedAt], [t2].[SubmittedBy], [t2].[TopicId], [t2].[VN_title], [t2].[VersionNumber]
+FROM (
+    SELECT TOP(1) [t].[Id], [t].[Abbreviation], [t].[CategoryId], [t].[Content], [t].[Context], [t].[CreatedAt], [t].[CreatedBy], [t].[DeletedAt], [t].[Description], [t].[EN_Title], [t].[IsActive], [t].[IsApproved], [t].[IsLegacy], [t].[LastModifiedAt], [t].[LastModifiedBy], [t].[MaxStudents], [t].[Objectives], [t].[PotentialDuplicate], [t].[Problem], [t].[SemesterId], [t].[SupervisorId], [t].[VN_title], [u].[Id] AS [Id0], [u].[AccessFailedCount], [u].[ConcurrencyStamp], [u].[CreatedAt] AS [CreatedAt0], [u].[DeletedAt] AS [DeletedAt0], [u].[Email], [u].[EmailConfirmed], [u].[LastModifiedAt] AS [LastModifiedAt0], [u].[LastModifiedBy] AS [LastModifiedBy0], [u].[LockoutEnabled], [u].[LockoutEnd], [u].[NormalizedEmail], [u].[NormalizedUserName], [u].[PasswordHash], [u].[PhoneNumber], [u].[PhoneNumberConfirmed], [u].[SecurityStamp], [u].[TwoFactorEnabled], [u].[UserName], [t0].[Id] AS [Id1], [t0].[CreatedAt] AS [CreatedAt1], [t0].[CreatedBy] AS [CreatedBy0], [t0].[DeletedAt] AS [DeletedAt1], [t0].[Description] AS [Description0], [t0].[IsActive] AS [IsActive0], [t0].[LastModifiedAt] AS [LastModifiedAt1], [t0].[LastModifiedBy] AS [LastModifiedBy1], [t0].[Name], [s].[Id] AS [Id2], [s].[CreatedAt] AS [CreatedAt2], [s].[CreatedBy] AS [CreatedBy1], [s].[DeletedAt] AS [DeletedAt2], [s].[Description] AS [Description1], [s].[EndDate], [s].[IsActive] AS [IsActive1], [s].[LastModifiedAt] AS [LastModifiedAt2], [s].[LastModifiedBy] AS [LastModifiedBy2], [s].[Name] AS [Name0], [s].[StartDate]
+    FROM [topics] AS [t]
+    INNER JOIN [users] AS [u] ON [t].[SupervisorId] = [u].[Id]
+    LEFT JOIN [topic_categories] AS [t0] ON [t].[CategoryId] = [t0].[Id]
+    INNER JOIN [semesters] AS [s] ON [t].[SemesterId] = [s].[Id]
+    WHERE [t].[Id] = @__topicId_0 AND [t].[IsActive] = CAST(1 AS bit) AND [t].[DeletedAt] IS NULL
+) AS [t1]
+LEFT JOIN [topic_versions] AS [t2] ON [t1].[Id] = [t2].[TopicId]
+ORDER BY [t1].[Id], [t1].[Id0], [t1].[Id1], [t1].[Id2]
+2025-10-04 02:55:47.082 +07:00 [INF] Executed DbCommand (59ms) [Parameters=[@__topicId_0='?' (DbType = Int32)], CommandType='"Text"', CommandTimeout='30']
+SELECT [t1].[Id], [t1].[Abbreviation], [t1].[CategoryId], [t1].[Content], [t1].[Context], [t1].[CreatedAt], [t1].[CreatedBy], [t1].[DeletedAt], [t1].[Description], [t1].[EN_Title], [t1].[IsActive], [t1].[IsApproved], [t1].[IsLegacy], [t1].[LastModifiedAt], [t1].[LastModifiedBy], [t1].[MaxStudents], [t1].[Objectives], [t1].[PotentialDuplicate], [t1].[Problem], [t1].[SemesterId], [t1].[SupervisorId], [t1].[VN_title], [t1].[Id0], [t1].[AccessFailedCount], [t1].[ConcurrencyStamp], [t1].[CreatedAt0], [t1].[DeletedAt0], [t1].[Email], [t1].[EmailConfirmed], [t1].[LastModifiedAt0], [t1].[LastModifiedBy0], [t1].[LockoutEnabled], [t1].[LockoutEnd], [t1].[NormalizedEmail], [t1].[NormalizedUserName], [t1].[PasswordHash], [t1].[PhoneNumber], [t1].[PhoneNumberConfirmed], [t1].[SecurityStamp], [t1].[TwoFactorEnabled], [t1].[UserName], [t1].[Id1], [t1].[CreatedAt1], [t1].[CreatedBy0], [t1].[DeletedAt1], [t1].[Description0], [t1].[IsActive0], [t1].[LastModifiedAt1], [t1].[LastModifiedBy1], [t1].[Name], [t1].[Id2], [t1].[CreatedAt2], [t1].[CreatedBy1], [t1].[DeletedAt2], [t1].[Description1], [t1].[EndDate], [t1].[IsActive1], [t1].[LastModifiedAt2], [t1].[LastModifiedBy2], [t1].[Name0], [t1].[StartDate], [t2].[Id], [t2].[Content], [t2].[Context], [t2].[CreatedAt], [t2].[CreatedBy], [t2].[DeletedAt], [t2].[Description], [t2].[DocumentUrl], [t2].[EN_Title], [t2].[ExpectedOutcomes], [t2].[IsActive], [t2].[LastModifiedAt], [t2].[LastModifiedBy], [t2].[Methodology], [t2].[Objectives], [t2].[PotentialDuplicate], [t2].[Problem], [t2].[Requirements], [t2].[Status], [t2].[SubmittedAt], [t2].[SubmittedBy], [t2].[TopicId], [t2].[VN_title], [t2].[VersionNumber]
+FROM (
+    SELECT TOP(1) [t].[Id], [t].[Abbreviation], [t].[CategoryId], [t].[Content], [t].[Context], [t].[CreatedAt], [t].[CreatedBy], [t].[DeletedAt], [t].[Description], [t].[EN_Title], [t].[IsActive], [t].[IsApproved], [t].[IsLegacy], [t].[LastModifiedAt], [t].[LastModifiedBy], [t].[MaxStudents], [t].[Objectives], [t].[PotentialDuplicate], [t].[Problem], [t].[SemesterId], [t].[SupervisorId], [t].[VN_title], [u].[Id] AS [Id0], [u].[AccessFailedCount], [u].[ConcurrencyStamp], [u].[CreatedAt] AS [CreatedAt0], [u].[DeletedAt] AS [DeletedAt0], [u].[Email], [u].[EmailConfirmed], [u].[LastModifiedAt] AS [LastModifiedAt0], [u].[LastModifiedBy] AS [LastModifiedBy0], [u].[LockoutEnabled], [u].[LockoutEnd], [u].[NormalizedEmail], [u].[NormalizedUserName], [u].[PasswordHash], [u].[PhoneNumber], [u].[PhoneNumberConfirmed], [u].[SecurityStamp], [u].[TwoFactorEnabled], [u].[UserName], [t0].[Id] AS [Id1], [t0].[CreatedAt] AS [CreatedAt1], [t0].[CreatedBy] AS [CreatedBy0], [t0].[DeletedAt] AS [DeletedAt1], [t0].[Description] AS [Description0], [t0].[IsActive] AS [IsActive0], [t0].[LastModifiedAt] AS [LastModifiedAt1], [t0].[LastModifiedBy] AS [LastModifiedBy1], [t0].[Name], [s].[Id] AS [Id2], [s].[CreatedAt] AS [CreatedAt2], [s].[CreatedBy] AS [CreatedBy1], [s].[DeletedAt] AS [DeletedAt2], [s].[Description] AS [Description1], [s].[EndDate], [s].[IsActive] AS [IsActive1], [s].[LastModifiedAt] AS [LastModifiedAt2], [s].[LastModifiedBy] AS [LastModifiedBy2], [s].[Name] AS [Name0], [s].[StartDate]
+    FROM [topics] AS [t]
+    INNER JOIN [users] AS [u] ON [t].[SupervisorId] = [u].[Id]
+    LEFT JOIN [topic_categories] AS [t0] ON [t].[CategoryId] = [t0].[Id]
+    INNER JOIN [semesters] AS [s] ON [t].[SemesterId] = [s].[Id]
+    WHERE [t].[Id] = @__topicId_0 AND [t].[IsActive] = CAST(1 AS bit) AND [t].[DeletedAt] IS NULL
+) AS [t1]
+LEFT JOIN [topic_versions] AS [t2] ON [t1].[Id] = [t2].[TopicId]
+ORDER BY [t1].[Id], [t1].[Id0], [t1].[Id1], [t1].[Id2]
+2025-10-04 02:55:47.083 +07:00 [DBG] Closing data reader to 'capbot_db' on server 'localhost'.
+2025-10-04 02:55:47.083 +07:00 [DBG] A data reader for 'capbot_db' on server 'localhost' is being disposed after spending 0ms reading results.
+2025-10-04 02:55:47.083 +07:00 [DBG] Closing connection to database 'capbot_db' on server 'localhost'.
+2025-10-04 02:55:47.083 +07:00 [DBG] Closed connection to database 'capbot_db' on server 'localhost' (0ms).
+2025-10-04 02:55:47.084 +07:00 [DBG] Opening connection to database 'capbot_db' on server 'localhost'.
+2025-10-04 02:55:47.085 +07:00 [DBG] Opened connection to database 'capbot_db' on server 'localhost'.
+2025-10-04 02:55:47.086 +07:00 [DBG] Creating DbCommand for 'ExecuteReader'.
+2025-10-04 02:55:47.086 +07:00 [DBG] Created DbCommand for 'ExecuteReader' (0ms).
+2025-10-04 02:55:47.086 +07:00 [DBG] Initialized DbCommand for 'ExecuteReader' (0ms).
+2025-10-04 02:55:47.086 +07:00 [DBG] Executing DbCommand [Parameters=[@__topicId_0='?' (DbType = Int32)], CommandType='"Text"', CommandTimeout='30']
+SELECT [s].[Id], [s].[AdditionalNotes], [s].[AiCheckDetails], [s].[AiCheckScore], [s].[AiCheckStatus], [s].[CreatedAt], [s].[CreatedBy], [s].[DeletedAt], [s].[DocumentUrl], [s].[IsActive], [s].[LastModifiedAt], [s].[LastModifiedBy], [s].[PhaseId], [s].[Status], [s].[SubmissionRound], [s].[SubmittedAt], [s].[SubmittedBy], [s].[TopicId], [s].[TopicVersionId], [p].[Id], [p].[CreatedAt], [p].[CreatedBy], [p].[DeletedAt], [p].[EndDate], [p].[IsActive], [p].[LastModifiedAt], [p].[LastModifiedBy], [p].[Name], [p].[PhaseTypeId], [p].[SemesterId], [p].[StartDate], [p].[SubmissionDeadline], [u].[Id], [u].[AccessFailedCount], [u].[ConcurrencyStamp], [u].[CreatedAt], [u].[DeletedAt], [u].[Email], [u].[EmailConfirmed], [u].[LastModifiedAt], [u].[LastModifiedBy], [u].[LockoutEnabled], [u].[LockoutEnd], [u].[NormalizedEmail], [u].[NormalizedUserName], [u].[PasswordHash], [u].[PhoneNumber], [u].[PhoneNumberConfirmed], [u].[SecurityStamp], [u].[TwoFactorEnabled], [u].[UserName], [r].[Id], [r].[AssignedAt], [r].[AssignedBy], [r].[AssignmentType], [r].[CompletedAt], [r].[Deadline], [r].[ReviewerId], [r].[SkillMatchScore], [r].[StartedAt], [r].[Status], [r].[SubmissionId]
+FROM [submissions] AS [s]
+INNER JOIN [phases] AS [p] ON [s].[PhaseId] = [p].[Id]
+INNER JOIN [users] AS [u] ON [s].[SubmittedBy] = [u].[Id]
+LEFT JOIN [reviewer_assignments] AS [r] ON [s].[Id] = [r].[SubmissionId]
+WHERE [s].[TopicId] = @__topicId_0 AND [s].[IsActive] = CAST(1 AS bit) AND [s].[DeletedAt] IS NULL
+ORDER BY [s].[Id], [p].[Id], [u].[Id]
+2025-10-04 02:55:47.106 +07:00 [INF] Executed DbCommand (20ms) [Parameters=[@__topicId_0='?' (DbType = Int32)], CommandType='"Text"', CommandTimeout='30']
+SELECT [s].[Id], [s].[AdditionalNotes], [s].[AiCheckDetails], [s].[AiCheckScore], [s].[AiCheckStatus], [s].[CreatedAt], [s].[CreatedBy], [s].[DeletedAt], [s].[DocumentUrl], [s].[IsActive], [s].[LastModifiedAt], [s].[LastModifiedBy], [s].[PhaseId], [s].[Status], [s].[SubmissionRound], [s].[SubmittedAt], [s].[SubmittedBy], [s].[TopicId], [s].[TopicVersionId], [p].[Id], [p].[CreatedAt], [p].[CreatedBy], [p].[DeletedAt], [p].[EndDate], [p].[IsActive], [p].[LastModifiedAt], [p].[LastModifiedBy], [p].[Name], [p].[PhaseTypeId], [p].[SemesterId], [p].[StartDate], [p].[SubmissionDeadline], [u].[Id], [u].[AccessFailedCount], [u].[ConcurrencyStamp], [u].[CreatedAt], [u].[DeletedAt], [u].[Email], [u].[EmailConfirmed], [u].[LastModifiedAt], [u].[LastModifiedBy], [u].[LockoutEnabled], [u].[LockoutEnd], [u].[NormalizedEmail], [u].[NormalizedUserName], [u].[PasswordHash], [u].[PhoneNumber], [u].[PhoneNumberConfirmed], [u].[SecurityStamp], [u].[TwoFactorEnabled], [u].[UserName], [r].[Id], [r].[AssignedAt], [r].[AssignedBy], [r].[AssignmentType], [r].[CompletedAt], [r].[Deadline], [r].[ReviewerId], [r].[SkillMatchScore], [r].[StartedAt], [r].[Status], [r].[SubmissionId]
+FROM [submissions] AS [s]
+INNER JOIN [phases] AS [p] ON [s].[PhaseId] = [p].[Id]
+INNER JOIN [users] AS [u] ON [s].[SubmittedBy] = [u].[Id]
+LEFT JOIN [reviewer_assignments] AS [r] ON [s].[Id] = [r].[SubmissionId]
+WHERE [s].[TopicId] = @__topicId_0 AND [s].[IsActive] = CAST(1 AS bit) AND [s].[DeletedAt] IS NULL
+ORDER BY [s].[Id], [p].[Id], [u].[Id]
+2025-10-04 02:55:47.106 +07:00 [DBG] Closing data reader to 'capbot_db' on server 'localhost'.
+2025-10-04 02:55:47.107 +07:00 [DBG] A data reader for 'capbot_db' on server 'localhost' is being disposed after spending 0ms reading results.
+2025-10-04 02:55:47.107 +07:00 [DBG] Closing connection to database 'capbot_db' on server 'localhost'.
+2025-10-04 02:55:47.107 +07:00 [DBG] Closed connection to database 'capbot_db' on server 'localhost' (0ms).
+2025-10-04 02:55:47.107 +07:00 [DBG] Opening connection to database 'capbot_db' on server 'localhost'.
+2025-10-04 02:55:47.107 +07:00 [DBG] Opened connection to database 'capbot_db' on server 'localhost'.
+2025-10-04 02:55:47.107 +07:00 [DBG] Creating DbCommand for 'ExecuteReader'.
+2025-10-04 02:55:47.108 +07:00 [DBG] Created DbCommand for 'ExecuteReader' (0ms).
+2025-10-04 02:55:47.108 +07:00 [DBG] Initialized DbCommand for 'ExecuteReader' (0ms).
+2025-10-04 02:55:47.108 +07:00 [DBG] Executing DbCommand [Parameters=[@__p_0='?' (DbType = Int64)], CommandType='"Text"', CommandTimeout='30']
+SELECT TOP(1) [e].[Id], [e].[Caption], [e].[CreatedAt], [e].[EntityId], [e].[EntityType], [e].[FileId], [e].[IsPrimary], [f].[Id], [f].[Alt], [f].[Checksum], [f].[CreatedAt], [f].[CreatedBy], [f].[DeletedAt], [f].[FileName], [f].[FilePath], [f].[FileSize], [f].[FileType], [f].[Height], [f].[IsActive], [f].[LastModifiedAt], [f].[LastModifiedBy], [f].[MimeType], [f].[ThumbnailUrl], [f].[Url], [f].[Width]
+FROM [entity_files] AS [e]
+INNER JOIN [files] AS [f] ON [e].[FileId] = [f].[Id]
+WHERE [e].[EntityId] = @__p_0 AND [e].[EntityType] = 1 AND [e].[IsPrimary] = CAST(1 AS bit)
+2025-10-04 02:55:47.114 +07:00 [INF] Executed DbCommand (7ms) [Parameters=[@__p_0='?' (DbType = Int64)], CommandType='"Text"', CommandTimeout='30']
+SELECT TOP(1) [e].[Id], [e].[Caption], [e].[CreatedAt], [e].[EntityId], [e].[EntityType], [e].[FileId], [e].[IsPrimary], [f].[Id], [f].[Alt], [f].[Checksum], [f].[CreatedAt], [f].[CreatedBy], [f].[DeletedAt], [f].[FileName], [f].[FilePath], [f].[FileSize], [f].[FileType], [f].[Height], [f].[IsActive], [f].[LastModifiedAt], [f].[LastModifiedBy], [f].[MimeType], [f].[ThumbnailUrl], [f].[Url], [f].[Width]
+FROM [entity_files] AS [e]
+INNER JOIN [files] AS [f] ON [e].[FileId] = [f].[Id]
+WHERE [e].[EntityId] = @__p_0 AND [e].[EntityType] = 1 AND [e].[IsPrimary] = CAST(1 AS bit)
+2025-10-04 02:55:47.114 +07:00 [DBG] Closing data reader to 'capbot_db' on server 'localhost'.
+2025-10-04 02:55:47.114 +07:00 [DBG] A data reader for 'capbot_db' on server 'localhost' is being disposed after spending 0ms reading results.
+2025-10-04 02:55:47.115 +07:00 [DBG] Closing connection to database 'capbot_db' on server 'localhost'.
+2025-10-04 02:55:47.115 +07:00 [DBG] Closed connection to database 'capbot_db' on server 'localhost' (0ms).
+2025-10-04 02:55:47.115 +07:00 [DBG] List of registered output formatters, in the following order: ["Microsoft.AspNetCore.OData.Formatter.ODataOutputFormatter","Microsoft.AspNetCore.OData.Formatter.ODataOutputFormatter","Microsoft.AspNetCore.OData.Formatter.ODataOutputFormatter","Microsoft.AspNetCore.Mvc.Formatters.HttpNoContentOutputFormatter","Microsoft.AspNetCore.Mvc.Formatters.StringOutputFormatter","Microsoft.AspNetCore.Mvc.Formatters.StreamOutputFormatter","Microsoft.AspNetCore.Mvc.Formatters.SystemTextJsonOutputFormatter"]
+2025-10-04 02:55:47.115 +07:00 [DBG] No information found on request to perform content negotiation.
+2025-10-04 02:55:47.116 +07:00 [DBG] Attempting to select the first output formatter in the output formatters list which supports a content type from the explicitly specified content types '["application/json"]'.
+2025-10-04 02:55:47.116 +07:00 [DBG] Selected output formatter 'Microsoft.AspNetCore.Mvc.Formatters.SystemTextJsonOutputFormatter' and content type 'application/json' to write the response.
+2025-10-04 02:55:47.116 +07:00 [INF] Executing ObjectResult, writing value of type 'FS.Commons.FSResponse'.
+2025-10-04 02:55:47.118 +07:00 [INF] Executed action CapBot.api.Controllers.TopicController.GetDetail (CapBot.api) in 102.2607ms
+2025-10-04 02:55:47.118 +07:00 [INF] Executed endpoint 'CapBot.api.Controllers.TopicController.GetDetail (CapBot.api)'
+2025-10-04 02:55:47.118 +07:00 [DBG] Connection id "0HNG2MQC634J9" completed keep alive response.
+2025-10-04 02:55:47.118 +07:00 [DBG] 'MyDbContext' disposed.
+2025-10-04 02:55:47.119 +07:00 [DBG] Disposing connection to database 'capbot_db' on server 'localhost'.
+2025-10-04 02:55:47.119 +07:00 [DBG] Disposed connection to database '' on server '' (0ms).
+2025-10-04 02:55:47.120 +07:00 [INF] Request finished HTTP/1.1 GET http://localhost:5207/api/topic/detail/104 - 200 null application/json; charset=utf-8 107.7629ms
+2025-10-04 02:55:53.311 +07:00 [INF] Request starting HTTP/1.1 GET http://localhost:5207/api/topic/detail/104 - null null
+2025-10-04 02:55:53.311 +07:00 [DBG] The request path /api/topic/detail/104 does not match a supported file type
+2025-10-04 02:55:53.312 +07:00 [DBG] The request path /api/topic/detail/104 does not match a supported file type
+2025-10-04 02:55:53.312 +07:00 [DBG] 1 candidate(s) found for the request path '/api/topic/detail/104'
+2025-10-04 02:55:53.312 +07:00 [DBG] Endpoint 'CapBot.api.Controllers.TopicController.GetDetail (CapBot.api)' with route pattern 'api/topic/detail/{topicId}' is valid for the request path '/api/topic/detail/104'
+2025-10-04 02:55:53.312 +07:00 [DBG] Request matched endpoint 'CapBot.api.Controllers.TopicController.GetDetail (CapBot.api)'
+2025-10-04 02:55:53.313 +07:00 [DBG] Successfully validated the token.
+2025-10-04 02:55:53.313 +07:00 [DBG] AuthenticationScheme: Bearer was successfully authenticated.
+2025-10-04 02:55:53.314 +07:00 [INF] Executing endpoint 'CapBot.api.Controllers.TopicController.GetDetail (CapBot.api)'
+2025-10-04 02:55:53.314 +07:00 [INF] Route matched with {action = "GetDetail", controller = "Topic"}. Executing controller action with signature System.Threading.Tasks.Task`1[Microsoft.AspNetCore.Mvc.IActionResult] GetDetail(Int32) on controller CapBot.api.Controllers.TopicController (CapBot.api).
+2025-10-04 02:55:53.315 +07:00 [DBG] Execution plan of authorization filters (in the following order): ["None"]
+2025-10-04 02:55:53.315 +07:00 [DBG] Execution plan of resource filters (in the following order): ["Microsoft.AspNetCore.Mvc.ConsumesAttribute"]
+2025-10-04 02:55:53.315 +07:00 [DBG] Execution plan of action filters (in the following order): ["Microsoft.AspNetCore.Mvc.ModelBinding.UnsupportedContentTypeFilter (Order: -3000)"]
+2025-10-04 02:55:53.315 +07:00 [DBG] Execution plan of exception filters (in the following order): ["None"]
+2025-10-04 02:55:53.315 +07:00 [DBG] Execution plan of result filters (in the following order): ["Microsoft.AspNetCore.Mvc.Infrastructure.ClientErrorResultFilter (Order: -2000)","Microsoft.AspNetCore.Mvc.ProducesAttribute (Order: 0)"]
+2025-10-04 02:55:53.315 +07:00 [DBG] Executing controller factory for controller CapBot.api.Controllers.TopicController (CapBot.api)
+2025-10-04 02:55:53.317 +07:00 [DBG] Executed controller factory for controller CapBot.api.Controllers.TopicController (CapBot.api)
+2025-10-04 02:55:53.318 +07:00 [DBG] Attempting to bind parameter 'topicId' of type 'System.Int32' ...
+2025-10-04 02:55:53.318 +07:00 [DBG] Attempting to bind parameter 'topicId' of type 'System.Int32' using the name 'topicId' in request data ...
+2025-10-04 02:55:53.318 +07:00 [DBG] Done attempting to bind parameter 'topicId' of type 'System.Int32'.
+2025-10-04 02:55:53.318 +07:00 [DBG] Done attempting to bind parameter 'topicId' of type 'System.Int32'.
+2025-10-04 02:55:53.318 +07:00 [DBG] Attempting to validate the bound parameter 'topicId' of type 'System.Int32' ...
+2025-10-04 02:55:53.319 +07:00 [DBG] Done attempting to validate the bound parameter 'topicId' of type 'System.Int32'.
+2025-10-04 02:55:53.320 +07:00 [DBG] Entity Framework Core 8.0.16 initialized 'MyDbContext' using provider 'Microsoft.EntityFrameworkCore.SqlServer:8.0.13' with options: MigrationsAssembly=App.DAL 
+2025-10-04 02:55:53.321 +07:00 [DBG] Creating DbConnection.
+2025-10-04 02:55:53.321 +07:00 [DBG] Created DbConnection. (0ms).
+2025-10-04 02:55:53.321 +07:00 [DBG] Opening connection to database 'capbot_db' on server 'localhost'.
+2025-10-04 02:55:53.321 +07:00 [DBG] Opened connection to database 'capbot_db' on server 'localhost'.
+2025-10-04 02:55:53.321 +07:00 [DBG] Creating DbCommand for 'ExecuteReader'.
+2025-10-04 02:55:53.322 +07:00 [DBG] Created DbCommand for 'ExecuteReader' (0ms).
+2025-10-04 02:55:53.322 +07:00 [DBG] Initialized DbCommand for 'ExecuteReader' (0ms).
+2025-10-04 02:55:53.322 +07:00 [DBG] Executing DbCommand [Parameters=[@__topicId_0='?' (DbType = Int32)], CommandType='"Text"', CommandTimeout='30']
+SELECT [t1].[Id], [t1].[Abbreviation], [t1].[CategoryId], [t1].[Content], [t1].[Context], [t1].[CreatedAt], [t1].[CreatedBy], [t1].[DeletedAt], [t1].[Description], [t1].[EN_Title], [t1].[IsActive], [t1].[IsApproved], [t1].[IsLegacy], [t1].[LastModifiedAt], [t1].[LastModifiedBy], [t1].[MaxStudents], [t1].[Objectives], [t1].[PotentialDuplicate], [t1].[Problem], [t1].[SemesterId], [t1].[SupervisorId], [t1].[VN_title], [t1].[Id0], [t1].[AccessFailedCount], [t1].[ConcurrencyStamp], [t1].[CreatedAt0], [t1].[DeletedAt0], [t1].[Email], [t1].[EmailConfirmed], [t1].[LastModifiedAt0], [t1].[LastModifiedBy0], [t1].[LockoutEnabled], [t1].[LockoutEnd], [t1].[NormalizedEmail], [t1].[NormalizedUserName], [t1].[PasswordHash], [t1].[PhoneNumber], [t1].[PhoneNumberConfirmed], [t1].[SecurityStamp], [t1].[TwoFactorEnabled], [t1].[UserName], [t1].[Id1], [t1].[CreatedAt1], [t1].[CreatedBy0], [t1].[DeletedAt1], [t1].[Description0], [t1].[IsActive0], [t1].[LastModifiedAt1], [t1].[LastModifiedBy1], [t1].[Name], [t1].[Id2], [t1].[CreatedAt2], [t1].[CreatedBy1], [t1].[DeletedAt2], [t1].[Description1], [t1].[EndDate], [t1].[IsActive1], [t1].[LastModifiedAt2], [t1].[LastModifiedBy2], [t1].[Name0], [t1].[StartDate], [t2].[Id], [t2].[Content], [t2].[Context], [t2].[CreatedAt], [t2].[CreatedBy], [t2].[DeletedAt], [t2].[Description], [t2].[DocumentUrl], [t2].[EN_Title], [t2].[ExpectedOutcomes], [t2].[IsActive], [t2].[LastModifiedAt], [t2].[LastModifiedBy], [t2].[Methodology], [t2].[Objectives], [t2].[PotentialDuplicate], [t2].[Problem], [t2].[Requirements], [t2].[Status], [t2].[SubmittedAt], [t2].[SubmittedBy], [t2].[TopicId], [t2].[VN_title], [t2].[VersionNumber]
+FROM (
+    SELECT TOP(1) [t].[Id], [t].[Abbreviation], [t].[CategoryId], [t].[Content], [t].[Context], [t].[CreatedAt], [t].[CreatedBy], [t].[DeletedAt], [t].[Description], [t].[EN_Title], [t].[IsActive], [t].[IsApproved], [t].[IsLegacy], [t].[LastModifiedAt], [t].[LastModifiedBy], [t].[MaxStudents], [t].[Objectives], [t].[PotentialDuplicate], [t].[Problem], [t].[SemesterId], [t].[SupervisorId], [t].[VN_title], [u].[Id] AS [Id0], [u].[AccessFailedCount], [u].[ConcurrencyStamp], [u].[CreatedAt] AS [CreatedAt0], [u].[DeletedAt] AS [DeletedAt0], [u].[Email], [u].[EmailConfirmed], [u].[LastModifiedAt] AS [LastModifiedAt0], [u].[LastModifiedBy] AS [LastModifiedBy0], [u].[LockoutEnabled], [u].[LockoutEnd], [u].[NormalizedEmail], [u].[NormalizedUserName], [u].[PasswordHash], [u].[PhoneNumber], [u].[PhoneNumberConfirmed], [u].[SecurityStamp], [u].[TwoFactorEnabled], [u].[UserName], [t0].[Id] AS [Id1], [t0].[CreatedAt] AS [CreatedAt1], [t0].[CreatedBy] AS [CreatedBy0], [t0].[DeletedAt] AS [DeletedAt1], [t0].[Description] AS [Description0], [t0].[IsActive] AS [IsActive0], [t0].[LastModifiedAt] AS [LastModifiedAt1], [t0].[LastModifiedBy] AS [LastModifiedBy1], [t0].[Name], [s].[Id] AS [Id2], [s].[CreatedAt] AS [CreatedAt2], [s].[CreatedBy] AS [CreatedBy1], [s].[DeletedAt] AS [DeletedAt2], [s].[Description] AS [Description1], [s].[EndDate], [s].[IsActive] AS [IsActive1], [s].[LastModifiedAt] AS [LastModifiedAt2], [s].[LastModifiedBy] AS [LastModifiedBy2], [s].[Name] AS [Name0], [s].[StartDate]
+    FROM [topics] AS [t]
+    INNER JOIN [users] AS [u] ON [t].[SupervisorId] = [u].[Id]
+    LEFT JOIN [topic_categories] AS [t0] ON [t].[CategoryId] = [t0].[Id]
+    INNER JOIN [semesters] AS [s] ON [t].[SemesterId] = [s].[Id]
+    WHERE [t].[Id] = @__topicId_0 AND [t].[IsActive] = CAST(1 AS bit) AND [t].[DeletedAt] IS NULL
+) AS [t1]
+LEFT JOIN [topic_versions] AS [t2] ON [t1].[Id] = [t2].[TopicId]
+ORDER BY [t1].[Id], [t1].[Id0], [t1].[Id1], [t1].[Id2]
+2025-10-04 02:55:53.358 +07:00 [INF] Executed DbCommand (35ms) [Parameters=[@__topicId_0='?' (DbType = Int32)], CommandType='"Text"', CommandTimeout='30']
+SELECT [t1].[Id], [t1].[Abbreviation], [t1].[CategoryId], [t1].[Content], [t1].[Context], [t1].[CreatedAt], [t1].[CreatedBy], [t1].[DeletedAt], [t1].[Description], [t1].[EN_Title], [t1].[IsActive], [t1].[IsApproved], [t1].[IsLegacy], [t1].[LastModifiedAt], [t1].[LastModifiedBy], [t1].[MaxStudents], [t1].[Objectives], [t1].[PotentialDuplicate], [t1].[Problem], [t1].[SemesterId], [t1].[SupervisorId], [t1].[VN_title], [t1].[Id0], [t1].[AccessFailedCount], [t1].[ConcurrencyStamp], [t1].[CreatedAt0], [t1].[DeletedAt0], [t1].[Email], [t1].[EmailConfirmed], [t1].[LastModifiedAt0], [t1].[LastModifiedBy0], [t1].[LockoutEnabled], [t1].[LockoutEnd], [t1].[NormalizedEmail], [t1].[NormalizedUserName], [t1].[PasswordHash], [t1].[PhoneNumber], [t1].[PhoneNumberConfirmed], [t1].[SecurityStamp], [t1].[TwoFactorEnabled], [t1].[UserName], [t1].[Id1], [t1].[CreatedAt1], [t1].[CreatedBy0], [t1].[DeletedAt1], [t1].[Description0], [t1].[IsActive0], [t1].[LastModifiedAt1], [t1].[LastModifiedBy1], [t1].[Name], [t1].[Id2], [t1].[CreatedAt2], [t1].[CreatedBy1], [t1].[DeletedAt2], [t1].[Description1], [t1].[EndDate], [t1].[IsActive1], [t1].[LastModifiedAt2], [t1].[LastModifiedBy2], [t1].[Name0], [t1].[StartDate], [t2].[Id], [t2].[Content], [t2].[Context], [t2].[CreatedAt], [t2].[CreatedBy], [t2].[DeletedAt], [t2].[Description], [t2].[DocumentUrl], [t2].[EN_Title], [t2].[ExpectedOutcomes], [t2].[IsActive], [t2].[LastModifiedAt], [t2].[LastModifiedBy], [t2].[Methodology], [t2].[Objectives], [t2].[PotentialDuplicate], [t2].[Problem], [t2].[Requirements], [t2].[Status], [t2].[SubmittedAt], [t2].[SubmittedBy], [t2].[TopicId], [t2].[VN_title], [t2].[VersionNumber]
+FROM (
+    SELECT TOP(1) [t].[Id], [t].[Abbreviation], [t].[CategoryId], [t].[Content], [t].[Context], [t].[CreatedAt], [t].[CreatedBy], [t].[DeletedAt], [t].[Description], [t].[EN_Title], [t].[IsActive], [t].[IsApproved], [t].[IsLegacy], [t].[LastModifiedAt], [t].[LastModifiedBy], [t].[MaxStudents], [t].[Objectives], [t].[PotentialDuplicate], [t].[Problem], [t].[SemesterId], [t].[SupervisorId], [t].[VN_title], [u].[Id] AS [Id0], [u].[AccessFailedCount], [u].[ConcurrencyStamp], [u].[CreatedAt] AS [CreatedAt0], [u].[DeletedAt] AS [DeletedAt0], [u].[Email], [u].[EmailConfirmed], [u].[LastModifiedAt] AS [LastModifiedAt0], [u].[LastModifiedBy] AS [LastModifiedBy0], [u].[LockoutEnabled], [u].[LockoutEnd], [u].[NormalizedEmail], [u].[NormalizedUserName], [u].[PasswordHash], [u].[PhoneNumber], [u].[PhoneNumberConfirmed], [u].[SecurityStamp], [u].[TwoFactorEnabled], [u].[UserName], [t0].[Id] AS [Id1], [t0].[CreatedAt] AS [CreatedAt1], [t0].[CreatedBy] AS [CreatedBy0], [t0].[DeletedAt] AS [DeletedAt1], [t0].[Description] AS [Description0], [t0].[IsActive] AS [IsActive0], [t0].[LastModifiedAt] AS [LastModifiedAt1], [t0].[LastModifiedBy] AS [LastModifiedBy1], [t0].[Name], [s].[Id] AS [Id2], [s].[CreatedAt] AS [CreatedAt2], [s].[CreatedBy] AS [CreatedBy1], [s].[DeletedAt] AS [DeletedAt2], [s].[Description] AS [Description1], [s].[EndDate], [s].[IsActive] AS [IsActive1], [s].[LastModifiedAt] AS [LastModifiedAt2], [s].[LastModifiedBy] AS [LastModifiedBy2], [s].[Name] AS [Name0], [s].[StartDate]
+    FROM [topics] AS [t]
+    INNER JOIN [users] AS [u] ON [t].[SupervisorId] = [u].[Id]
+    LEFT JOIN [topic_categories] AS [t0] ON [t].[CategoryId] = [t0].[Id]
+    INNER JOIN [semesters] AS [s] ON [t].[SemesterId] = [s].[Id]
+    WHERE [t].[Id] = @__topicId_0 AND [t].[IsActive] = CAST(1 AS bit) AND [t].[DeletedAt] IS NULL
+) AS [t1]
+LEFT JOIN [topic_versions] AS [t2] ON [t1].[Id] = [t2].[TopicId]
+ORDER BY [t1].[Id], [t1].[Id0], [t1].[Id1], [t1].[Id2]
+2025-10-04 02:55:53.360 +07:00 [DBG] Closing data reader to 'capbot_db' on server 'localhost'.
+2025-10-04 02:55:53.361 +07:00 [DBG] A data reader for 'capbot_db' on server 'localhost' is being disposed after spending 1ms reading results.
+2025-10-04 02:55:53.361 +07:00 [DBG] Closing connection to database 'capbot_db' on server 'localhost'.
+2025-10-04 02:55:53.361 +07:00 [DBG] Closed connection to database 'capbot_db' on server 'localhost' (0ms).
+2025-10-04 02:55:53.362 +07:00 [DBG] Opening connection to database 'capbot_db' on server 'localhost'.
+2025-10-04 02:55:53.368 +07:00 [DBG] Opened connection to database 'capbot_db' on server 'localhost'.
+2025-10-04 02:55:53.368 +07:00 [DBG] Creating DbCommand for 'ExecuteReader'.
+2025-10-04 02:55:53.368 +07:00 [DBG] Created DbCommand for 'ExecuteReader' (0ms).
+2025-10-04 02:55:53.368 +07:00 [DBG] Initialized DbCommand for 'ExecuteReader' (0ms).
+2025-10-04 02:55:53.369 +07:00 [DBG] Executing DbCommand [Parameters=[@__topicId_0='?' (DbType = Int32)], CommandType='"Text"', CommandTimeout='30']
+SELECT [s].[Id], [s].[AdditionalNotes], [s].[AiCheckDetails], [s].[AiCheckScore], [s].[AiCheckStatus], [s].[CreatedAt], [s].[CreatedBy], [s].[DeletedAt], [s].[DocumentUrl], [s].[IsActive], [s].[LastModifiedAt], [s].[LastModifiedBy], [s].[PhaseId], [s].[Status], [s].[SubmissionRound], [s].[SubmittedAt], [s].[SubmittedBy], [s].[TopicId], [s].[TopicVersionId], [p].[Id], [p].[CreatedAt], [p].[CreatedBy], [p].[DeletedAt], [p].[EndDate], [p].[IsActive], [p].[LastModifiedAt], [p].[LastModifiedBy], [p].[Name], [p].[PhaseTypeId], [p].[SemesterId], [p].[StartDate], [p].[SubmissionDeadline], [u].[Id], [u].[AccessFailedCount], [u].[ConcurrencyStamp], [u].[CreatedAt], [u].[DeletedAt], [u].[Email], [u].[EmailConfirmed], [u].[LastModifiedAt], [u].[LastModifiedBy], [u].[LockoutEnabled], [u].[LockoutEnd], [u].[NormalizedEmail], [u].[NormalizedUserName], [u].[PasswordHash], [u].[PhoneNumber], [u].[PhoneNumberConfirmed], [u].[SecurityStamp], [u].[TwoFactorEnabled], [u].[UserName], [r].[Id], [r].[AssignedAt], [r].[AssignedBy], [r].[AssignmentType], [r].[CompletedAt], [r].[Deadline], [r].[ReviewerId], [r].[SkillMatchScore], [r].[StartedAt], [r].[Status], [r].[SubmissionId]
+FROM [submissions] AS [s]
+INNER JOIN [phases] AS [p] ON [s].[PhaseId] = [p].[Id]
+INNER JOIN [users] AS [u] ON [s].[SubmittedBy] = [u].[Id]
+LEFT JOIN [reviewer_assignments] AS [r] ON [s].[Id] = [r].[SubmissionId]
+WHERE [s].[TopicId] = @__topicId_0 AND [s].[IsActive] = CAST(1 AS bit) AND [s].[DeletedAt] IS NULL
+ORDER BY [s].[Id], [p].[Id], [u].[Id]
+2025-10-04 02:55:53.390 +07:00 [INF] Executed DbCommand (21ms) [Parameters=[@__topicId_0='?' (DbType = Int32)], CommandType='"Text"', CommandTimeout='30']
+SELECT [s].[Id], [s].[AdditionalNotes], [s].[AiCheckDetails], [s].[AiCheckScore], [s].[AiCheckStatus], [s].[CreatedAt], [s].[CreatedBy], [s].[DeletedAt], [s].[DocumentUrl], [s].[IsActive], [s].[LastModifiedAt], [s].[LastModifiedBy], [s].[PhaseId], [s].[Status], [s].[SubmissionRound], [s].[SubmittedAt], [s].[SubmittedBy], [s].[TopicId], [s].[TopicVersionId], [p].[Id], [p].[CreatedAt], [p].[CreatedBy], [p].[DeletedAt], [p].[EndDate], [p].[IsActive], [p].[LastModifiedAt], [p].[LastModifiedBy], [p].[Name], [p].[PhaseTypeId], [p].[SemesterId], [p].[StartDate], [p].[SubmissionDeadline], [u].[Id], [u].[AccessFailedCount], [u].[ConcurrencyStamp], [u].[CreatedAt], [u].[DeletedAt], [u].[Email], [u].[EmailConfirmed], [u].[LastModifiedAt], [u].[LastModifiedBy], [u].[LockoutEnabled], [u].[LockoutEnd], [u].[NormalizedEmail], [u].[NormalizedUserName], [u].[PasswordHash], [u].[PhoneNumber], [u].[PhoneNumberConfirmed], [u].[SecurityStamp], [u].[TwoFactorEnabled], [u].[UserName], [r].[Id], [r].[AssignedAt], [r].[AssignedBy], [r].[AssignmentType], [r].[CompletedAt], [r].[Deadline], [r].[ReviewerId], [r].[SkillMatchScore], [r].[StartedAt], [r].[Status], [r].[SubmissionId]
+FROM [submissions] AS [s]
+INNER JOIN [phases] AS [p] ON [s].[PhaseId] = [p].[Id]
+INNER JOIN [users] AS [u] ON [s].[SubmittedBy] = [u].[Id]
+LEFT JOIN [reviewer_assignments] AS [r] ON [s].[Id] = [r].[SubmissionId]
+WHERE [s].[TopicId] = @__topicId_0 AND [s].[IsActive] = CAST(1 AS bit) AND [s].[DeletedAt] IS NULL
+ORDER BY [s].[Id], [p].[Id], [u].[Id]
+2025-10-04 02:55:53.390 +07:00 [DBG] Closing data reader to 'capbot_db' on server 'localhost'.
+2025-10-04 02:55:53.391 +07:00 [DBG] A data reader for 'capbot_db' on server 'localhost' is being disposed after spending 0ms reading results.
+2025-10-04 02:55:53.391 +07:00 [DBG] Closing connection to database 'capbot_db' on server 'localhost'.
+2025-10-04 02:55:53.391 +07:00 [DBG] Closed connection to database 'capbot_db' on server 'localhost' (0ms).
+2025-10-04 02:55:53.391 +07:00 [DBG] Opening connection to database 'capbot_db' on server 'localhost'.
+2025-10-04 02:55:53.392 +07:00 [DBG] Opened connection to database 'capbot_db' on server 'localhost'.
+2025-10-04 02:55:53.392 +07:00 [DBG] Creating DbCommand for 'ExecuteReader'.
+2025-10-04 02:55:53.392 +07:00 [DBG] Created DbCommand for 'ExecuteReader' (0ms).
+2025-10-04 02:55:53.392 +07:00 [DBG] Initialized DbCommand for 'ExecuteReader' (0ms).
+2025-10-04 02:55:53.393 +07:00 [DBG] Executing DbCommand [Parameters=[@__p_0='?' (DbType = Int64)], CommandType='"Text"', CommandTimeout='30']
+SELECT TOP(1) [e].[Id], [e].[Caption], [e].[CreatedAt], [e].[EntityId], [e].[EntityType], [e].[FileId], [e].[IsPrimary], [f].[Id], [f].[Alt], [f].[Checksum], [f].[CreatedAt], [f].[CreatedBy], [f].[DeletedAt], [f].[FileName], [f].[FilePath], [f].[FileSize], [f].[FileType], [f].[Height], [f].[IsActive], [f].[LastModifiedAt], [f].[LastModifiedBy], [f].[MimeType], [f].[ThumbnailUrl], [f].[Url], [f].[Width]
+FROM [entity_files] AS [e]
+INNER JOIN [files] AS [f] ON [e].[FileId] = [f].[Id]
+WHERE [e].[EntityId] = @__p_0 AND [e].[EntityType] = 1 AND [e].[IsPrimary] = CAST(1 AS bit)
+2025-10-04 02:55:53.402 +07:00 [INF] Executed DbCommand (10ms) [Parameters=[@__p_0='?' (DbType = Int64)], CommandType='"Text"', CommandTimeout='30']
+SELECT TOP(1) [e].[Id], [e].[Caption], [e].[CreatedAt], [e].[EntityId], [e].[EntityType], [e].[FileId], [e].[IsPrimary], [f].[Id], [f].[Alt], [f].[Checksum], [f].[CreatedAt], [f].[CreatedBy], [f].[DeletedAt], [f].[FileName], [f].[FilePath], [f].[FileSize], [f].[FileType], [f].[Height], [f].[IsActive], [f].[LastModifiedAt], [f].[LastModifiedBy], [f].[MimeType], [f].[ThumbnailUrl], [f].[Url], [f].[Width]
+FROM [entity_files] AS [e]
+INNER JOIN [files] AS [f] ON [e].[FileId] = [f].[Id]
+WHERE [e].[EntityId] = @__p_0 AND [e].[EntityType] = 1 AND [e].[IsPrimary] = CAST(1 AS bit)
+2025-10-04 02:55:53.403 +07:00 [DBG] Closing data reader to 'capbot_db' on server 'localhost'.
+2025-10-04 02:55:53.403 +07:00 [DBG] A data reader for 'capbot_db' on server 'localhost' is being disposed after spending 0ms reading results.
+2025-10-04 02:55:53.403 +07:00 [DBG] Closing connection to database 'capbot_db' on server 'localhost'.
+2025-10-04 02:55:53.403 +07:00 [DBG] Closed connection to database 'capbot_db' on server 'localhost' (0ms).
+2025-10-04 02:55:53.403 +07:00 [DBG] List of registered output formatters, in the following order: ["Microsoft.AspNetCore.OData.Formatter.ODataOutputFormatter","Microsoft.AspNetCore.OData.Formatter.ODataOutputFormatter","Microsoft.AspNetCore.OData.Formatter.ODataOutputFormatter","Microsoft.AspNetCore.Mvc.Formatters.HttpNoContentOutputFormatter","Microsoft.AspNetCore.Mvc.Formatters.StringOutputFormatter","Microsoft.AspNetCore.Mvc.Formatters.StreamOutputFormatter","Microsoft.AspNetCore.Mvc.Formatters.SystemTextJsonOutputFormatter"]
+2025-10-04 02:55:53.403 +07:00 [DBG] No information found on request to perform content negotiation.
+2025-10-04 02:55:53.404 +07:00 [DBG] Attempting to select the first output formatter in the output formatters list which supports a content type from the explicitly specified content types '["application/json"]'.
+2025-10-04 02:55:53.404 +07:00 [DBG] Selected output formatter 'Microsoft.AspNetCore.Mvc.Formatters.SystemTextJsonOutputFormatter' and content type 'application/json' to write the response.
+2025-10-04 02:55:53.404 +07:00 [INF] Executing ObjectResult, writing value of type 'FS.Commons.FSResponse'.
+2025-10-04 02:55:53.404 +07:00 [INF] Executed action CapBot.api.Controllers.TopicController.GetDetail (CapBot.api) in 89.2259ms
+2025-10-04 02:55:53.404 +07:00 [INF] Executed endpoint 'CapBot.api.Controllers.TopicController.GetDetail (CapBot.api)'
+2025-10-04 02:55:53.405 +07:00 [DBG] Connection id "0HNG2MQC634J9" completed keep alive response.
+2025-10-04 02:55:53.405 +07:00 [DBG] 'MyDbContext' disposed.
+2025-10-04 02:55:53.405 +07:00 [DBG] Disposing connection to database 'capbot_db' on server 'localhost'.
+2025-10-04 02:55:53.406 +07:00 [DBG] Disposed connection to database '' on server '' (0ms).
+2025-10-04 02:55:53.406 +07:00 [INF] Request finished HTTP/1.1 GET http://localhost:5207/api/topic/detail/104 - 200 null application/json; charset=utf-8 94.9393ms
+2025-10-04 02:56:00.956 +07:00 [INF] Request starting HTTP/1.1 GET http://localhost:5207/api/topic/detail/104 - null null
+2025-10-04 02:56:00.957 +07:00 [DBG] The request path /api/topic/detail/104 does not match a supported file type
+2025-10-04 02:56:00.958 +07:00 [DBG] The request path /api/topic/detail/104 does not match a supported file type
+2025-10-04 02:56:00.958 +07:00 [DBG] 1 candidate(s) found for the request path '/api/topic/detail/104'
+2025-10-04 02:56:00.958 +07:00 [DBG] Endpoint 'CapBot.api.Controllers.TopicController.GetDetail (CapBot.api)' with route pattern 'api/topic/detail/{topicId}' is valid for the request path '/api/topic/detail/104'
+2025-10-04 02:56:00.958 +07:00 [DBG] Request matched endpoint 'CapBot.api.Controllers.TopicController.GetDetail (CapBot.api)'
+2025-10-04 02:56:00.959 +07:00 [DBG] Successfully validated the token.
+2025-10-04 02:56:00.960 +07:00 [DBG] AuthenticationScheme: Bearer was successfully authenticated.
+2025-10-04 02:56:00.960 +07:00 [INF] Executing endpoint 'CapBot.api.Controllers.TopicController.GetDetail (CapBot.api)'
+2025-10-04 02:56:00.960 +07:00 [INF] Route matched with {action = "GetDetail", controller = "Topic"}. Executing controller action with signature System.Threading.Tasks.Task`1[Microsoft.AspNetCore.Mvc.IActionResult] GetDetail(Int32) on controller CapBot.api.Controllers.TopicController (CapBot.api).
+2025-10-04 02:56:00.960 +07:00 [DBG] Execution plan of authorization filters (in the following order): ["None"]
+2025-10-04 02:56:00.961 +07:00 [DBG] Execution plan of resource filters (in the following order): ["Microsoft.AspNetCore.Mvc.ConsumesAttribute"]
+2025-10-04 02:56:00.961 +07:00 [DBG] Execution plan of action filters (in the following order): ["Microsoft.AspNetCore.Mvc.ModelBinding.UnsupportedContentTypeFilter (Order: -3000)"]
+2025-10-04 02:56:00.961 +07:00 [DBG] Execution plan of exception filters (in the following order): ["None"]
+2025-10-04 02:56:00.961 +07:00 [DBG] Execution plan of result filters (in the following order): ["Microsoft.AspNetCore.Mvc.Infrastructure.ClientErrorResultFilter (Order: -2000)","Microsoft.AspNetCore.Mvc.ProducesAttribute (Order: 0)"]
+2025-10-04 02:56:00.961 +07:00 [DBG] Executing controller factory for controller CapBot.api.Controllers.TopicController (CapBot.api)
+2025-10-04 02:56:00.962 +07:00 [DBG] Executed controller factory for controller CapBot.api.Controllers.TopicController (CapBot.api)
+2025-10-04 02:56:00.963 +07:00 [DBG] Attempting to bind parameter 'topicId' of type 'System.Int32' ...
+2025-10-04 02:56:00.964 +07:00 [DBG] Attempting to bind parameter 'topicId' of type 'System.Int32' using the name 'topicId' in request data ...
+2025-10-04 02:56:00.964 +07:00 [DBG] Done attempting to bind parameter 'topicId' of type 'System.Int32'.
+2025-10-04 02:56:00.965 +07:00 [DBG] Done attempting to bind parameter 'topicId' of type 'System.Int32'.
+2025-10-04 02:56:00.965 +07:00 [DBG] Attempting to validate the bound parameter 'topicId' of type 'System.Int32' ...
+2025-10-04 02:56:00.965 +07:00 [DBG] Done attempting to validate the bound parameter 'topicId' of type 'System.Int32'.
+2025-10-04 02:56:00.969 +07:00 [DBG] Entity Framework Core 8.0.16 initialized 'MyDbContext' using provider 'Microsoft.EntityFrameworkCore.SqlServer:8.0.13' with options: MigrationsAssembly=App.DAL 
+2025-10-04 02:56:00.970 +07:00 [DBG] Creating DbConnection.
+2025-10-04 02:56:00.970 +07:00 [DBG] Created DbConnection. (0ms).
+2025-10-04 02:56:00.970 +07:00 [DBG] Opening connection to database 'capbot_db' on server 'localhost'.
+2025-10-04 02:56:00.971 +07:00 [DBG] Opened connection to database 'capbot_db' on server 'localhost'.
+2025-10-04 02:56:00.971 +07:00 [DBG] Creating DbCommand for 'ExecuteReader'.
+2025-10-04 02:56:00.971 +07:00 [DBG] Created DbCommand for 'ExecuteReader' (0ms).
+2025-10-04 02:56:00.971 +07:00 [DBG] Initialized DbCommand for 'ExecuteReader' (0ms).
+2025-10-04 02:56:00.971 +07:00 [DBG] Executing DbCommand [Parameters=[@__topicId_0='?' (DbType = Int32)], CommandType='"Text"', CommandTimeout='30']
+SELECT [t1].[Id], [t1].[Abbreviation], [t1].[CategoryId], [t1].[Content], [t1].[Context], [t1].[CreatedAt], [t1].[CreatedBy], [t1].[DeletedAt], [t1].[Description], [t1].[EN_Title], [t1].[IsActive], [t1].[IsApproved], [t1].[IsLegacy], [t1].[LastModifiedAt], [t1].[LastModifiedBy], [t1].[MaxStudents], [t1].[Objectives], [t1].[PotentialDuplicate], [t1].[Problem], [t1].[SemesterId], [t1].[SupervisorId], [t1].[VN_title], [t1].[Id0], [t1].[AccessFailedCount], [t1].[ConcurrencyStamp], [t1].[CreatedAt0], [t1].[DeletedAt0], [t1].[Email], [t1].[EmailConfirmed], [t1].[LastModifiedAt0], [t1].[LastModifiedBy0], [t1].[LockoutEnabled], [t1].[LockoutEnd], [t1].[NormalizedEmail], [t1].[NormalizedUserName], [t1].[PasswordHash], [t1].[PhoneNumber], [t1].[PhoneNumberConfirmed], [t1].[SecurityStamp], [t1].[TwoFactorEnabled], [t1].[UserName], [t1].[Id1], [t1].[CreatedAt1], [t1].[CreatedBy0], [t1].[DeletedAt1], [t1].[Description0], [t1].[IsActive0], [t1].[LastModifiedAt1], [t1].[LastModifiedBy1], [t1].[Name], [t1].[Id2], [t1].[CreatedAt2], [t1].[CreatedBy1], [t1].[DeletedAt2], [t1].[Description1], [t1].[EndDate], [t1].[IsActive1], [t1].[LastModifiedAt2], [t1].[LastModifiedBy2], [t1].[Name0], [t1].[StartDate], [t2].[Id], [t2].[Content], [t2].[Context], [t2].[CreatedAt], [t2].[CreatedBy], [t2].[DeletedAt], [t2].[Description], [t2].[DocumentUrl], [t2].[EN_Title], [t2].[ExpectedOutcomes], [t2].[IsActive], [t2].[LastModifiedAt], [t2].[LastModifiedBy], [t2].[Methodology], [t2].[Objectives], [t2].[PotentialDuplicate], [t2].[Problem], [t2].[Requirements], [t2].[Status], [t2].[SubmittedAt], [t2].[SubmittedBy], [t2].[TopicId], [t2].[VN_title], [t2].[VersionNumber]
+FROM (
+    SELECT TOP(1) [t].[Id], [t].[Abbreviation], [t].[CategoryId], [t].[Content], [t].[Context], [t].[CreatedAt], [t].[CreatedBy], [t].[DeletedAt], [t].[Description], [t].[EN_Title], [t].[IsActive], [t].[IsApproved], [t].[IsLegacy], [t].[LastModifiedAt], [t].[LastModifiedBy], [t].[MaxStudents], [t].[Objectives], [t].[PotentialDuplicate], [t].[Problem], [t].[SemesterId], [t].[SupervisorId], [t].[VN_title], [u].[Id] AS [Id0], [u].[AccessFailedCount], [u].[ConcurrencyStamp], [u].[CreatedAt] AS [CreatedAt0], [u].[DeletedAt] AS [DeletedAt0], [u].[Email], [u].[EmailConfirmed], [u].[LastModifiedAt] AS [LastModifiedAt0], [u].[LastModifiedBy] AS [LastModifiedBy0], [u].[LockoutEnabled], [u].[LockoutEnd], [u].[NormalizedEmail], [u].[NormalizedUserName], [u].[PasswordHash], [u].[PhoneNumber], [u].[PhoneNumberConfirmed], [u].[SecurityStamp], [u].[TwoFactorEnabled], [u].[UserName], [t0].[Id] AS [Id1], [t0].[CreatedAt] AS [CreatedAt1], [t0].[CreatedBy] AS [CreatedBy0], [t0].[DeletedAt] AS [DeletedAt1], [t0].[Description] AS [Description0], [t0].[IsActive] AS [IsActive0], [t0].[LastModifiedAt] AS [LastModifiedAt1], [t0].[LastModifiedBy] AS [LastModifiedBy1], [t0].[Name], [s].[Id] AS [Id2], [s].[CreatedAt] AS [CreatedAt2], [s].[CreatedBy] AS [CreatedBy1], [s].[DeletedAt] AS [DeletedAt2], [s].[Description] AS [Description1], [s].[EndDate], [s].[IsActive] AS [IsActive1], [s].[LastModifiedAt] AS [LastModifiedAt2], [s].[LastModifiedBy] AS [LastModifiedBy2], [s].[Name] AS [Name0], [s].[StartDate]
+    FROM [topics] AS [t]
+    INNER JOIN [users] AS [u] ON [t].[SupervisorId] = [u].[Id]
+    LEFT JOIN [topic_categories] AS [t0] ON [t].[CategoryId] = [t0].[Id]
+    INNER JOIN [semesters] AS [s] ON [t].[SemesterId] = [s].[Id]
+    WHERE [t].[Id] = @__topicId_0 AND [t].[IsActive] = CAST(1 AS bit) AND [t].[DeletedAt] IS NULL
+) AS [t1]
+LEFT JOIN [topic_versions] AS [t2] ON [t1].[Id] = [t2].[TopicId]
+ORDER BY [t1].[Id], [t1].[Id0], [t1].[Id1], [t1].[Id2]
+2025-10-04 02:56:01.020 +07:00 [INF] Executed DbCommand (49ms) [Parameters=[@__topicId_0='?' (DbType = Int32)], CommandType='"Text"', CommandTimeout='30']
+SELECT [t1].[Id], [t1].[Abbreviation], [t1].[CategoryId], [t1].[Content], [t1].[Context], [t1].[CreatedAt], [t1].[CreatedBy], [t1].[DeletedAt], [t1].[Description], [t1].[EN_Title], [t1].[IsActive], [t1].[IsApproved], [t1].[IsLegacy], [t1].[LastModifiedAt], [t1].[LastModifiedBy], [t1].[MaxStudents], [t1].[Objectives], [t1].[PotentialDuplicate], [t1].[Problem], [t1].[SemesterId], [t1].[SupervisorId], [t1].[VN_title], [t1].[Id0], [t1].[AccessFailedCount], [t1].[ConcurrencyStamp], [t1].[CreatedAt0], [t1].[DeletedAt0], [t1].[Email], [t1].[EmailConfirmed], [t1].[LastModifiedAt0], [t1].[LastModifiedBy0], [t1].[LockoutEnabled], [t1].[LockoutEnd], [t1].[NormalizedEmail], [t1].[NormalizedUserName], [t1].[PasswordHash], [t1].[PhoneNumber], [t1].[PhoneNumberConfirmed], [t1].[SecurityStamp], [t1].[TwoFactorEnabled], [t1].[UserName], [t1].[Id1], [t1].[CreatedAt1], [t1].[CreatedBy0], [t1].[DeletedAt1], [t1].[Description0], [t1].[IsActive0], [t1].[LastModifiedAt1], [t1].[LastModifiedBy1], [t1].[Name], [t1].[Id2], [t1].[CreatedAt2], [t1].[CreatedBy1], [t1].[DeletedAt2], [t1].[Description1], [t1].[EndDate], [t1].[IsActive1], [t1].[LastModifiedAt2], [t1].[LastModifiedBy2], [t1].[Name0], [t1].[StartDate], [t2].[Id], [t2].[Content], [t2].[Context], [t2].[CreatedAt], [t2].[CreatedBy], [t2].[DeletedAt], [t2].[Description], [t2].[DocumentUrl], [t2].[EN_Title], [t2].[ExpectedOutcomes], [t2].[IsActive], [t2].[LastModifiedAt], [t2].[LastModifiedBy], [t2].[Methodology], [t2].[Objectives], [t2].[PotentialDuplicate], [t2].[Problem], [t2].[Requirements], [t2].[Status], [t2].[SubmittedAt], [t2].[SubmittedBy], [t2].[TopicId], [t2].[VN_title], [t2].[VersionNumber]
+FROM (
+    SELECT TOP(1) [t].[Id], [t].[Abbreviation], [t].[CategoryId], [t].[Content], [t].[Context], [t].[CreatedAt], [t].[CreatedBy], [t].[DeletedAt], [t].[Description], [t].[EN_Title], [t].[IsActive], [t].[IsApproved], [t].[IsLegacy], [t].[LastModifiedAt], [t].[LastModifiedBy], [t].[MaxStudents], [t].[Objectives], [t].[PotentialDuplicate], [t].[Problem], [t].[SemesterId], [t].[SupervisorId], [t].[VN_title], [u].[Id] AS [Id0], [u].[AccessFailedCount], [u].[ConcurrencyStamp], [u].[CreatedAt] AS [CreatedAt0], [u].[DeletedAt] AS [DeletedAt0], [u].[Email], [u].[EmailConfirmed], [u].[LastModifiedAt] AS [LastModifiedAt0], [u].[LastModifiedBy] AS [LastModifiedBy0], [u].[LockoutEnabled], [u].[LockoutEnd], [u].[NormalizedEmail], [u].[NormalizedUserName], [u].[PasswordHash], [u].[PhoneNumber], [u].[PhoneNumberConfirmed], [u].[SecurityStamp], [u].[TwoFactorEnabled], [u].[UserName], [t0].[Id] AS [Id1], [t0].[CreatedAt] AS [CreatedAt1], [t0].[CreatedBy] AS [CreatedBy0], [t0].[DeletedAt] AS [DeletedAt1], [t0].[Description] AS [Description0], [t0].[IsActive] AS [IsActive0], [t0].[LastModifiedAt] AS [LastModifiedAt1], [t0].[LastModifiedBy] AS [LastModifiedBy1], [t0].[Name], [s].[Id] AS [Id2], [s].[CreatedAt] AS [CreatedAt2], [s].[CreatedBy] AS [CreatedBy1], [s].[DeletedAt] AS [DeletedAt2], [s].[Description] AS [Description1], [s].[EndDate], [s].[IsActive] AS [IsActive1], [s].[LastModifiedAt] AS [LastModifiedAt2], [s].[LastModifiedBy] AS [LastModifiedBy2], [s].[Name] AS [Name0], [s].[StartDate]
+    FROM [topics] AS [t]
+    INNER JOIN [users] AS [u] ON [t].[SupervisorId] = [u].[Id]
+    LEFT JOIN [topic_categories] AS [t0] ON [t].[CategoryId] = [t0].[Id]
+    INNER JOIN [semesters] AS [s] ON [t].[SemesterId] = [s].[Id]
+    WHERE [t].[Id] = @__topicId_0 AND [t].[IsActive] = CAST(1 AS bit) AND [t].[DeletedAt] IS NULL
+) AS [t1]
+LEFT JOIN [topic_versions] AS [t2] ON [t1].[Id] = [t2].[TopicId]
+ORDER BY [t1].[Id], [t1].[Id0], [t1].[Id1], [t1].[Id2]
+2025-10-04 02:56:01.021 +07:00 [DBG] Closing data reader to 'capbot_db' on server 'localhost'.
+2025-10-04 02:56:01.021 +07:00 [DBG] A data reader for 'capbot_db' on server 'localhost' is being disposed after spending 0ms reading results.
+2025-10-04 02:56:01.021 +07:00 [DBG] Closing connection to database 'capbot_db' on server 'localhost'.
+2025-10-04 02:56:01.021 +07:00 [DBG] Closed connection to database 'capbot_db' on server 'localhost' (0ms).
+2025-10-04 02:56:01.021 +07:00 [DBG] Opening connection to database 'capbot_db' on server 'localhost'.
+2025-10-04 02:56:01.022 +07:00 [DBG] Opened connection to database 'capbot_db' on server 'localhost'.
+2025-10-04 02:56:01.022 +07:00 [DBG] Creating DbCommand for 'ExecuteReader'.
+2025-10-04 02:56:01.022 +07:00 [DBG] Created DbCommand for 'ExecuteReader' (0ms).
+2025-10-04 02:56:01.022 +07:00 [DBG] Initialized DbCommand for 'ExecuteReader' (0ms).
+2025-10-04 02:56:01.022 +07:00 [DBG] Executing DbCommand [Parameters=[@__topicId_0='?' (DbType = Int32)], CommandType='"Text"', CommandTimeout='30']
+SELECT [s].[Id], [s].[AdditionalNotes], [s].[AiCheckDetails], [s].[AiCheckScore], [s].[AiCheckStatus], [s].[CreatedAt], [s].[CreatedBy], [s].[DeletedAt], [s].[DocumentUrl], [s].[IsActive], [s].[LastModifiedAt], [s].[LastModifiedBy], [s].[PhaseId], [s].[Status], [s].[SubmissionRound], [s].[SubmittedAt], [s].[SubmittedBy], [s].[TopicId], [s].[TopicVersionId], [p].[Id], [p].[CreatedAt], [p].[CreatedBy], [p].[DeletedAt], [p].[EndDate], [p].[IsActive], [p].[LastModifiedAt], [p].[LastModifiedBy], [p].[Name], [p].[PhaseTypeId], [p].[SemesterId], [p].[StartDate], [p].[SubmissionDeadline], [u].[Id], [u].[AccessFailedCount], [u].[ConcurrencyStamp], [u].[CreatedAt], [u].[DeletedAt], [u].[Email], [u].[EmailConfirmed], [u].[LastModifiedAt], [u].[LastModifiedBy], [u].[LockoutEnabled], [u].[LockoutEnd], [u].[NormalizedEmail], [u].[NormalizedUserName], [u].[PasswordHash], [u].[PhoneNumber], [u].[PhoneNumberConfirmed], [u].[SecurityStamp], [u].[TwoFactorEnabled], [u].[UserName], [r].[Id], [r].[AssignedAt], [r].[AssignedBy], [r].[AssignmentType], [r].[CompletedAt], [r].[Deadline], [r].[ReviewerId], [r].[SkillMatchScore], [r].[StartedAt], [r].[Status], [r].[SubmissionId]
+FROM [submissions] AS [s]
+INNER JOIN [phases] AS [p] ON [s].[PhaseId] = [p].[Id]
+INNER JOIN [users] AS [u] ON [s].[SubmittedBy] = [u].[Id]
+LEFT JOIN [reviewer_assignments] AS [r] ON [s].[Id] = [r].[SubmissionId]
+WHERE [s].[TopicId] = @__topicId_0 AND [s].[IsActive] = CAST(1 AS bit) AND [s].[DeletedAt] IS NULL
+ORDER BY [s].[Id], [p].[Id], [u].[Id]
+2025-10-04 02:56:01.042 +07:00 [INF] Executed DbCommand (20ms) [Parameters=[@__topicId_0='?' (DbType = Int32)], CommandType='"Text"', CommandTimeout='30']
+SELECT [s].[Id], [s].[AdditionalNotes], [s].[AiCheckDetails], [s].[AiCheckScore], [s].[AiCheckStatus], [s].[CreatedAt], [s].[CreatedBy], [s].[DeletedAt], [s].[DocumentUrl], [s].[IsActive], [s].[LastModifiedAt], [s].[LastModifiedBy], [s].[PhaseId], [s].[Status], [s].[SubmissionRound], [s].[SubmittedAt], [s].[SubmittedBy], [s].[TopicId], [s].[TopicVersionId], [p].[Id], [p].[CreatedAt], [p].[CreatedBy], [p].[DeletedAt], [p].[EndDate], [p].[IsActive], [p].[LastModifiedAt], [p].[LastModifiedBy], [p].[Name], [p].[PhaseTypeId], [p].[SemesterId], [p].[StartDate], [p].[SubmissionDeadline], [u].[Id], [u].[AccessFailedCount], [u].[ConcurrencyStamp], [u].[CreatedAt], [u].[DeletedAt], [u].[Email], [u].[EmailConfirmed], [u].[LastModifiedAt], [u].[LastModifiedBy], [u].[LockoutEnabled], [u].[LockoutEnd], [u].[NormalizedEmail], [u].[NormalizedUserName], [u].[PasswordHash], [u].[PhoneNumber], [u].[PhoneNumberConfirmed], [u].[SecurityStamp], [u].[TwoFactorEnabled], [u].[UserName], [r].[Id], [r].[AssignedAt], [r].[AssignedBy], [r].[AssignmentType], [r].[CompletedAt], [r].[Deadline], [r].[ReviewerId], [r].[SkillMatchScore], [r].[StartedAt], [r].[Status], [r].[SubmissionId]
+FROM [submissions] AS [s]
+INNER JOIN [phases] AS [p] ON [s].[PhaseId] = [p].[Id]
+INNER JOIN [users] AS [u] ON [s].[SubmittedBy] = [u].[Id]
+LEFT JOIN [reviewer_assignments] AS [r] ON [s].[Id] = [r].[SubmissionId]
+WHERE [s].[TopicId] = @__topicId_0 AND [s].[IsActive] = CAST(1 AS bit) AND [s].[DeletedAt] IS NULL
+ORDER BY [s].[Id], [p].[Id], [u].[Id]
+2025-10-04 02:56:01.043 +07:00 [DBG] Closing data reader to 'capbot_db' on server 'localhost'.
+2025-10-04 02:56:01.044 +07:00 [DBG] A data reader for 'capbot_db' on server 'localhost' is being disposed after spending 0ms reading results.
+2025-10-04 02:56:01.044 +07:00 [DBG] Closing connection to database 'capbot_db' on server 'localhost'.
+2025-10-04 02:56:01.044 +07:00 [DBG] Closed connection to database 'capbot_db' on server 'localhost' (0ms).
+2025-10-04 02:56:01.045 +07:00 [DBG] Opening connection to database 'capbot_db' on server 'localhost'.
+2025-10-04 02:56:01.045 +07:00 [DBG] Opened connection to database 'capbot_db' on server 'localhost'.
+2025-10-04 02:56:01.046 +07:00 [DBG] Creating DbCommand for 'ExecuteReader'.
+2025-10-04 02:56:01.046 +07:00 [DBG] Created DbCommand for 'ExecuteReader' (0ms).
+2025-10-04 02:56:01.046 +07:00 [DBG] Initialized DbCommand for 'ExecuteReader' (0ms).
+2025-10-04 02:56:01.046 +07:00 [DBG] Executing DbCommand [Parameters=[@__p_0='?' (DbType = Int64)], CommandType='"Text"', CommandTimeout='30']
+SELECT TOP(1) [e].[Id], [e].[Caption], [e].[CreatedAt], [e].[EntityId], [e].[EntityType], [e].[FileId], [e].[IsPrimary], [f].[Id], [f].[Alt], [f].[Checksum], [f].[CreatedAt], [f].[CreatedBy], [f].[DeletedAt], [f].[FileName], [f].[FilePath], [f].[FileSize], [f].[FileType], [f].[Height], [f].[IsActive], [f].[LastModifiedAt], [f].[LastModifiedBy], [f].[MimeType], [f].[ThumbnailUrl], [f].[Url], [f].[Width]
+FROM [entity_files] AS [e]
+INNER JOIN [files] AS [f] ON [e].[FileId] = [f].[Id]
+WHERE [e].[EntityId] = @__p_0 AND [e].[EntityType] = 1 AND [e].[IsPrimary] = CAST(1 AS bit)
+2025-10-04 02:56:01.058 +07:00 [INF] Executed DbCommand (12ms) [Parameters=[@__p_0='?' (DbType = Int64)], CommandType='"Text"', CommandTimeout='30']
+SELECT TOP(1) [e].[Id], [e].[Caption], [e].[CreatedAt], [e].[EntityId], [e].[EntityType], [e].[FileId], [e].[IsPrimary], [f].[Id], [f].[Alt], [f].[Checksum], [f].[CreatedAt], [f].[CreatedBy], [f].[DeletedAt], [f].[FileName], [f].[FilePath], [f].[FileSize], [f].[FileType], [f].[Height], [f].[IsActive], [f].[LastModifiedAt], [f].[LastModifiedBy], [f].[MimeType], [f].[ThumbnailUrl], [f].[Url], [f].[Width]
+FROM [entity_files] AS [e]
+INNER JOIN [files] AS [f] ON [e].[FileId] = [f].[Id]
+WHERE [e].[EntityId] = @__p_0 AND [e].[EntityType] = 1 AND [e].[IsPrimary] = CAST(1 AS bit)
+2025-10-04 02:56:01.058 +07:00 [DBG] Closing data reader to 'capbot_db' on server 'localhost'.
+2025-10-04 02:56:01.065 +07:00 [DBG] A data reader for 'capbot_db' on server 'localhost' is being disposed after spending 6ms reading results.
+2025-10-04 02:56:01.065 +07:00 [DBG] Closing connection to database 'capbot_db' on server 'localhost'.
+2025-10-04 02:56:01.066 +07:00 [DBG] Closed connection to database 'capbot_db' on server 'localhost' (0ms).
+2025-10-04 02:56:01.066 +07:00 [DBG] List of registered output formatters, in the following order: ["Microsoft.AspNetCore.OData.Formatter.ODataOutputFormatter","Microsoft.AspNetCore.OData.Formatter.ODataOutputFormatter","Microsoft.AspNetCore.OData.Formatter.ODataOutputFormatter","Microsoft.AspNetCore.Mvc.Formatters.HttpNoContentOutputFormatter","Microsoft.AspNetCore.Mvc.Formatters.StringOutputFormatter","Microsoft.AspNetCore.Mvc.Formatters.StreamOutputFormatter","Microsoft.AspNetCore.Mvc.Formatters.SystemTextJsonOutputFormatter"]
+2025-10-04 02:56:01.066 +07:00 [DBG] No information found on request to perform content negotiation.
+2025-10-04 02:56:01.066 +07:00 [DBG] Attempting to select the first output formatter in the output formatters list which supports a content type from the explicitly specified content types '["application/json"]'.
+2025-10-04 02:56:01.066 +07:00 [DBG] Selected output formatter 'Microsoft.AspNetCore.Mvc.Formatters.SystemTextJsonOutputFormatter' and content type 'application/json' to write the response.
+2025-10-04 02:56:01.067 +07:00 [INF] Executing ObjectResult, writing value of type 'FS.Commons.FSResponse'.
+2025-10-04 02:56:01.067 +07:00 [INF] Executed action CapBot.api.Controllers.TopicController.GetDetail (CapBot.api) in 106.3127ms
+2025-10-04 02:56:01.067 +07:00 [INF] Executed endpoint 'CapBot.api.Controllers.TopicController.GetDetail (CapBot.api)'
+2025-10-04 02:56:01.068 +07:00 [DBG] Connection id "0HNG2MQC634J9" completed keep alive response.
+2025-10-04 02:56:01.068 +07:00 [DBG] 'MyDbContext' disposed.
+2025-10-04 02:56:01.068 +07:00 [DBG] Disposing connection to database 'capbot_db' on server 'localhost'.
+2025-10-04 02:56:01.068 +07:00 [DBG] Disposed connection to database '' on server '' (0ms).
+2025-10-04 02:56:01.068 +07:00 [INF] Request finished HTTP/1.1 GET http://localhost:5207/api/topic/detail/104 - 200 null application/json; charset=utf-8 111.9253ms
+2025-10-04 02:56:01.658 +07:00 [INF] Request starting HTTP/1.1 GET http://localhost:5207/api/topic/detail/104 - null null
+2025-10-04 02:56:01.660 +07:00 [DBG] The request path /api/topic/detail/104 does not match a supported file type
+2025-10-04 02:56:01.660 +07:00 [DBG] The request path /api/topic/detail/104 does not match a supported file type
+2025-10-04 02:56:01.660 +07:00 [DBG] 1 candidate(s) found for the request path '/api/topic/detail/104'
+2025-10-04 02:56:01.660 +07:00 [DBG] Endpoint 'CapBot.api.Controllers.TopicController.GetDetail (CapBot.api)' with route pattern 'api/topic/detail/{topicId}' is valid for the request path '/api/topic/detail/104'
+2025-10-04 02:56:01.661 +07:00 [DBG] Request matched endpoint 'CapBot.api.Controllers.TopicController.GetDetail (CapBot.api)'
+2025-10-04 02:56:01.661 +07:00 [DBG] Successfully validated the token.
+2025-10-04 02:56:01.661 +07:00 [DBG] AuthenticationScheme: Bearer was successfully authenticated.
+2025-10-04 02:56:01.662 +07:00 [INF] Executing endpoint 'CapBot.api.Controllers.TopicController.GetDetail (CapBot.api)'
+2025-10-04 02:56:01.662 +07:00 [INF] Route matched with {action = "GetDetail", controller = "Topic"}. Executing controller action with signature System.Threading.Tasks.Task`1[Microsoft.AspNetCore.Mvc.IActionResult] GetDetail(Int32) on controller CapBot.api.Controllers.TopicController (CapBot.api).
+2025-10-04 02:56:01.662 +07:00 [DBG] Execution plan of authorization filters (in the following order): ["None"]
+2025-10-04 02:56:01.662 +07:00 [DBG] Execution plan of resource filters (in the following order): ["Microsoft.AspNetCore.Mvc.ConsumesAttribute"]
+2025-10-04 02:56:01.662 +07:00 [DBG] Execution plan of action filters (in the following order): ["Microsoft.AspNetCore.Mvc.ModelBinding.UnsupportedContentTypeFilter (Order: -3000)"]
+2025-10-04 02:56:01.662 +07:00 [DBG] Execution plan of exception filters (in the following order): ["None"]
+2025-10-04 02:56:01.663 +07:00 [DBG] Execution plan of result filters (in the following order): ["Microsoft.AspNetCore.Mvc.Infrastructure.ClientErrorResultFilter (Order: -2000)","Microsoft.AspNetCore.Mvc.ProducesAttribute (Order: 0)"]
+2025-10-04 02:56:01.663 +07:00 [DBG] Executing controller factory for controller CapBot.api.Controllers.TopicController (CapBot.api)
+2025-10-04 02:56:01.663 +07:00 [DBG] Executed controller factory for controller CapBot.api.Controllers.TopicController (CapBot.api)
+2025-10-04 02:56:01.663 +07:00 [DBG] Attempting to bind parameter 'topicId' of type 'System.Int32' ...
+2025-10-04 02:56:01.664 +07:00 [DBG] Attempting to bind parameter 'topicId' of type 'System.Int32' using the name 'topicId' in request data ...
+2025-10-04 02:56:01.664 +07:00 [DBG] Done attempting to bind parameter 'topicId' of type 'System.Int32'.
+2025-10-04 02:56:01.664 +07:00 [DBG] Done attempting to bind parameter 'topicId' of type 'System.Int32'.
+2025-10-04 02:56:01.664 +07:00 [DBG] Attempting to validate the bound parameter 'topicId' of type 'System.Int32' ...
+2025-10-04 02:56:01.664 +07:00 [DBG] Done attempting to validate the bound parameter 'topicId' of type 'System.Int32'.
+2025-10-04 02:56:01.665 +07:00 [DBG] Entity Framework Core 8.0.16 initialized 'MyDbContext' using provider 'Microsoft.EntityFrameworkCore.SqlServer:8.0.13' with options: MigrationsAssembly=App.DAL 
+2025-10-04 02:56:01.667 +07:00 [DBG] Creating DbConnection.
+2025-10-04 02:56:01.668 +07:00 [DBG] Created DbConnection. (0ms).
+2025-10-04 02:56:01.668 +07:00 [DBG] Opening connection to database 'capbot_db' on server 'localhost'.
+2025-10-04 02:56:01.668 +07:00 [DBG] Opened connection to database 'capbot_db' on server 'localhost'.
+2025-10-04 02:56:01.668 +07:00 [DBG] Creating DbCommand for 'ExecuteReader'.
+2025-10-04 02:56:01.668 +07:00 [DBG] Created DbCommand for 'ExecuteReader' (0ms).
+2025-10-04 02:56:01.668 +07:00 [DBG] Initialized DbCommand for 'ExecuteReader' (0ms).
+2025-10-04 02:56:01.668 +07:00 [DBG] Executing DbCommand [Parameters=[@__topicId_0='?' (DbType = Int32)], CommandType='"Text"', CommandTimeout='30']
+SELECT [t1].[Id], [t1].[Abbreviation], [t1].[CategoryId], [t1].[Content], [t1].[Context], [t1].[CreatedAt], [t1].[CreatedBy], [t1].[DeletedAt], [t1].[Description], [t1].[EN_Title], [t1].[IsActive], [t1].[IsApproved], [t1].[IsLegacy], [t1].[LastModifiedAt], [t1].[LastModifiedBy], [t1].[MaxStudents], [t1].[Objectives], [t1].[PotentialDuplicate], [t1].[Problem], [t1].[SemesterId], [t1].[SupervisorId], [t1].[VN_title], [t1].[Id0], [t1].[AccessFailedCount], [t1].[ConcurrencyStamp], [t1].[CreatedAt0], [t1].[DeletedAt0], [t1].[Email], [t1].[EmailConfirmed], [t1].[LastModifiedAt0], [t1].[LastModifiedBy0], [t1].[LockoutEnabled], [t1].[LockoutEnd], [t1].[NormalizedEmail], [t1].[NormalizedUserName], [t1].[PasswordHash], [t1].[PhoneNumber], [t1].[PhoneNumberConfirmed], [t1].[SecurityStamp], [t1].[TwoFactorEnabled], [t1].[UserName], [t1].[Id1], [t1].[CreatedAt1], [t1].[CreatedBy0], [t1].[DeletedAt1], [t1].[Description0], [t1].[IsActive0], [t1].[LastModifiedAt1], [t1].[LastModifiedBy1], [t1].[Name], [t1].[Id2], [t1].[CreatedAt2], [t1].[CreatedBy1], [t1].[DeletedAt2], [t1].[Description1], [t1].[EndDate], [t1].[IsActive1], [t1].[LastModifiedAt2], [t1].[LastModifiedBy2], [t1].[Name0], [t1].[StartDate], [t2].[Id], [t2].[Content], [t2].[Context], [t2].[CreatedAt], [t2].[CreatedBy], [t2].[DeletedAt], [t2].[Description], [t2].[DocumentUrl], [t2].[EN_Title], [t2].[ExpectedOutcomes], [t2].[IsActive], [t2].[LastModifiedAt], [t2].[LastModifiedBy], [t2].[Methodology], [t2].[Objectives], [t2].[PotentialDuplicate], [t2].[Problem], [t2].[Requirements], [t2].[Status], [t2].[SubmittedAt], [t2].[SubmittedBy], [t2].[TopicId], [t2].[VN_title], [t2].[VersionNumber]
+FROM (
+    SELECT TOP(1) [t].[Id], [t].[Abbreviation], [t].[CategoryId], [t].[Content], [t].[Context], [t].[CreatedAt], [t].[CreatedBy], [t].[DeletedAt], [t].[Description], [t].[EN_Title], [t].[IsActive], [t].[IsApproved], [t].[IsLegacy], [t].[LastModifiedAt], [t].[LastModifiedBy], [t].[MaxStudents], [t].[Objectives], [t].[PotentialDuplicate], [t].[Problem], [t].[SemesterId], [t].[SupervisorId], [t].[VN_title], [u].[Id] AS [Id0], [u].[AccessFailedCount], [u].[ConcurrencyStamp], [u].[CreatedAt] AS [CreatedAt0], [u].[DeletedAt] AS [DeletedAt0], [u].[Email], [u].[EmailConfirmed], [u].[LastModifiedAt] AS [LastModifiedAt0], [u].[LastModifiedBy] AS [LastModifiedBy0], [u].[LockoutEnabled], [u].[LockoutEnd], [u].[NormalizedEmail], [u].[NormalizedUserName], [u].[PasswordHash], [u].[PhoneNumber], [u].[PhoneNumberConfirmed], [u].[SecurityStamp], [u].[TwoFactorEnabled], [u].[UserName], [t0].[Id] AS [Id1], [t0].[CreatedAt] AS [CreatedAt1], [t0].[CreatedBy] AS [CreatedBy0], [t0].[DeletedAt] AS [DeletedAt1], [t0].[Description] AS [Description0], [t0].[IsActive] AS [IsActive0], [t0].[LastModifiedAt] AS [LastModifiedAt1], [t0].[LastModifiedBy] AS [LastModifiedBy1], [t0].[Name], [s].[Id] AS [Id2], [s].[CreatedAt] AS [CreatedAt2], [s].[CreatedBy] AS [CreatedBy1], [s].[DeletedAt] AS [DeletedAt2], [s].[Description] AS [Description1], [s].[EndDate], [s].[IsActive] AS [IsActive1], [s].[LastModifiedAt] AS [LastModifiedAt2], [s].[LastModifiedBy] AS [LastModifiedBy2], [s].[Name] AS [Name0], [s].[StartDate]
+    FROM [topics] AS [t]
+    INNER JOIN [users] AS [u] ON [t].[SupervisorId] = [u].[Id]
+    LEFT JOIN [topic_categories] AS [t0] ON [t].[CategoryId] = [t0].[Id]
+    INNER JOIN [semesters] AS [s] ON [t].[SemesterId] = [s].[Id]
+    WHERE [t].[Id] = @__topicId_0 AND [t].[IsActive] = CAST(1 AS bit) AND [t].[DeletedAt] IS NULL
+) AS [t1]
+LEFT JOIN [topic_versions] AS [t2] ON [t1].[Id] = [t2].[TopicId]
+ORDER BY [t1].[Id], [t1].[Id0], [t1].[Id1], [t1].[Id2]
+2025-10-04 02:56:01.687 +07:00 [INF] Executed DbCommand (18ms) [Parameters=[@__topicId_0='?' (DbType = Int32)], CommandType='"Text"', CommandTimeout='30']
+SELECT [t1].[Id], [t1].[Abbreviation], [t1].[CategoryId], [t1].[Content], [t1].[Context], [t1].[CreatedAt], [t1].[CreatedBy], [t1].[DeletedAt], [t1].[Description], [t1].[EN_Title], [t1].[IsActive], [t1].[IsApproved], [t1].[IsLegacy], [t1].[LastModifiedAt], [t1].[LastModifiedBy], [t1].[MaxStudents], [t1].[Objectives], [t1].[PotentialDuplicate], [t1].[Problem], [t1].[SemesterId], [t1].[SupervisorId], [t1].[VN_title], [t1].[Id0], [t1].[AccessFailedCount], [t1].[ConcurrencyStamp], [t1].[CreatedAt0], [t1].[DeletedAt0], [t1].[Email], [t1].[EmailConfirmed], [t1].[LastModifiedAt0], [t1].[LastModifiedBy0], [t1].[LockoutEnabled], [t1].[LockoutEnd], [t1].[NormalizedEmail], [t1].[NormalizedUserName], [t1].[PasswordHash], [t1].[PhoneNumber], [t1].[PhoneNumberConfirmed], [t1].[SecurityStamp], [t1].[TwoFactorEnabled], [t1].[UserName], [t1].[Id1], [t1].[CreatedAt1], [t1].[CreatedBy0], [t1].[DeletedAt1], [t1].[Description0], [t1].[IsActive0], [t1].[LastModifiedAt1], [t1].[LastModifiedBy1], [t1].[Name], [t1].[Id2], [t1].[CreatedAt2], [t1].[CreatedBy1], [t1].[DeletedAt2], [t1].[Description1], [t1].[EndDate], [t1].[IsActive1], [t1].[LastModifiedAt2], [t1].[LastModifiedBy2], [t1].[Name0], [t1].[StartDate], [t2].[Id], [t2].[Content], [t2].[Context], [t2].[CreatedAt], [t2].[CreatedBy], [t2].[DeletedAt], [t2].[Description], [t2].[DocumentUrl], [t2].[EN_Title], [t2].[ExpectedOutcomes], [t2].[IsActive], [t2].[LastModifiedAt], [t2].[LastModifiedBy], [t2].[Methodology], [t2].[Objectives], [t2].[PotentialDuplicate], [t2].[Problem], [t2].[Requirements], [t2].[Status], [t2].[SubmittedAt], [t2].[SubmittedBy], [t2].[TopicId], [t2].[VN_title], [t2].[VersionNumber]
+FROM (
+    SELECT TOP(1) [t].[Id], [t].[Abbreviation], [t].[CategoryId], [t].[Content], [t].[Context], [t].[CreatedAt], [t].[CreatedBy], [t].[DeletedAt], [t].[Description], [t].[EN_Title], [t].[IsActive], [t].[IsApproved], [t].[IsLegacy], [t].[LastModifiedAt], [t].[LastModifiedBy], [t].[MaxStudents], [t].[Objectives], [t].[PotentialDuplicate], [t].[Problem], [t].[SemesterId], [t].[SupervisorId], [t].[VN_title], [u].[Id] AS [Id0], [u].[AccessFailedCount], [u].[ConcurrencyStamp], [u].[CreatedAt] AS [CreatedAt0], [u].[DeletedAt] AS [DeletedAt0], [u].[Email], [u].[EmailConfirmed], [u].[LastModifiedAt] AS [LastModifiedAt0], [u].[LastModifiedBy] AS [LastModifiedBy0], [u].[LockoutEnabled], [u].[LockoutEnd], [u].[NormalizedEmail], [u].[NormalizedUserName], [u].[PasswordHash], [u].[PhoneNumber], [u].[PhoneNumberConfirmed], [u].[SecurityStamp], [u].[TwoFactorEnabled], [u].[UserName], [t0].[Id] AS [Id1], [t0].[CreatedAt] AS [CreatedAt1], [t0].[CreatedBy] AS [CreatedBy0], [t0].[DeletedAt] AS [DeletedAt1], [t0].[Description] AS [Description0], [t0].[IsActive] AS [IsActive0], [t0].[LastModifiedAt] AS [LastModifiedAt1], [t0].[LastModifiedBy] AS [LastModifiedBy1], [t0].[Name], [s].[Id] AS [Id2], [s].[CreatedAt] AS [CreatedAt2], [s].[CreatedBy] AS [CreatedBy1], [s].[DeletedAt] AS [DeletedAt2], [s].[Description] AS [Description1], [s].[EndDate], [s].[IsActive] AS [IsActive1], [s].[LastModifiedAt] AS [LastModifiedAt2], [s].[LastModifiedBy] AS [LastModifiedBy2], [s].[Name] AS [Name0], [s].[StartDate]
+    FROM [topics] AS [t]
+    INNER JOIN [users] AS [u] ON [t].[SupervisorId] = [u].[Id]
+    LEFT JOIN [topic_categories] AS [t0] ON [t].[CategoryId] = [t0].[Id]
+    INNER JOIN [semesters] AS [s] ON [t].[SemesterId] = [s].[Id]
+    WHERE [t].[Id] = @__topicId_0 AND [t].[IsActive] = CAST(1 AS bit) AND [t].[DeletedAt] IS NULL
+) AS [t1]
+LEFT JOIN [topic_versions] AS [t2] ON [t1].[Id] = [t2].[TopicId]
+ORDER BY [t1].[Id], [t1].[Id0], [t1].[Id1], [t1].[Id2]
+2025-10-04 02:56:01.689 +07:00 [DBG] Closing data reader to 'capbot_db' on server 'localhost'.
+2025-10-04 02:56:01.689 +07:00 [DBG] A data reader for 'capbot_db' on server 'localhost' is being disposed after spending 1ms reading results.
+2025-10-04 02:56:01.689 +07:00 [DBG] Closing connection to database 'capbot_db' on server 'localhost'.
+2025-10-04 02:56:01.690 +07:00 [DBG] Closed connection to database 'capbot_db' on server 'localhost' (0ms).
+2025-10-04 02:56:01.690 +07:00 [DBG] Opening connection to database 'capbot_db' on server 'localhost'.
+2025-10-04 02:56:01.691 +07:00 [DBG] Opened connection to database 'capbot_db' on server 'localhost'.
+2025-10-04 02:56:01.691 +07:00 [DBG] Creating DbCommand for 'ExecuteReader'.
+2025-10-04 02:56:01.691 +07:00 [DBG] Created DbCommand for 'ExecuteReader' (0ms).
+2025-10-04 02:56:01.691 +07:00 [DBG] Initialized DbCommand for 'ExecuteReader' (0ms).
+2025-10-04 02:56:01.691 +07:00 [DBG] Executing DbCommand [Parameters=[@__topicId_0='?' (DbType = Int32)], CommandType='"Text"', CommandTimeout='30']
+SELECT [s].[Id], [s].[AdditionalNotes], [s].[AiCheckDetails], [s].[AiCheckScore], [s].[AiCheckStatus], [s].[CreatedAt], [s].[CreatedBy], [s].[DeletedAt], [s].[DocumentUrl], [s].[IsActive], [s].[LastModifiedAt], [s].[LastModifiedBy], [s].[PhaseId], [s].[Status], [s].[SubmissionRound], [s].[SubmittedAt], [s].[SubmittedBy], [s].[TopicId], [s].[TopicVersionId], [p].[Id], [p].[CreatedAt], [p].[CreatedBy], [p].[DeletedAt], [p].[EndDate], [p].[IsActive], [p].[LastModifiedAt], [p].[LastModifiedBy], [p].[Name], [p].[PhaseTypeId], [p].[SemesterId], [p].[StartDate], [p].[SubmissionDeadline], [u].[Id], [u].[AccessFailedCount], [u].[ConcurrencyStamp], [u].[CreatedAt], [u].[DeletedAt], [u].[Email], [u].[EmailConfirmed], [u].[LastModifiedAt], [u].[LastModifiedBy], [u].[LockoutEnabled], [u].[LockoutEnd], [u].[NormalizedEmail], [u].[NormalizedUserName], [u].[PasswordHash], [u].[PhoneNumber], [u].[PhoneNumberConfirmed], [u].[SecurityStamp], [u].[TwoFactorEnabled], [u].[UserName], [r].[Id], [r].[AssignedAt], [r].[AssignedBy], [r].[AssignmentType], [r].[CompletedAt], [r].[Deadline], [r].[ReviewerId], [r].[SkillMatchScore], [r].[StartedAt], [r].[Status], [r].[SubmissionId]
+FROM [submissions] AS [s]
+INNER JOIN [phases] AS [p] ON [s].[PhaseId] = [p].[Id]
+INNER JOIN [users] AS [u] ON [s].[SubmittedBy] = [u].[Id]
+LEFT JOIN [reviewer_assignments] AS [r] ON [s].[Id] = [r].[SubmissionId]
+WHERE [s].[TopicId] = @__topicId_0 AND [s].[IsActive] = CAST(1 AS bit) AND [s].[DeletedAt] IS NULL
+ORDER BY [s].[Id], [p].[Id], [u].[Id]
+2025-10-04 02:56:01.709 +07:00 [INF] Executed DbCommand (18ms) [Parameters=[@__topicId_0='?' (DbType = Int32)], CommandType='"Text"', CommandTimeout='30']
+SELECT [s].[Id], [s].[AdditionalNotes], [s].[AiCheckDetails], [s].[AiCheckScore], [s].[AiCheckStatus], [s].[CreatedAt], [s].[CreatedBy], [s].[DeletedAt], [s].[DocumentUrl], [s].[IsActive], [s].[LastModifiedAt], [s].[LastModifiedBy], [s].[PhaseId], [s].[Status], [s].[SubmissionRound], [s].[SubmittedAt], [s].[SubmittedBy], [s].[TopicId], [s].[TopicVersionId], [p].[Id], [p].[CreatedAt], [p].[CreatedBy], [p].[DeletedAt], [p].[EndDate], [p].[IsActive], [p].[LastModifiedAt], [p].[LastModifiedBy], [p].[Name], [p].[PhaseTypeId], [p].[SemesterId], [p].[StartDate], [p].[SubmissionDeadline], [u].[Id], [u].[AccessFailedCount], [u].[ConcurrencyStamp], [u].[CreatedAt], [u].[DeletedAt], [u].[Email], [u].[EmailConfirmed], [u].[LastModifiedAt], [u].[LastModifiedBy], [u].[LockoutEnabled], [u].[LockoutEnd], [u].[NormalizedEmail], [u].[NormalizedUserName], [u].[PasswordHash], [u].[PhoneNumber], [u].[PhoneNumberConfirmed], [u].[SecurityStamp], [u].[TwoFactorEnabled], [u].[UserName], [r].[Id], [r].[AssignedAt], [r].[AssignedBy], [r].[AssignmentType], [r].[CompletedAt], [r].[Deadline], [r].[ReviewerId], [r].[SkillMatchScore], [r].[StartedAt], [r].[Status], [r].[SubmissionId]
+FROM [submissions] AS [s]
+INNER JOIN [phases] AS [p] ON [s].[PhaseId] = [p].[Id]
+INNER JOIN [users] AS [u] ON [s].[SubmittedBy] = [u].[Id]
+LEFT JOIN [reviewer_assignments] AS [r] ON [s].[Id] = [r].[SubmissionId]
+WHERE [s].[TopicId] = @__topicId_0 AND [s].[IsActive] = CAST(1 AS bit) AND [s].[DeletedAt] IS NULL
+ORDER BY [s].[Id], [p].[Id], [u].[Id]
+2025-10-04 02:56:01.710 +07:00 [DBG] Closing data reader to 'capbot_db' on server 'localhost'.
+2025-10-04 02:56:01.710 +07:00 [DBG] A data reader for 'capbot_db' on server 'localhost' is being disposed after spending 0ms reading results.
+2025-10-04 02:56:01.710 +07:00 [DBG] Closing connection to database 'capbot_db' on server 'localhost'.
+2025-10-04 02:56:01.711 +07:00 [DBG] Closed connection to database 'capbot_db' on server 'localhost' (0ms).
+2025-10-04 02:56:01.713 +07:00 [DBG] Opening connection to database 'capbot_db' on server 'localhost'.
+2025-10-04 02:56:01.713 +07:00 [DBG] Opened connection to database 'capbot_db' on server 'localhost'.
+2025-10-04 02:56:01.713 +07:00 [DBG] Creating DbCommand for 'ExecuteReader'.
+2025-10-04 02:56:01.713 +07:00 [DBG] Created DbCommand for 'ExecuteReader' (0ms).
+2025-10-04 02:56:01.713 +07:00 [DBG] Initialized DbCommand for 'ExecuteReader' (0ms).
+2025-10-04 02:56:01.713 +07:00 [DBG] Executing DbCommand [Parameters=[@__p_0='?' (DbType = Int64)], CommandType='"Text"', CommandTimeout='30']
+SELECT TOP(1) [e].[Id], [e].[Caption], [e].[CreatedAt], [e].[EntityId], [e].[EntityType], [e].[FileId], [e].[IsPrimary], [f].[Id], [f].[Alt], [f].[Checksum], [f].[CreatedAt], [f].[CreatedBy], [f].[DeletedAt], [f].[FileName], [f].[FilePath], [f].[FileSize], [f].[FileType], [f].[Height], [f].[IsActive], [f].[LastModifiedAt], [f].[LastModifiedBy], [f].[MimeType], [f].[ThumbnailUrl], [f].[Url], [f].[Width]
+FROM [entity_files] AS [e]
+INNER JOIN [files] AS [f] ON [e].[FileId] = [f].[Id]
+WHERE [e].[EntityId] = @__p_0 AND [e].[EntityType] = 1 AND [e].[IsPrimary] = CAST(1 AS bit)
+2025-10-04 02:56:01.714 +07:00 [INF] Executed DbCommand (1ms) [Parameters=[@__p_0='?' (DbType = Int64)], CommandType='"Text"', CommandTimeout='30']
+SELECT TOP(1) [e].[Id], [e].[Caption], [e].[CreatedAt], [e].[EntityId], [e].[EntityType], [e].[FileId], [e].[IsPrimary], [f].[Id], [f].[Alt], [f].[Checksum], [f].[CreatedAt], [f].[CreatedBy], [f].[DeletedAt], [f].[FileName], [f].[FilePath], [f].[FileSize], [f].[FileType], [f].[Height], [f].[IsActive], [f].[LastModifiedAt], [f].[LastModifiedBy], [f].[MimeType], [f].[ThumbnailUrl], [f].[Url], [f].[Width]
+FROM [entity_files] AS [e]
+INNER JOIN [files] AS [f] ON [e].[FileId] = [f].[Id]
+WHERE [e].[EntityId] = @__p_0 AND [e].[EntityType] = 1 AND [e].[IsPrimary] = CAST(1 AS bit)
+2025-10-04 02:56:01.715 +07:00 [DBG] Closing data reader to 'capbot_db' on server 'localhost'.
+2025-10-04 02:56:01.715 +07:00 [DBG] A data reader for 'capbot_db' on server 'localhost' is being disposed after spending 0ms reading results.
+2025-10-04 02:56:01.715 +07:00 [DBG] Closing connection to database 'capbot_db' on server 'localhost'.
+2025-10-04 02:56:01.715 +07:00 [DBG] Closed connection to database 'capbot_db' on server 'localhost' (0ms).
+2025-10-04 02:56:01.715 +07:00 [DBG] List of registered output formatters, in the following order: ["Microsoft.AspNetCore.OData.Formatter.ODataOutputFormatter","Microsoft.AspNetCore.OData.Formatter.ODataOutputFormatter","Microsoft.AspNetCore.OData.Formatter.ODataOutputFormatter","Microsoft.AspNetCore.Mvc.Formatters.HttpNoContentOutputFormatter","Microsoft.AspNetCore.Mvc.Formatters.StringOutputFormatter","Microsoft.AspNetCore.Mvc.Formatters.StreamOutputFormatter","Microsoft.AspNetCore.Mvc.Formatters.SystemTextJsonOutputFormatter"]
+2025-10-04 02:56:01.716 +07:00 [DBG] No information found on request to perform content negotiation.
+2025-10-04 02:56:01.716 +07:00 [DBG] Attempting to select the first output formatter in the output formatters list which supports a content type from the explicitly specified content types '["application/json"]'.
+2025-10-04 02:56:01.716 +07:00 [DBG] Selected output formatter 'Microsoft.AspNetCore.Mvc.Formatters.SystemTextJsonOutputFormatter' and content type 'application/json' to write the response.
+2025-10-04 02:56:01.716 +07:00 [INF] Executing ObjectResult, writing value of type 'FS.Commons.FSResponse'.
+2025-10-04 02:56:01.716 +07:00 [INF] Executed action CapBot.api.Controllers.TopicController.GetDetail (CapBot.api) in 53.5439ms
+2025-10-04 02:56:01.716 +07:00 [INF] Executed endpoint 'CapBot.api.Controllers.TopicController.GetDetail (CapBot.api)'
+2025-10-04 02:56:01.717 +07:00 [DBG] Connection id "0HNG2MQC634J9" completed keep alive response.
+2025-10-04 02:56:01.717 +07:00 [DBG] 'MyDbContext' disposed.
+2025-10-04 02:56:01.717 +07:00 [DBG] Disposing connection to database 'capbot_db' on server 'localhost'.
+2025-10-04 02:56:01.717 +07:00 [DBG] Disposed connection to database '' on server '' (0ms).
+2025-10-04 02:56:01.717 +07:00 [INF] Request finished HTTP/1.1 GET http://localhost:5207/api/topic/detail/104 - 200 null application/json; charset=utf-8 59.0385ms
+2025-10-04 02:56:02.315 +07:00 [INF] Request starting HTTP/1.1 GET http://localhost:5207/api/topic/detail/104 - null null
+2025-10-04 02:56:02.315 +07:00 [DBG] The request path /api/topic/detail/104 does not match a supported file type
+2025-10-04 02:56:02.315 +07:00 [DBG] The request path /api/topic/detail/104 does not match a supported file type
+2025-10-04 02:56:02.315 +07:00 [DBG] 1 candidate(s) found for the request path '/api/topic/detail/104'
+2025-10-04 02:56:02.315 +07:00 [DBG] Endpoint 'CapBot.api.Controllers.TopicController.GetDetail (CapBot.api)' with route pattern 'api/topic/detail/{topicId}' is valid for the request path '/api/topic/detail/104'
+2025-10-04 02:56:02.315 +07:00 [DBG] Request matched endpoint 'CapBot.api.Controllers.TopicController.GetDetail (CapBot.api)'
+2025-10-04 02:56:02.316 +07:00 [DBG] Successfully validated the token.
+2025-10-04 02:56:02.316 +07:00 [DBG] AuthenticationScheme: Bearer was successfully authenticated.
+2025-10-04 02:56:02.316 +07:00 [INF] Executing endpoint 'CapBot.api.Controllers.TopicController.GetDetail (CapBot.api)'
+2025-10-04 02:56:02.316 +07:00 [INF] Route matched with {action = "GetDetail", controller = "Topic"}. Executing controller action with signature System.Threading.Tasks.Task`1[Microsoft.AspNetCore.Mvc.IActionResult] GetDetail(Int32) on controller CapBot.api.Controllers.TopicController (CapBot.api).
+2025-10-04 02:56:02.316 +07:00 [DBG] Execution plan of authorization filters (in the following order): ["None"]
+2025-10-04 02:56:02.316 +07:00 [DBG] Execution plan of resource filters (in the following order): ["Microsoft.AspNetCore.Mvc.ConsumesAttribute"]
+2025-10-04 02:56:02.317 +07:00 [DBG] Execution plan of action filters (in the following order): ["Microsoft.AspNetCore.Mvc.ModelBinding.UnsupportedContentTypeFilter (Order: -3000)"]
+2025-10-04 02:56:02.317 +07:00 [DBG] Execution plan of exception filters (in the following order): ["None"]
+2025-10-04 02:56:02.317 +07:00 [DBG] Execution plan of result filters (in the following order): ["Microsoft.AspNetCore.Mvc.Infrastructure.ClientErrorResultFilter (Order: -2000)","Microsoft.AspNetCore.Mvc.ProducesAttribute (Order: 0)"]
+2025-10-04 02:56:02.317 +07:00 [DBG] Executing controller factory for controller CapBot.api.Controllers.TopicController (CapBot.api)
+2025-10-04 02:56:02.317 +07:00 [DBG] Executed controller factory for controller CapBot.api.Controllers.TopicController (CapBot.api)
+2025-10-04 02:56:02.317 +07:00 [DBG] Attempting to bind parameter 'topicId' of type 'System.Int32' ...
+2025-10-04 02:56:02.318 +07:00 [DBG] Attempting to bind parameter 'topicId' of type 'System.Int32' using the name 'topicId' in request data ...
+2025-10-04 02:56:02.318 +07:00 [DBG] Done attempting to bind parameter 'topicId' of type 'System.Int32'.
+2025-10-04 02:56:02.318 +07:00 [DBG] Done attempting to bind parameter 'topicId' of type 'System.Int32'.
+2025-10-04 02:56:02.318 +07:00 [DBG] Attempting to validate the bound parameter 'topicId' of type 'System.Int32' ...
+2025-10-04 02:56:02.318 +07:00 [DBG] Done attempting to validate the bound parameter 'topicId' of type 'System.Int32'.
+2025-10-04 02:56:02.319 +07:00 [DBG] Entity Framework Core 8.0.16 initialized 'MyDbContext' using provider 'Microsoft.EntityFrameworkCore.SqlServer:8.0.13' with options: MigrationsAssembly=App.DAL 
+2025-10-04 02:56:02.320 +07:00 [DBG] Creating DbConnection.
+2025-10-04 02:56:02.320 +07:00 [DBG] Created DbConnection. (0ms).
+2025-10-04 02:56:02.320 +07:00 [DBG] Opening connection to database 'capbot_db' on server 'localhost'.
+2025-10-04 02:56:02.320 +07:00 [DBG] Opened connection to database 'capbot_db' on server 'localhost'.
+2025-10-04 02:56:02.320 +07:00 [DBG] Creating DbCommand for 'ExecuteReader'.
+2025-10-04 02:56:02.320 +07:00 [DBG] Created DbCommand for 'ExecuteReader' (0ms).
+2025-10-04 02:56:02.320 +07:00 [DBG] Initialized DbCommand for 'ExecuteReader' (0ms).
+2025-10-04 02:56:02.320 +07:00 [DBG] Executing DbCommand [Parameters=[@__topicId_0='?' (DbType = Int32)], CommandType='"Text"', CommandTimeout='30']
+SELECT [t1].[Id], [t1].[Abbreviation], [t1].[CategoryId], [t1].[Content], [t1].[Context], [t1].[CreatedAt], [t1].[CreatedBy], [t1].[DeletedAt], [t1].[Description], [t1].[EN_Title], [t1].[IsActive], [t1].[IsApproved], [t1].[IsLegacy], [t1].[LastModifiedAt], [t1].[LastModifiedBy], [t1].[MaxStudents], [t1].[Objectives], [t1].[PotentialDuplicate], [t1].[Problem], [t1].[SemesterId], [t1].[SupervisorId], [t1].[VN_title], [t1].[Id0], [t1].[AccessFailedCount], [t1].[ConcurrencyStamp], [t1].[CreatedAt0], [t1].[DeletedAt0], [t1].[Email], [t1].[EmailConfirmed], [t1].[LastModifiedAt0], [t1].[LastModifiedBy0], [t1].[LockoutEnabled], [t1].[LockoutEnd], [t1].[NormalizedEmail], [t1].[NormalizedUserName], [t1].[PasswordHash], [t1].[PhoneNumber], [t1].[PhoneNumberConfirmed], [t1].[SecurityStamp], [t1].[TwoFactorEnabled], [t1].[UserName], [t1].[Id1], [t1].[CreatedAt1], [t1].[CreatedBy0], [t1].[DeletedAt1], [t1].[Description0], [t1].[IsActive0], [t1].[LastModifiedAt1], [t1].[LastModifiedBy1], [t1].[Name], [t1].[Id2], [t1].[CreatedAt2], [t1].[CreatedBy1], [t1].[DeletedAt2], [t1].[Description1], [t1].[EndDate], [t1].[IsActive1], [t1].[LastModifiedAt2], [t1].[LastModifiedBy2], [t1].[Name0], [t1].[StartDate], [t2].[Id], [t2].[Content], [t2].[Context], [t2].[CreatedAt], [t2].[CreatedBy], [t2].[DeletedAt], [t2].[Description], [t2].[DocumentUrl], [t2].[EN_Title], [t2].[ExpectedOutcomes], [t2].[IsActive], [t2].[LastModifiedAt], [t2].[LastModifiedBy], [t2].[Methodology], [t2].[Objectives], [t2].[PotentialDuplicate], [t2].[Problem], [t2].[Requirements], [t2].[Status], [t2].[SubmittedAt], [t2].[SubmittedBy], [t2].[TopicId], [t2].[VN_title], [t2].[VersionNumber]
+FROM (
+    SELECT TOP(1) [t].[Id], [t].[Abbreviation], [t].[CategoryId], [t].[Content], [t].[Context], [t].[CreatedAt], [t].[CreatedBy], [t].[DeletedAt], [t].[Description], [t].[EN_Title], [t].[IsActive], [t].[IsApproved], [t].[IsLegacy], [t].[LastModifiedAt], [t].[LastModifiedBy], [t].[MaxStudents], [t].[Objectives], [t].[PotentialDuplicate], [t].[Problem], [t].[SemesterId], [t].[SupervisorId], [t].[VN_title], [u].[Id] AS [Id0], [u].[AccessFailedCount], [u].[ConcurrencyStamp], [u].[CreatedAt] AS [CreatedAt0], [u].[DeletedAt] AS [DeletedAt0], [u].[Email], [u].[EmailConfirmed], [u].[LastModifiedAt] AS [LastModifiedAt0], [u].[LastModifiedBy] AS [LastModifiedBy0], [u].[LockoutEnabled], [u].[LockoutEnd], [u].[NormalizedEmail], [u].[NormalizedUserName], [u].[PasswordHash], [u].[PhoneNumber], [u].[PhoneNumberConfirmed], [u].[SecurityStamp], [u].[TwoFactorEnabled], [u].[UserName], [t0].[Id] AS [Id1], [t0].[CreatedAt] AS [CreatedAt1], [t0].[CreatedBy] AS [CreatedBy0], [t0].[DeletedAt] AS [DeletedAt1], [t0].[Description] AS [Description0], [t0].[IsActive] AS [IsActive0], [t0].[LastModifiedAt] AS [LastModifiedAt1], [t0].[LastModifiedBy] AS [LastModifiedBy1], [t0].[Name], [s].[Id] AS [Id2], [s].[CreatedAt] AS [CreatedAt2], [s].[CreatedBy] AS [CreatedBy1], [s].[DeletedAt] AS [DeletedAt2], [s].[Description] AS [Description1], [s].[EndDate], [s].[IsActive] AS [IsActive1], [s].[LastModifiedAt] AS [LastModifiedAt2], [s].[LastModifiedBy] AS [LastModifiedBy2], [s].[Name] AS [Name0], [s].[StartDate]
+    FROM [topics] AS [t]
+    INNER JOIN [users] AS [u] ON [t].[SupervisorId] = [u].[Id]
+    LEFT JOIN [topic_categories] AS [t0] ON [t].[CategoryId] = [t0].[Id]
+    INNER JOIN [semesters] AS [s] ON [t].[SemesterId] = [s].[Id]
+    WHERE [t].[Id] = @__topicId_0 AND [t].[IsActive] = CAST(1 AS bit) AND [t].[DeletedAt] IS NULL
+) AS [t1]
+LEFT JOIN [topic_versions] AS [t2] ON [t1].[Id] = [t2].[TopicId]
+ORDER BY [t1].[Id], [t1].[Id0], [t1].[Id1], [t1].[Id2]
+2025-10-04 02:56:02.322 +07:00 [INF] Executed DbCommand (2ms) [Parameters=[@__topicId_0='?' (DbType = Int32)], CommandType='"Text"', CommandTimeout='30']
+SELECT [t1].[Id], [t1].[Abbreviation], [t1].[CategoryId], [t1].[Content], [t1].[Context], [t1].[CreatedAt], [t1].[CreatedBy], [t1].[DeletedAt], [t1].[Description], [t1].[EN_Title], [t1].[IsActive], [t1].[IsApproved], [t1].[IsLegacy], [t1].[LastModifiedAt], [t1].[LastModifiedBy], [t1].[MaxStudents], [t1].[Objectives], [t1].[PotentialDuplicate], [t1].[Problem], [t1].[SemesterId], [t1].[SupervisorId], [t1].[VN_title], [t1].[Id0], [t1].[AccessFailedCount], [t1].[ConcurrencyStamp], [t1].[CreatedAt0], [t1].[DeletedAt0], [t1].[Email], [t1].[EmailConfirmed], [t1].[LastModifiedAt0], [t1].[LastModifiedBy0], [t1].[LockoutEnabled], [t1].[LockoutEnd], [t1].[NormalizedEmail], [t1].[NormalizedUserName], [t1].[PasswordHash], [t1].[PhoneNumber], [t1].[PhoneNumberConfirmed], [t1].[SecurityStamp], [t1].[TwoFactorEnabled], [t1].[UserName], [t1].[Id1], [t1].[CreatedAt1], [t1].[CreatedBy0], [t1].[DeletedAt1], [t1].[Description0], [t1].[IsActive0], [t1].[LastModifiedAt1], [t1].[LastModifiedBy1], [t1].[Name], [t1].[Id2], [t1].[CreatedAt2], [t1].[CreatedBy1], [t1].[DeletedAt2], [t1].[Description1], [t1].[EndDate], [t1].[IsActive1], [t1].[LastModifiedAt2], [t1].[LastModifiedBy2], [t1].[Name0], [t1].[StartDate], [t2].[Id], [t2].[Content], [t2].[Context], [t2].[CreatedAt], [t2].[CreatedBy], [t2].[DeletedAt], [t2].[Description], [t2].[DocumentUrl], [t2].[EN_Title], [t2].[ExpectedOutcomes], [t2].[IsActive], [t2].[LastModifiedAt], [t2].[LastModifiedBy], [t2].[Methodology], [t2].[Objectives], [t2].[PotentialDuplicate], [t2].[Problem], [t2].[Requirements], [t2].[Status], [t2].[SubmittedAt], [t2].[SubmittedBy], [t2].[TopicId], [t2].[VN_title], [t2].[VersionNumber]
+FROM (
+    SELECT TOP(1) [t].[Id], [t].[Abbreviation], [t].[CategoryId], [t].[Content], [t].[Context], [t].[CreatedAt], [t].[CreatedBy], [t].[DeletedAt], [t].[Description], [t].[EN_Title], [t].[IsActive], [t].[IsApproved], [t].[IsLegacy], [t].[LastModifiedAt], [t].[LastModifiedBy], [t].[MaxStudents], [t].[Objectives], [t].[PotentialDuplicate], [t].[Problem], [t].[SemesterId], [t].[SupervisorId], [t].[VN_title], [u].[Id] AS [Id0], [u].[AccessFailedCount], [u].[ConcurrencyStamp], [u].[CreatedAt] AS [CreatedAt0], [u].[DeletedAt] AS [DeletedAt0], [u].[Email], [u].[EmailConfirmed], [u].[LastModifiedAt] AS [LastModifiedAt0], [u].[LastModifiedBy] AS [LastModifiedBy0], [u].[LockoutEnabled], [u].[LockoutEnd], [u].[NormalizedEmail], [u].[NormalizedUserName], [u].[PasswordHash], [u].[PhoneNumber], [u].[PhoneNumberConfirmed], [u].[SecurityStamp], [u].[TwoFactorEnabled], [u].[UserName], [t0].[Id] AS [Id1], [t0].[CreatedAt] AS [CreatedAt1], [t0].[CreatedBy] AS [CreatedBy0], [t0].[DeletedAt] AS [DeletedAt1], [t0].[Description] AS [Description0], [t0].[IsActive] AS [IsActive0], [t0].[LastModifiedAt] AS [LastModifiedAt1], [t0].[LastModifiedBy] AS [LastModifiedBy1], [t0].[Name], [s].[Id] AS [Id2], [s].[CreatedAt] AS [CreatedAt2], [s].[CreatedBy] AS [CreatedBy1], [s].[DeletedAt] AS [DeletedAt2], [s].[Description] AS [Description1], [s].[EndDate], [s].[IsActive] AS [IsActive1], [s].[LastModifiedAt] AS [LastModifiedAt2], [s].[LastModifiedBy] AS [LastModifiedBy2], [s].[Name] AS [Name0], [s].[StartDate]
+    FROM [topics] AS [t]
+    INNER JOIN [users] AS [u] ON [t].[SupervisorId] = [u].[Id]
+    LEFT JOIN [topic_categories] AS [t0] ON [t].[CategoryId] = [t0].[Id]
+    INNER JOIN [semesters] AS [s] ON [t].[SemesterId] = [s].[Id]
+    WHERE [t].[Id] = @__topicId_0 AND [t].[IsActive] = CAST(1 AS bit) AND [t].[DeletedAt] IS NULL
+) AS [t1]
+LEFT JOIN [topic_versions] AS [t2] ON [t1].[Id] = [t2].[TopicId]
+ORDER BY [t1].[Id], [t1].[Id0], [t1].[Id1], [t1].[Id2]
+2025-10-04 02:56:02.324 +07:00 [DBG] Closing data reader to 'capbot_db' on server 'localhost'.
+2025-10-04 02:56:02.324 +07:00 [DBG] A data reader for 'capbot_db' on server 'localhost' is being disposed after spending 0ms reading results.
+2025-10-04 02:56:02.324 +07:00 [DBG] Closing connection to database 'capbot_db' on server 'localhost'.
+2025-10-04 02:56:02.325 +07:00 [DBG] Closed connection to database 'capbot_db' on server 'localhost' (1ms).
+2025-10-04 02:56:02.327 +07:00 [DBG] Opening connection to database 'capbot_db' on server 'localhost'.
+2025-10-04 02:56:02.328 +07:00 [DBG] Opened connection to database 'capbot_db' on server 'localhost'.
+2025-10-04 02:56:02.328 +07:00 [DBG] Creating DbCommand for 'ExecuteReader'.
+2025-10-04 02:56:02.328 +07:00 [DBG] Created DbCommand for 'ExecuteReader' (0ms).
+2025-10-04 02:56:02.330 +07:00 [DBG] Initialized DbCommand for 'ExecuteReader' (1ms).
+2025-10-04 02:56:02.330 +07:00 [DBG] Executing DbCommand [Parameters=[@__topicId_0='?' (DbType = Int32)], CommandType='"Text"', CommandTimeout='30']
+SELECT [s].[Id], [s].[AdditionalNotes], [s].[AiCheckDetails], [s].[AiCheckScore], [s].[AiCheckStatus], [s].[CreatedAt], [s].[CreatedBy], [s].[DeletedAt], [s].[DocumentUrl], [s].[IsActive], [s].[LastModifiedAt], [s].[LastModifiedBy], [s].[PhaseId], [s].[Status], [s].[SubmissionRound], [s].[SubmittedAt], [s].[SubmittedBy], [s].[TopicId], [s].[TopicVersionId], [p].[Id], [p].[CreatedAt], [p].[CreatedBy], [p].[DeletedAt], [p].[EndDate], [p].[IsActive], [p].[LastModifiedAt], [p].[LastModifiedBy], [p].[Name], [p].[PhaseTypeId], [p].[SemesterId], [p].[StartDate], [p].[SubmissionDeadline], [u].[Id], [u].[AccessFailedCount], [u].[ConcurrencyStamp], [u].[CreatedAt], [u].[DeletedAt], [u].[Email], [u].[EmailConfirmed], [u].[LastModifiedAt], [u].[LastModifiedBy], [u].[LockoutEnabled], [u].[LockoutEnd], [u].[NormalizedEmail], [u].[NormalizedUserName], [u].[PasswordHash], [u].[PhoneNumber], [u].[PhoneNumberConfirmed], [u].[SecurityStamp], [u].[TwoFactorEnabled], [u].[UserName], [r].[Id], [r].[AssignedAt], [r].[AssignedBy], [r].[AssignmentType], [r].[CompletedAt], [r].[Deadline], [r].[ReviewerId], [r].[SkillMatchScore], [r].[StartedAt], [r].[Status], [r].[SubmissionId]
+FROM [submissions] AS [s]
+INNER JOIN [phases] AS [p] ON [s].[PhaseId] = [p].[Id]
+INNER JOIN [users] AS [u] ON [s].[SubmittedBy] = [u].[Id]
+LEFT JOIN [reviewer_assignments] AS [r] ON [s].[Id] = [r].[SubmissionId]
+WHERE [s].[TopicId] = @__topicId_0 AND [s].[IsActive] = CAST(1 AS bit) AND [s].[DeletedAt] IS NULL
+ORDER BY [s].[Id], [p].[Id], [u].[Id]
+2025-10-04 02:56:02.332 +07:00 [INF] Executed DbCommand (2ms) [Parameters=[@__topicId_0='?' (DbType = Int32)], CommandType='"Text"', CommandTimeout='30']
+SELECT [s].[Id], [s].[AdditionalNotes], [s].[AiCheckDetails], [s].[AiCheckScore], [s].[AiCheckStatus], [s].[CreatedAt], [s].[CreatedBy], [s].[DeletedAt], [s].[DocumentUrl], [s].[IsActive], [s].[LastModifiedAt], [s].[LastModifiedBy], [s].[PhaseId], [s].[Status], [s].[SubmissionRound], [s].[SubmittedAt], [s].[SubmittedBy], [s].[TopicId], [s].[TopicVersionId], [p].[Id], [p].[CreatedAt], [p].[CreatedBy], [p].[DeletedAt], [p].[EndDate], [p].[IsActive], [p].[LastModifiedAt], [p].[LastModifiedBy], [p].[Name], [p].[PhaseTypeId], [p].[SemesterId], [p].[StartDate], [p].[SubmissionDeadline], [u].[Id], [u].[AccessFailedCount], [u].[ConcurrencyStamp], [u].[CreatedAt], [u].[DeletedAt], [u].[Email], [u].[EmailConfirmed], [u].[LastModifiedAt], [u].[LastModifiedBy], [u].[LockoutEnabled], [u].[LockoutEnd], [u].[NormalizedEmail], [u].[NormalizedUserName], [u].[PasswordHash], [u].[PhoneNumber], [u].[PhoneNumberConfirmed], [u].[SecurityStamp], [u].[TwoFactorEnabled], [u].[UserName], [r].[Id], [r].[AssignedAt], [r].[AssignedBy], [r].[AssignmentType], [r].[CompletedAt], [r].[Deadline], [r].[ReviewerId], [r].[SkillMatchScore], [r].[StartedAt], [r].[Status], [r].[SubmissionId]
+FROM [submissions] AS [s]
+INNER JOIN [phases] AS [p] ON [s].[PhaseId] = [p].[Id]
+INNER JOIN [users] AS [u] ON [s].[SubmittedBy] = [u].[Id]
+LEFT JOIN [reviewer_assignments] AS [r] ON [s].[Id] = [r].[SubmissionId]
+WHERE [s].[TopicId] = @__topicId_0 AND [s].[IsActive] = CAST(1 AS bit) AND [s].[DeletedAt] IS NULL
+ORDER BY [s].[Id], [p].[Id], [u].[Id]
+2025-10-04 02:56:02.333 +07:00 [DBG] Closing data reader to 'capbot_db' on server 'localhost'.
+2025-10-04 02:56:02.333 +07:00 [DBG] A data reader for 'capbot_db' on server 'localhost' is being disposed after spending 0ms reading results.
+2025-10-04 02:56:02.333 +07:00 [DBG] Closing connection to database 'capbot_db' on server 'localhost'.
+2025-10-04 02:56:02.333 +07:00 [DBG] Closed connection to database 'capbot_db' on server 'localhost' (0ms).
+2025-10-04 02:56:02.334 +07:00 [DBG] Opening connection to database 'capbot_db' on server 'localhost'.
+2025-10-04 02:56:02.334 +07:00 [DBG] Opened connection to database 'capbot_db' on server 'localhost'.
+2025-10-04 02:56:02.334 +07:00 [DBG] Creating DbCommand for 'ExecuteReader'.
+2025-10-04 02:56:02.334 +07:00 [DBG] Created DbCommand for 'ExecuteReader' (0ms).
+2025-10-04 02:56:02.334 +07:00 [DBG] Initialized DbCommand for 'ExecuteReader' (0ms).
+2025-10-04 02:56:02.334 +07:00 [DBG] Executing DbCommand [Parameters=[@__p_0='?' (DbType = Int64)], CommandType='"Text"', CommandTimeout='30']
+SELECT TOP(1) [e].[Id], [e].[Caption], [e].[CreatedAt], [e].[EntityId], [e].[EntityType], [e].[FileId], [e].[IsPrimary], [f].[Id], [f].[Alt], [f].[Checksum], [f].[CreatedAt], [f].[CreatedBy], [f].[DeletedAt], [f].[FileName], [f].[FilePath], [f].[FileSize], [f].[FileType], [f].[Height], [f].[IsActive], [f].[LastModifiedAt], [f].[LastModifiedBy], [f].[MimeType], [f].[ThumbnailUrl], [f].[Url], [f].[Width]
+FROM [entity_files] AS [e]
+INNER JOIN [files] AS [f] ON [e].[FileId] = [f].[Id]
+WHERE [e].[EntityId] = @__p_0 AND [e].[EntityType] = 1 AND [e].[IsPrimary] = CAST(1 AS bit)
+2025-10-04 02:56:02.335 +07:00 [INF] Executed DbCommand (1ms) [Parameters=[@__p_0='?' (DbType = Int64)], CommandType='"Text"', CommandTimeout='30']
+SELECT TOP(1) [e].[Id], [e].[Caption], [e].[CreatedAt], [e].[EntityId], [e].[EntityType], [e].[FileId], [e].[IsPrimary], [f].[Id], [f].[Alt], [f].[Checksum], [f].[CreatedAt], [f].[CreatedBy], [f].[DeletedAt], [f].[FileName], [f].[FilePath], [f].[FileSize], [f].[FileType], [f].[Height], [f].[IsActive], [f].[LastModifiedAt], [f].[LastModifiedBy], [f].[MimeType], [f].[ThumbnailUrl], [f].[Url], [f].[Width]
+FROM [entity_files] AS [e]
+INNER JOIN [files] AS [f] ON [e].[FileId] = [f].[Id]
+WHERE [e].[EntityId] = @__p_0 AND [e].[EntityType] = 1 AND [e].[IsPrimary] = CAST(1 AS bit)
+2025-10-04 02:56:02.335 +07:00 [DBG] Closing data reader to 'capbot_db' on server 'localhost'.
+2025-10-04 02:56:02.335 +07:00 [DBG] A data reader for 'capbot_db' on server 'localhost' is being disposed after spending 0ms reading results.
+2025-10-04 02:56:02.335 +07:00 [DBG] Closing connection to database 'capbot_db' on server 'localhost'.
+2025-10-04 02:56:02.335 +07:00 [DBG] Closed connection to database 'capbot_db' on server 'localhost' (0ms).
+2025-10-04 02:56:02.336 +07:00 [DBG] List of registered output formatters, in the following order: ["Microsoft.AspNetCore.OData.Formatter.ODataOutputFormatter","Microsoft.AspNetCore.OData.Formatter.ODataOutputFormatter","Microsoft.AspNetCore.OData.Formatter.ODataOutputFormatter","Microsoft.AspNetCore.Mvc.Formatters.HttpNoContentOutputFormatter","Microsoft.AspNetCore.Mvc.Formatters.StringOutputFormatter","Microsoft.AspNetCore.Mvc.Formatters.StreamOutputFormatter","Microsoft.AspNetCore.Mvc.Formatters.SystemTextJsonOutputFormatter"]
+2025-10-04 02:56:02.336 +07:00 [DBG] No information found on request to perform content negotiation.
+2025-10-04 02:56:02.336 +07:00 [DBG] Attempting to select the first output formatter in the output formatters list which supports a content type from the explicitly specified content types '["application/json"]'.
+2025-10-04 02:56:02.336 +07:00 [DBG] Selected output formatter 'Microsoft.AspNetCore.Mvc.Formatters.SystemTextJsonOutputFormatter' and content type 'application/json' to write the response.
+2025-10-04 02:56:02.336 +07:00 [INF] Executing ObjectResult, writing value of type 'FS.Commons.FSResponse'.
+2025-10-04 02:56:02.336 +07:00 [INF] Executed action CapBot.api.Controllers.TopicController.GetDetail (CapBot.api) in 19.5862ms
+2025-10-04 02:56:02.337 +07:00 [INF] Executed endpoint 'CapBot.api.Controllers.TopicController.GetDetail (CapBot.api)'
+2025-10-04 02:56:02.337 +07:00 [DBG] Connection id "0HNG2MQC634J9" completed keep alive response.
+2025-10-04 02:56:02.337 +07:00 [DBG] 'MyDbContext' disposed.
+2025-10-04 02:56:02.337 +07:00 [DBG] Disposing connection to database 'capbot_db' on server 'localhost'.
+2025-10-04 02:56:02.337 +07:00 [DBG] Disposed connection to database '' on server '' (0ms).
+2025-10-04 02:56:02.337 +07:00 [INF] Request finished HTTP/1.1 GET http://localhost:5207/api/topic/detail/104 - 200 null application/json; charset=utf-8 22.2146ms
+2025-10-04 02:56:02.902 +07:00 [INF] Request starting HTTP/1.1 GET http://localhost:5207/api/topic/detail/104 - null null
+2025-10-04 02:56:02.902 +07:00 [DBG] The request path /api/topic/detail/104 does not match a supported file type
+2025-10-04 02:56:02.906 +07:00 [DBG] The request path /api/topic/detail/104 does not match a supported file type
+2025-10-04 02:56:02.907 +07:00 [DBG] 1 candidate(s) found for the request path '/api/topic/detail/104'
+2025-10-04 02:56:02.907 +07:00 [DBG] Endpoint 'CapBot.api.Controllers.TopicController.GetDetail (CapBot.api)' with route pattern 'api/topic/detail/{topicId}' is valid for the request path '/api/topic/detail/104'
+2025-10-04 02:56:02.907 +07:00 [DBG] Request matched endpoint 'CapBot.api.Controllers.TopicController.GetDetail (CapBot.api)'
+2025-10-04 02:56:02.910 +07:00 [DBG] Successfully validated the token.
+2025-10-04 02:56:02.911 +07:00 [DBG] AuthenticationScheme: Bearer was successfully authenticated.
+2025-10-04 02:56:02.911 +07:00 [INF] Executing endpoint 'CapBot.api.Controllers.TopicController.GetDetail (CapBot.api)'
+2025-10-04 02:56:02.911 +07:00 [INF] Route matched with {action = "GetDetail", controller = "Topic"}. Executing controller action with signature System.Threading.Tasks.Task`1[Microsoft.AspNetCore.Mvc.IActionResult] GetDetail(Int32) on controller CapBot.api.Controllers.TopicController (CapBot.api).
+2025-10-04 02:56:02.911 +07:00 [DBG] Execution plan of authorization filters (in the following order): ["None"]
+2025-10-04 02:56:02.912 +07:00 [DBG] Execution plan of resource filters (in the following order): ["Microsoft.AspNetCore.Mvc.ConsumesAttribute"]
+2025-10-04 02:56:02.912 +07:00 [DBG] Execution plan of action filters (in the following order): ["Microsoft.AspNetCore.Mvc.ModelBinding.UnsupportedContentTypeFilter (Order: -3000)"]
+2025-10-04 02:56:02.912 +07:00 [DBG] Execution plan of exception filters (in the following order): ["None"]
+2025-10-04 02:56:02.912 +07:00 [DBG] Execution plan of result filters (in the following order): ["Microsoft.AspNetCore.Mvc.Infrastructure.ClientErrorResultFilter (Order: -2000)","Microsoft.AspNetCore.Mvc.ProducesAttribute (Order: 0)"]
+2025-10-04 02:56:02.912 +07:00 [DBG] Executing controller factory for controller CapBot.api.Controllers.TopicController (CapBot.api)
+2025-10-04 02:56:02.913 +07:00 [DBG] Executed controller factory for controller CapBot.api.Controllers.TopicController (CapBot.api)
+2025-10-04 02:56:02.913 +07:00 [DBG] Attempting to bind parameter 'topicId' of type 'System.Int32' ...
+2025-10-04 02:56:02.913 +07:00 [DBG] Attempting to bind parameter 'topicId' of type 'System.Int32' using the name 'topicId' in request data ...
+2025-10-04 02:56:02.914 +07:00 [DBG] Done attempting to bind parameter 'topicId' of type 'System.Int32'.
+2025-10-04 02:56:02.914 +07:00 [DBG] Done attempting to bind parameter 'topicId' of type 'System.Int32'.
+2025-10-04 02:56:02.914 +07:00 [DBG] Attempting to validate the bound parameter 'topicId' of type 'System.Int32' ...
+2025-10-04 02:56:02.914 +07:00 [DBG] Done attempting to validate the bound parameter 'topicId' of type 'System.Int32'.
+2025-10-04 02:56:02.915 +07:00 [DBG] Entity Framework Core 8.0.16 initialized 'MyDbContext' using provider 'Microsoft.EntityFrameworkCore.SqlServer:8.0.13' with options: MigrationsAssembly=App.DAL 
+2025-10-04 02:56:02.917 +07:00 [DBG] Creating DbConnection.
+2025-10-04 02:56:02.918 +07:00 [DBG] Created DbConnection. (0ms).
+2025-10-04 02:56:02.918 +07:00 [DBG] Opening connection to database 'capbot_db' on server 'localhost'.
+2025-10-04 02:56:02.918 +07:00 [DBG] Opened connection to database 'capbot_db' on server 'localhost'.
+2025-10-04 02:56:02.918 +07:00 [DBG] Creating DbCommand for 'ExecuteReader'.
+2025-10-04 02:56:02.918 +07:00 [DBG] Created DbCommand for 'ExecuteReader' (0ms).
+2025-10-04 02:56:02.919 +07:00 [DBG] Initialized DbCommand for 'ExecuteReader' (0ms).
+2025-10-04 02:56:02.919 +07:00 [DBG] Executing DbCommand [Parameters=[@__topicId_0='?' (DbType = Int32)], CommandType='"Text"', CommandTimeout='30']
+SELECT [t1].[Id], [t1].[Abbreviation], [t1].[CategoryId], [t1].[Content], [t1].[Context], [t1].[CreatedAt], [t1].[CreatedBy], [t1].[DeletedAt], [t1].[Description], [t1].[EN_Title], [t1].[IsActive], [t1].[IsApproved], [t1].[IsLegacy], [t1].[LastModifiedAt], [t1].[LastModifiedBy], [t1].[MaxStudents], [t1].[Objectives], [t1].[PotentialDuplicate], [t1].[Problem], [t1].[SemesterId], [t1].[SupervisorId], [t1].[VN_title], [t1].[Id0], [t1].[AccessFailedCount], [t1].[ConcurrencyStamp], [t1].[CreatedAt0], [t1].[DeletedAt0], [t1].[Email], [t1].[EmailConfirmed], [t1].[LastModifiedAt0], [t1].[LastModifiedBy0], [t1].[LockoutEnabled], [t1].[LockoutEnd], [t1].[NormalizedEmail], [t1].[NormalizedUserName], [t1].[PasswordHash], [t1].[PhoneNumber], [t1].[PhoneNumberConfirmed], [t1].[SecurityStamp], [t1].[TwoFactorEnabled], [t1].[UserName], [t1].[Id1], [t1].[CreatedAt1], [t1].[CreatedBy0], [t1].[DeletedAt1], [t1].[Description0], [t1].[IsActive0], [t1].[LastModifiedAt1], [t1].[LastModifiedBy1], [t1].[Name], [t1].[Id2], [t1].[CreatedAt2], [t1].[CreatedBy1], [t1].[DeletedAt2], [t1].[Description1], [t1].[EndDate], [t1].[IsActive1], [t1].[LastModifiedAt2], [t1].[LastModifiedBy2], [t1].[Name0], [t1].[StartDate], [t2].[Id], [t2].[Content], [t2].[Context], [t2].[CreatedAt], [t2].[CreatedBy], [t2].[DeletedAt], [t2].[Description], [t2].[DocumentUrl], [t2].[EN_Title], [t2].[ExpectedOutcomes], [t2].[IsActive], [t2].[LastModifiedAt], [t2].[LastModifiedBy], [t2].[Methodology], [t2].[Objectives], [t2].[PotentialDuplicate], [t2].[Problem], [t2].[Requirements], [t2].[Status], [t2].[SubmittedAt], [t2].[SubmittedBy], [t2].[TopicId], [t2].[VN_title], [t2].[VersionNumber]
+FROM (
+    SELECT TOP(1) [t].[Id], [t].[Abbreviation], [t].[CategoryId], [t].[Content], [t].[Context], [t].[CreatedAt], [t].[CreatedBy], [t].[DeletedAt], [t].[Description], [t].[EN_Title], [t].[IsActive], [t].[IsApproved], [t].[IsLegacy], [t].[LastModifiedAt], [t].[LastModifiedBy], [t].[MaxStudents], [t].[Objectives], [t].[PotentialDuplicate], [t].[Problem], [t].[SemesterId], [t].[SupervisorId], [t].[VN_title], [u].[Id] AS [Id0], [u].[AccessFailedCount], [u].[ConcurrencyStamp], [u].[CreatedAt] AS [CreatedAt0], [u].[DeletedAt] AS [DeletedAt0], [u].[Email], [u].[EmailConfirmed], [u].[LastModifiedAt] AS [LastModifiedAt0], [u].[LastModifiedBy] AS [LastModifiedBy0], [u].[LockoutEnabled], [u].[LockoutEnd], [u].[NormalizedEmail], [u].[NormalizedUserName], [u].[PasswordHash], [u].[PhoneNumber], [u].[PhoneNumberConfirmed], [u].[SecurityStamp], [u].[TwoFactorEnabled], [u].[UserName], [t0].[Id] AS [Id1], [t0].[CreatedAt] AS [CreatedAt1], [t0].[CreatedBy] AS [CreatedBy0], [t0].[DeletedAt] AS [DeletedAt1], [t0].[Description] AS [Description0], [t0].[IsActive] AS [IsActive0], [t0].[LastModifiedAt] AS [LastModifiedAt1], [t0].[LastModifiedBy] AS [LastModifiedBy1], [t0].[Name], [s].[Id] AS [Id2], [s].[CreatedAt] AS [CreatedAt2], [s].[CreatedBy] AS [CreatedBy1], [s].[DeletedAt] AS [DeletedAt2], [s].[Description] AS [Description1], [s].[EndDate], [s].[IsActive] AS [IsActive1], [s].[LastModifiedAt] AS [LastModifiedAt2], [s].[LastModifiedBy] AS [LastModifiedBy2], [s].[Name] AS [Name0], [s].[StartDate]
+    FROM [topics] AS [t]
+    INNER JOIN [users] AS [u] ON [t].[SupervisorId] = [u].[Id]
+    LEFT JOIN [topic_categories] AS [t0] ON [t].[CategoryId] = [t0].[Id]
+    INNER JOIN [semesters] AS [s] ON [t].[SemesterId] = [s].[Id]
+    WHERE [t].[Id] = @__topicId_0 AND [t].[IsActive] = CAST(1 AS bit) AND [t].[DeletedAt] IS NULL
+) AS [t1]
+LEFT JOIN [topic_versions] AS [t2] ON [t1].[Id] = [t2].[TopicId]
+ORDER BY [t1].[Id], [t1].[Id0], [t1].[Id1], [t1].[Id2]
+2025-10-04 02:56:02.920 +07:00 [INF] Executed DbCommand (2ms) [Parameters=[@__topicId_0='?' (DbType = Int32)], CommandType='"Text"', CommandTimeout='30']
+SELECT [t1].[Id], [t1].[Abbreviation], [t1].[CategoryId], [t1].[Content], [t1].[Context], [t1].[CreatedAt], [t1].[CreatedBy], [t1].[DeletedAt], [t1].[Description], [t1].[EN_Title], [t1].[IsActive], [t1].[IsApproved], [t1].[IsLegacy], [t1].[LastModifiedAt], [t1].[LastModifiedBy], [t1].[MaxStudents], [t1].[Objectives], [t1].[PotentialDuplicate], [t1].[Problem], [t1].[SemesterId], [t1].[SupervisorId], [t1].[VN_title], [t1].[Id0], [t1].[AccessFailedCount], [t1].[ConcurrencyStamp], [t1].[CreatedAt0], [t1].[DeletedAt0], [t1].[Email], [t1].[EmailConfirmed], [t1].[LastModifiedAt0], [t1].[LastModifiedBy0], [t1].[LockoutEnabled], [t1].[LockoutEnd], [t1].[NormalizedEmail], [t1].[NormalizedUserName], [t1].[PasswordHash], [t1].[PhoneNumber], [t1].[PhoneNumberConfirmed], [t1].[SecurityStamp], [t1].[TwoFactorEnabled], [t1].[UserName], [t1].[Id1], [t1].[CreatedAt1], [t1].[CreatedBy0], [t1].[DeletedAt1], [t1].[Description0], [t1].[IsActive0], [t1].[LastModifiedAt1], [t1].[LastModifiedBy1], [t1].[Name], [t1].[Id2], [t1].[CreatedAt2], [t1].[CreatedBy1], [t1].[DeletedAt2], [t1].[Description1], [t1].[EndDate], [t1].[IsActive1], [t1].[LastModifiedAt2], [t1].[LastModifiedBy2], [t1].[Name0], [t1].[StartDate], [t2].[Id], [t2].[Content], [t2].[Context], [t2].[CreatedAt], [t2].[CreatedBy], [t2].[DeletedAt], [t2].[Description], [t2].[DocumentUrl], [t2].[EN_Title], [t2].[ExpectedOutcomes], [t2].[IsActive], [t2].[LastModifiedAt], [t2].[LastModifiedBy], [t2].[Methodology], [t2].[Objectives], [t2].[PotentialDuplicate], [t2].[Problem], [t2].[Requirements], [t2].[Status], [t2].[SubmittedAt], [t2].[SubmittedBy], [t2].[TopicId], [t2].[VN_title], [t2].[VersionNumber]
+FROM (
+    SELECT TOP(1) [t].[Id], [t].[Abbreviation], [t].[CategoryId], [t].[Content], [t].[Context], [t].[CreatedAt], [t].[CreatedBy], [t].[DeletedAt], [t].[Description], [t].[EN_Title], [t].[IsActive], [t].[IsApproved], [t].[IsLegacy], [t].[LastModifiedAt], [t].[LastModifiedBy], [t].[MaxStudents], [t].[Objectives], [t].[PotentialDuplicate], [t].[Problem], [t].[SemesterId], [t].[SupervisorId], [t].[VN_title], [u].[Id] AS [Id0], [u].[AccessFailedCount], [u].[ConcurrencyStamp], [u].[CreatedAt] AS [CreatedAt0], [u].[DeletedAt] AS [DeletedAt0], [u].[Email], [u].[EmailConfirmed], [u].[LastModifiedAt] AS [LastModifiedAt0], [u].[LastModifiedBy] AS [LastModifiedBy0], [u].[LockoutEnabled], [u].[LockoutEnd], [u].[NormalizedEmail], [u].[NormalizedUserName], [u].[PasswordHash], [u].[PhoneNumber], [u].[PhoneNumberConfirmed], [u].[SecurityStamp], [u].[TwoFactorEnabled], [u].[UserName], [t0].[Id] AS [Id1], [t0].[CreatedAt] AS [CreatedAt1], [t0].[CreatedBy] AS [CreatedBy0], [t0].[DeletedAt] AS [DeletedAt1], [t0].[Description] AS [Description0], [t0].[IsActive] AS [IsActive0], [t0].[LastModifiedAt] AS [LastModifiedAt1], [t0].[LastModifiedBy] AS [LastModifiedBy1], [t0].[Name], [s].[Id] AS [Id2], [s].[CreatedAt] AS [CreatedAt2], [s].[CreatedBy] AS [CreatedBy1], [s].[DeletedAt] AS [DeletedAt2], [s].[Description] AS [Description1], [s].[EndDate], [s].[IsActive] AS [IsActive1], [s].[LastModifiedAt] AS [LastModifiedAt2], [s].[LastModifiedBy] AS [LastModifiedBy2], [s].[Name] AS [Name0], [s].[StartDate]
+    FROM [topics] AS [t]
+    INNER JOIN [users] AS [u] ON [t].[SupervisorId] = [u].[Id]
+    LEFT JOIN [topic_categories] AS [t0] ON [t].[CategoryId] = [t0].[Id]
+    INNER JOIN [semesters] AS [s] ON [t].[SemesterId] = [s].[Id]
+    WHERE [t].[Id] = @__topicId_0 AND [t].[IsActive] = CAST(1 AS bit) AND [t].[DeletedAt] IS NULL
+) AS [t1]
+LEFT JOIN [topic_versions] AS [t2] ON [t1].[Id] = [t2].[TopicId]
+ORDER BY [t1].[Id], [t1].[Id0], [t1].[Id1], [t1].[Id2]
+2025-10-04 02:56:02.921 +07:00 [DBG] Closing data reader to 'capbot_db' on server 'localhost'.
+2025-10-04 02:56:02.921 +07:00 [DBG] A data reader for 'capbot_db' on server 'localhost' is being disposed after spending 0ms reading results.
+2025-10-04 02:56:02.921 +07:00 [DBG] Closing connection to database 'capbot_db' on server 'localhost'.
+2025-10-04 02:56:02.921 +07:00 [DBG] Closed connection to database 'capbot_db' on server 'localhost' (0ms).
+2025-10-04 02:56:02.922 +07:00 [DBG] Opening connection to database 'capbot_db' on server 'localhost'.
+2025-10-04 02:56:02.922 +07:00 [DBG] Opened connection to database 'capbot_db' on server 'localhost'.
+2025-10-04 02:56:02.922 +07:00 [DBG] Creating DbCommand for 'ExecuteReader'.
+2025-10-04 02:56:02.922 +07:00 [DBG] Created DbCommand for 'ExecuteReader' (0ms).
+2025-10-04 02:56:02.922 +07:00 [DBG] Initialized DbCommand for 'ExecuteReader' (0ms).
+2025-10-04 02:56:02.923 +07:00 [DBG] Executing DbCommand [Parameters=[@__topicId_0='?' (DbType = Int32)], CommandType='"Text"', CommandTimeout='30']
+SELECT [s].[Id], [s].[AdditionalNotes], [s].[AiCheckDetails], [s].[AiCheckScore], [s].[AiCheckStatus], [s].[CreatedAt], [s].[CreatedBy], [s].[DeletedAt], [s].[DocumentUrl], [s].[IsActive], [s].[LastModifiedAt], [s].[LastModifiedBy], [s].[PhaseId], [s].[Status], [s].[SubmissionRound], [s].[SubmittedAt], [s].[SubmittedBy], [s].[TopicId], [s].[TopicVersionId], [p].[Id], [p].[CreatedAt], [p].[CreatedBy], [p].[DeletedAt], [p].[EndDate], [p].[IsActive], [p].[LastModifiedAt], [p].[LastModifiedBy], [p].[Name], [p].[PhaseTypeId], [p].[SemesterId], [p].[StartDate], [p].[SubmissionDeadline], [u].[Id], [u].[AccessFailedCount], [u].[ConcurrencyStamp], [u].[CreatedAt], [u].[DeletedAt], [u].[Email], [u].[EmailConfirmed], [u].[LastModifiedAt], [u].[LastModifiedBy], [u].[LockoutEnabled], [u].[LockoutEnd], [u].[NormalizedEmail], [u].[NormalizedUserName], [u].[PasswordHash], [u].[PhoneNumber], [u].[PhoneNumberConfirmed], [u].[SecurityStamp], [u].[TwoFactorEnabled], [u].[UserName], [r].[Id], [r].[AssignedAt], [r].[AssignedBy], [r].[AssignmentType], [r].[CompletedAt], [r].[Deadline], [r].[ReviewerId], [r].[SkillMatchScore], [r].[StartedAt], [r].[Status], [r].[SubmissionId]
+FROM [submissions] AS [s]
+INNER JOIN [phases] AS [p] ON [s].[PhaseId] = [p].[Id]
+INNER JOIN [users] AS [u] ON [s].[SubmittedBy] = [u].[Id]
+LEFT JOIN [reviewer_assignments] AS [r] ON [s].[Id] = [r].[SubmissionId]
+WHERE [s].[TopicId] = @__topicId_0 AND [s].[IsActive] = CAST(1 AS bit) AND [s].[DeletedAt] IS NULL
+ORDER BY [s].[Id], [p].[Id], [u].[Id]
+2025-10-04 02:56:02.924 +07:00 [INF] Executed DbCommand (1ms) [Parameters=[@__topicId_0='?' (DbType = Int32)], CommandType='"Text"', CommandTimeout='30']
+SELECT [s].[Id], [s].[AdditionalNotes], [s].[AiCheckDetails], [s].[AiCheckScore], [s].[AiCheckStatus], [s].[CreatedAt], [s].[CreatedBy], [s].[DeletedAt], [s].[DocumentUrl], [s].[IsActive], [s].[LastModifiedAt], [s].[LastModifiedBy], [s].[PhaseId], [s].[Status], [s].[SubmissionRound], [s].[SubmittedAt], [s].[SubmittedBy], [s].[TopicId], [s].[TopicVersionId], [p].[Id], [p].[CreatedAt], [p].[CreatedBy], [p].[DeletedAt], [p].[EndDate], [p].[IsActive], [p].[LastModifiedAt], [p].[LastModifiedBy], [p].[Name], [p].[PhaseTypeId], [p].[SemesterId], [p].[StartDate], [p].[SubmissionDeadline], [u].[Id], [u].[AccessFailedCount], [u].[ConcurrencyStamp], [u].[CreatedAt], [u].[DeletedAt], [u].[Email], [u].[EmailConfirmed], [u].[LastModifiedAt], [u].[LastModifiedBy], [u].[LockoutEnabled], [u].[LockoutEnd], [u].[NormalizedEmail], [u].[NormalizedUserName], [u].[PasswordHash], [u].[PhoneNumber], [u].[PhoneNumberConfirmed], [u].[SecurityStamp], [u].[TwoFactorEnabled], [u].[UserName], [r].[Id], [r].[AssignedAt], [r].[AssignedBy], [r].[AssignmentType], [r].[CompletedAt], [r].[Deadline], [r].[ReviewerId], [r].[SkillMatchScore], [r].[StartedAt], [r].[Status], [r].[SubmissionId]
+FROM [submissions] AS [s]
+INNER JOIN [phases] AS [p] ON [s].[PhaseId] = [p].[Id]
+INNER JOIN [users] AS [u] ON [s].[SubmittedBy] = [u].[Id]
+LEFT JOIN [reviewer_assignments] AS [r] ON [s].[Id] = [r].[SubmissionId]
+WHERE [s].[TopicId] = @__topicId_0 AND [s].[IsActive] = CAST(1 AS bit) AND [s].[DeletedAt] IS NULL
+ORDER BY [s].[Id], [p].[Id], [u].[Id]
+2025-10-04 02:56:02.924 +07:00 [DBG] Closing data reader to 'capbot_db' on server 'localhost'.
+2025-10-04 02:56:02.925 +07:00 [DBG] A data reader for 'capbot_db' on server 'localhost' is being disposed after spending 0ms reading results.
+2025-10-04 02:56:02.925 +07:00 [DBG] Closing connection to database 'capbot_db' on server 'localhost'.
+2025-10-04 02:56:02.926 +07:00 [DBG] Closed connection to database 'capbot_db' on server 'localhost' (0ms).
+2025-10-04 02:56:02.929 +07:00 [DBG] Opening connection to database 'capbot_db' on server 'localhost'.
+2025-10-04 02:56:02.931 +07:00 [DBG] Opened connection to database 'capbot_db' on server 'localhost'.
+2025-10-04 02:56:02.933 +07:00 [DBG] Creating DbCommand for 'ExecuteReader'.
+2025-10-04 02:56:02.934 +07:00 [DBG] Created DbCommand for 'ExecuteReader' (1ms).
+2025-10-04 02:56:02.934 +07:00 [DBG] Initialized DbCommand for 'ExecuteReader' (1ms).
+2025-10-04 02:56:02.934 +07:00 [DBG] Executing DbCommand [Parameters=[@__p_0='?' (DbType = Int64)], CommandType='"Text"', CommandTimeout='30']
+SELECT TOP(1) [e].[Id], [e].[Caption], [e].[CreatedAt], [e].[EntityId], [e].[EntityType], [e].[FileId], [e].[IsPrimary], [f].[Id], [f].[Alt], [f].[Checksum], [f].[CreatedAt], [f].[CreatedBy], [f].[DeletedAt], [f].[FileName], [f].[FilePath], [f].[FileSize], [f].[FileType], [f].[Height], [f].[IsActive], [f].[LastModifiedAt], [f].[LastModifiedBy], [f].[MimeType], [f].[ThumbnailUrl], [f].[Url], [f].[Width]
+FROM [entity_files] AS [e]
+INNER JOIN [files] AS [f] ON [e].[FileId] = [f].[Id]
+WHERE [e].[EntityId] = @__p_0 AND [e].[EntityType] = 1 AND [e].[IsPrimary] = CAST(1 AS bit)
+2025-10-04 02:56:02.936 +07:00 [INF] Executed DbCommand (1ms) [Parameters=[@__p_0='?' (DbType = Int64)], CommandType='"Text"', CommandTimeout='30']
+SELECT TOP(1) [e].[Id], [e].[Caption], [e].[CreatedAt], [e].[EntityId], [e].[EntityType], [e].[FileId], [e].[IsPrimary], [f].[Id], [f].[Alt], [f].[Checksum], [f].[CreatedAt], [f].[CreatedBy], [f].[DeletedAt], [f].[FileName], [f].[FilePath], [f].[FileSize], [f].[FileType], [f].[Height], [f].[IsActive], [f].[LastModifiedAt], [f].[LastModifiedBy], [f].[MimeType], [f].[ThumbnailUrl], [f].[Url], [f].[Width]
+FROM [entity_files] AS [e]
+INNER JOIN [files] AS [f] ON [e].[FileId] = [f].[Id]
+WHERE [e].[EntityId] = @__p_0 AND [e].[EntityType] = 1 AND [e].[IsPrimary] = CAST(1 AS bit)
+2025-10-04 02:56:02.936 +07:00 [DBG] Closing data reader to 'capbot_db' on server 'localhost'.
+2025-10-04 02:56:02.936 +07:00 [DBG] A data reader for 'capbot_db' on server 'localhost' is being disposed after spending 0ms reading results.
+2025-10-04 02:56:02.936 +07:00 [DBG] Closing connection to database 'capbot_db' on server 'localhost'.
+2025-10-04 02:56:02.936 +07:00 [DBG] Closed connection to database 'capbot_db' on server 'localhost' (0ms).
+2025-10-04 02:56:02.936 +07:00 [DBG] List of registered output formatters, in the following order: ["Microsoft.AspNetCore.OData.Formatter.ODataOutputFormatter","Microsoft.AspNetCore.OData.Formatter.ODataOutputFormatter","Microsoft.AspNetCore.OData.Formatter.ODataOutputFormatter","Microsoft.AspNetCore.Mvc.Formatters.HttpNoContentOutputFormatter","Microsoft.AspNetCore.Mvc.Formatters.StringOutputFormatter","Microsoft.AspNetCore.Mvc.Formatters.StreamOutputFormatter","Microsoft.AspNetCore.Mvc.Formatters.SystemTextJsonOutputFormatter"]
+2025-10-04 02:56:02.937 +07:00 [DBG] No information found on request to perform content negotiation.
+2025-10-04 02:56:02.937 +07:00 [DBG] Attempting to select the first output formatter in the output formatters list which supports a content type from the explicitly specified content types '["application/json"]'.
+2025-10-04 02:56:02.937 +07:00 [DBG] Selected output formatter 'Microsoft.AspNetCore.Mvc.Formatters.SystemTextJsonOutputFormatter' and content type 'application/json' to write the response.
+2025-10-04 02:56:02.937 +07:00 [INF] Executing ObjectResult, writing value of type 'FS.Commons.FSResponse'.
+2025-10-04 02:56:02.937 +07:00 [INF] Executed action CapBot.api.Controllers.TopicController.GetDetail (CapBot.api) in 25.3072ms
+2025-10-04 02:56:02.937 +07:00 [INF] Executed endpoint 'CapBot.api.Controllers.TopicController.GetDetail (CapBot.api)'
+2025-10-04 02:56:02.938 +07:00 [DBG] Connection id "0HNG2MQC634J9" completed keep alive response.
+2025-10-04 02:56:02.938 +07:00 [DBG] 'MyDbContext' disposed.
+2025-10-04 02:56:02.938 +07:00 [DBG] Disposing connection to database 'capbot_db' on server 'localhost'.
+2025-10-04 02:56:02.938 +07:00 [DBG] Disposed connection to database '' on server '' (0ms).
+2025-10-04 02:56:02.938 +07:00 [INF] Request finished HTTP/1.1 GET http://localhost:5207/api/topic/detail/104 - 200 null application/json; charset=utf-8 36.233ms
+2025-10-04 02:56:03.476 +07:00 [INF] Request starting HTTP/1.1 GET http://localhost:5207/api/topic/detail/104 - null null
+2025-10-04 02:56:03.476 +07:00 [DBG] The request path /api/topic/detail/104 does not match a supported file type
+2025-10-04 02:56:03.476 +07:00 [DBG] The request path /api/topic/detail/104 does not match a supported file type
+2025-10-04 02:56:03.476 +07:00 [DBG] 1 candidate(s) found for the request path '/api/topic/detail/104'
+2025-10-04 02:56:03.476 +07:00 [DBG] Endpoint 'CapBot.api.Controllers.TopicController.GetDetail (CapBot.api)' with route pattern 'api/topic/detail/{topicId}' is valid for the request path '/api/topic/detail/104'
+2025-10-04 02:56:03.476 +07:00 [DBG] Request matched endpoint 'CapBot.api.Controllers.TopicController.GetDetail (CapBot.api)'
+2025-10-04 02:56:03.477 +07:00 [DBG] Successfully validated the token.
+2025-10-04 02:56:03.477 +07:00 [DBG] AuthenticationScheme: Bearer was successfully authenticated.
+2025-10-04 02:56:03.477 +07:00 [INF] Executing endpoint 'CapBot.api.Controllers.TopicController.GetDetail (CapBot.api)'
+2025-10-04 02:56:03.477 +07:00 [INF] Route matched with {action = "GetDetail", controller = "Topic"}. Executing controller action with signature System.Threading.Tasks.Task`1[Microsoft.AspNetCore.Mvc.IActionResult] GetDetail(Int32) on controller CapBot.api.Controllers.TopicController (CapBot.api).
+2025-10-04 02:56:03.477 +07:00 [DBG] Execution plan of authorization filters (in the following order): ["None"]
+2025-10-04 02:56:03.477 +07:00 [DBG] Execution plan of resource filters (in the following order): ["Microsoft.AspNetCore.Mvc.ConsumesAttribute"]
+2025-10-04 02:56:03.478 +07:00 [DBG] Execution plan of action filters (in the following order): ["Microsoft.AspNetCore.Mvc.ModelBinding.UnsupportedContentTypeFilter (Order: -3000)"]
+2025-10-04 02:56:03.478 +07:00 [DBG] Execution plan of exception filters (in the following order): ["None"]
+2025-10-04 02:56:03.478 +07:00 [DBG] Execution plan of result filters (in the following order): ["Microsoft.AspNetCore.Mvc.Infrastructure.ClientErrorResultFilter (Order: -2000)","Microsoft.AspNetCore.Mvc.ProducesAttribute (Order: 0)"]
+2025-10-04 02:56:03.478 +07:00 [DBG] Executing controller factory for controller CapBot.api.Controllers.TopicController (CapBot.api)
+2025-10-04 02:56:03.478 +07:00 [DBG] Executed controller factory for controller CapBot.api.Controllers.TopicController (CapBot.api)
+2025-10-04 02:56:03.478 +07:00 [DBG] Attempting to bind parameter 'topicId' of type 'System.Int32' ...
+2025-10-04 02:56:03.478 +07:00 [DBG] Attempting to bind parameter 'topicId' of type 'System.Int32' using the name 'topicId' in request data ...
+2025-10-04 02:56:03.478 +07:00 [DBG] Done attempting to bind parameter 'topicId' of type 'System.Int32'.
+2025-10-04 02:56:03.479 +07:00 [DBG] Done attempting to bind parameter 'topicId' of type 'System.Int32'.
+2025-10-04 02:56:03.479 +07:00 [DBG] Attempting to validate the bound parameter 'topicId' of type 'System.Int32' ...
+2025-10-04 02:56:03.479 +07:00 [DBG] Done attempting to validate the bound parameter 'topicId' of type 'System.Int32'.
+2025-10-04 02:56:03.479 +07:00 [DBG] Entity Framework Core 8.0.16 initialized 'MyDbContext' using provider 'Microsoft.EntityFrameworkCore.SqlServer:8.0.13' with options: MigrationsAssembly=App.DAL 
+2025-10-04 02:56:03.480 +07:00 [DBG] Creating DbConnection.
+2025-10-04 02:56:03.480 +07:00 [DBG] Created DbConnection. (0ms).
+2025-10-04 02:56:03.480 +07:00 [DBG] Opening connection to database 'capbot_db' on server 'localhost'.
+2025-10-04 02:56:03.480 +07:00 [DBG] Opened connection to database 'capbot_db' on server 'localhost'.
+2025-10-04 02:56:03.481 +07:00 [DBG] Creating DbCommand for 'ExecuteReader'.
+2025-10-04 02:56:03.481 +07:00 [DBG] Created DbCommand for 'ExecuteReader' (0ms).
+2025-10-04 02:56:03.481 +07:00 [DBG] Initialized DbCommand for 'ExecuteReader' (0ms).
+2025-10-04 02:56:03.481 +07:00 [DBG] Executing DbCommand [Parameters=[@__topicId_0='?' (DbType = Int32)], CommandType='"Text"', CommandTimeout='30']
+SELECT [t1].[Id], [t1].[Abbreviation], [t1].[CategoryId], [t1].[Content], [t1].[Context], [t1].[CreatedAt], [t1].[CreatedBy], [t1].[DeletedAt], [t1].[Description], [t1].[EN_Title], [t1].[IsActive], [t1].[IsApproved], [t1].[IsLegacy], [t1].[LastModifiedAt], [t1].[LastModifiedBy], [t1].[MaxStudents], [t1].[Objectives], [t1].[PotentialDuplicate], [t1].[Problem], [t1].[SemesterId], [t1].[SupervisorId], [t1].[VN_title], [t1].[Id0], [t1].[AccessFailedCount], [t1].[ConcurrencyStamp], [t1].[CreatedAt0], [t1].[DeletedAt0], [t1].[Email], [t1].[EmailConfirmed], [t1].[LastModifiedAt0], [t1].[LastModifiedBy0], [t1].[LockoutEnabled], [t1].[LockoutEnd], [t1].[NormalizedEmail], [t1].[NormalizedUserName], [t1].[PasswordHash], [t1].[PhoneNumber], [t1].[PhoneNumberConfirmed], [t1].[SecurityStamp], [t1].[TwoFactorEnabled], [t1].[UserName], [t1].[Id1], [t1].[CreatedAt1], [t1].[CreatedBy0], [t1].[DeletedAt1], [t1].[Description0], [t1].[IsActive0], [t1].[LastModifiedAt1], [t1].[LastModifiedBy1], [t1].[Name], [t1].[Id2], [t1].[CreatedAt2], [t1].[CreatedBy1], [t1].[DeletedAt2], [t1].[Description1], [t1].[EndDate], [t1].[IsActive1], [t1].[LastModifiedAt2], [t1].[LastModifiedBy2], [t1].[Name0], [t1].[StartDate], [t2].[Id], [t2].[Content], [t2].[Context], [t2].[CreatedAt], [t2].[CreatedBy], [t2].[DeletedAt], [t2].[Description], [t2].[DocumentUrl], [t2].[EN_Title], [t2].[ExpectedOutcomes], [t2].[IsActive], [t2].[LastModifiedAt], [t2].[LastModifiedBy], [t2].[Methodology], [t2].[Objectives], [t2].[PotentialDuplicate], [t2].[Problem], [t2].[Requirements], [t2].[Status], [t2].[SubmittedAt], [t2].[SubmittedBy], [t2].[TopicId], [t2].[VN_title], [t2].[VersionNumber]
+FROM (
+    SELECT TOP(1) [t].[Id], [t].[Abbreviation], [t].[CategoryId], [t].[Content], [t].[Context], [t].[CreatedAt], [t].[CreatedBy], [t].[DeletedAt], [t].[Description], [t].[EN_Title], [t].[IsActive], [t].[IsApproved], [t].[IsLegacy], [t].[LastModifiedAt], [t].[LastModifiedBy], [t].[MaxStudents], [t].[Objectives], [t].[PotentialDuplicate], [t].[Problem], [t].[SemesterId], [t].[SupervisorId], [t].[VN_title], [u].[Id] AS [Id0], [u].[AccessFailedCount], [u].[ConcurrencyStamp], [u].[CreatedAt] AS [CreatedAt0], [u].[DeletedAt] AS [DeletedAt0], [u].[Email], [u].[EmailConfirmed], [u].[LastModifiedAt] AS [LastModifiedAt0], [u].[LastModifiedBy] AS [LastModifiedBy0], [u].[LockoutEnabled], [u].[LockoutEnd], [u].[NormalizedEmail], [u].[NormalizedUserName], [u].[PasswordHash], [u].[PhoneNumber], [u].[PhoneNumberConfirmed], [u].[SecurityStamp], [u].[TwoFactorEnabled], [u].[UserName], [t0].[Id] AS [Id1], [t0].[CreatedAt] AS [CreatedAt1], [t0].[CreatedBy] AS [CreatedBy0], [t0].[DeletedAt] AS [DeletedAt1], [t0].[Description] AS [Description0], [t0].[IsActive] AS [IsActive0], [t0].[LastModifiedAt] AS [LastModifiedAt1], [t0].[LastModifiedBy] AS [LastModifiedBy1], [t0].[Name], [s].[Id] AS [Id2], [s].[CreatedAt] AS [CreatedAt2], [s].[CreatedBy] AS [CreatedBy1], [s].[DeletedAt] AS [DeletedAt2], [s].[Description] AS [Description1], [s].[EndDate], [s].[IsActive] AS [IsActive1], [s].[LastModifiedAt] AS [LastModifiedAt2], [s].[LastModifiedBy] AS [LastModifiedBy2], [s].[Name] AS [Name0], [s].[StartDate]
+    FROM [topics] AS [t]
+    INNER JOIN [users] AS [u] ON [t].[SupervisorId] = [u].[Id]
+    LEFT JOIN [topic_categories] AS [t0] ON [t].[CategoryId] = [t0].[Id]
+    INNER JOIN [semesters] AS [s] ON [t].[SemesterId] = [s].[Id]
+    WHERE [t].[Id] = @__topicId_0 AND [t].[IsActive] = CAST(1 AS bit) AND [t].[DeletedAt] IS NULL
+) AS [t1]
+LEFT JOIN [topic_versions] AS [t2] ON [t1].[Id] = [t2].[TopicId]
+ORDER BY [t1].[Id], [t1].[Id0], [t1].[Id1], [t1].[Id2]
+2025-10-04 02:56:03.483 +07:00 [INF] Executed DbCommand (2ms) [Parameters=[@__topicId_0='?' (DbType = Int32)], CommandType='"Text"', CommandTimeout='30']
+SELECT [t1].[Id], [t1].[Abbreviation], [t1].[CategoryId], [t1].[Content], [t1].[Context], [t1].[CreatedAt], [t1].[CreatedBy], [t1].[DeletedAt], [t1].[Description], [t1].[EN_Title], [t1].[IsActive], [t1].[IsApproved], [t1].[IsLegacy], [t1].[LastModifiedAt], [t1].[LastModifiedBy], [t1].[MaxStudents], [t1].[Objectives], [t1].[PotentialDuplicate], [t1].[Problem], [t1].[SemesterId], [t1].[SupervisorId], [t1].[VN_title], [t1].[Id0], [t1].[AccessFailedCount], [t1].[ConcurrencyStamp], [t1].[CreatedAt0], [t1].[DeletedAt0], [t1].[Email], [t1].[EmailConfirmed], [t1].[LastModifiedAt0], [t1].[LastModifiedBy0], [t1].[LockoutEnabled], [t1].[LockoutEnd], [t1].[NormalizedEmail], [t1].[NormalizedUserName], [t1].[PasswordHash], [t1].[PhoneNumber], [t1].[PhoneNumberConfirmed], [t1].[SecurityStamp], [t1].[TwoFactorEnabled], [t1].[UserName], [t1].[Id1], [t1].[CreatedAt1], [t1].[CreatedBy0], [t1].[DeletedAt1], [t1].[Description0], [t1].[IsActive0], [t1].[LastModifiedAt1], [t1].[LastModifiedBy1], [t1].[Name], [t1].[Id2], [t1].[CreatedAt2], [t1].[CreatedBy1], [t1].[DeletedAt2], [t1].[Description1], [t1].[EndDate], [t1].[IsActive1], [t1].[LastModifiedAt2], [t1].[LastModifiedBy2], [t1].[Name0], [t1].[StartDate], [t2].[Id], [t2].[Content], [t2].[Context], [t2].[CreatedAt], [t2].[CreatedBy], [t2].[DeletedAt], [t2].[Description], [t2].[DocumentUrl], [t2].[EN_Title], [t2].[ExpectedOutcomes], [t2].[IsActive], [t2].[LastModifiedAt], [t2].[LastModifiedBy], [t2].[Methodology], [t2].[Objectives], [t2].[PotentialDuplicate], [t2].[Problem], [t2].[Requirements], [t2].[Status], [t2].[SubmittedAt], [t2].[SubmittedBy], [t2].[TopicId], [t2].[VN_title], [t2].[VersionNumber]
+FROM (
+    SELECT TOP(1) [t].[Id], [t].[Abbreviation], [t].[CategoryId], [t].[Content], [t].[Context], [t].[CreatedAt], [t].[CreatedBy], [t].[DeletedAt], [t].[Description], [t].[EN_Title], [t].[IsActive], [t].[IsApproved], [t].[IsLegacy], [t].[LastModifiedAt], [t].[LastModifiedBy], [t].[MaxStudents], [t].[Objectives], [t].[PotentialDuplicate], [t].[Problem], [t].[SemesterId], [t].[SupervisorId], [t].[VN_title], [u].[Id] AS [Id0], [u].[AccessFailedCount], [u].[ConcurrencyStamp], [u].[CreatedAt] AS [CreatedAt0], [u].[DeletedAt] AS [DeletedAt0], [u].[Email], [u].[EmailConfirmed], [u].[LastModifiedAt] AS [LastModifiedAt0], [u].[LastModifiedBy] AS [LastModifiedBy0], [u].[LockoutEnabled], [u].[LockoutEnd], [u].[NormalizedEmail], [u].[NormalizedUserName], [u].[PasswordHash], [u].[PhoneNumber], [u].[PhoneNumberConfirmed], [u].[SecurityStamp], [u].[TwoFactorEnabled], [u].[UserName], [t0].[Id] AS [Id1], [t0].[CreatedAt] AS [CreatedAt1], [t0].[CreatedBy] AS [CreatedBy0], [t0].[DeletedAt] AS [DeletedAt1], [t0].[Description] AS [Description0], [t0].[IsActive] AS [IsActive0], [t0].[LastModifiedAt] AS [LastModifiedAt1], [t0].[LastModifiedBy] AS [LastModifiedBy1], [t0].[Name], [s].[Id] AS [Id2], [s].[CreatedAt] AS [CreatedAt2], [s].[CreatedBy] AS [CreatedBy1], [s].[DeletedAt] AS [DeletedAt2], [s].[Description] AS [Description1], [s].[EndDate], [s].[IsActive] AS [IsActive1], [s].[LastModifiedAt] AS [LastModifiedAt2], [s].[LastModifiedBy] AS [LastModifiedBy2], [s].[Name] AS [Name0], [s].[StartDate]
+    FROM [topics] AS [t]
+    INNER JOIN [users] AS [u] ON [t].[SupervisorId] = [u].[Id]
+    LEFT JOIN [topic_categories] AS [t0] ON [t].[CategoryId] = [t0].[Id]
+    INNER JOIN [semesters] AS [s] ON [t].[SemesterId] = [s].[Id]
+    WHERE [t].[Id] = @__topicId_0 AND [t].[IsActive] = CAST(1 AS bit) AND [t].[DeletedAt] IS NULL
+) AS [t1]
+LEFT JOIN [topic_versions] AS [t2] ON [t1].[Id] = [t2].[TopicId]
+ORDER BY [t1].[Id], [t1].[Id0], [t1].[Id1], [t1].[Id2]
+2025-10-04 02:56:03.484 +07:00 [DBG] Closing data reader to 'capbot_db' on server 'localhost'.
+2025-10-04 02:56:03.484 +07:00 [DBG] A data reader for 'capbot_db' on server 'localhost' is being disposed after spending 0ms reading results.
+2025-10-04 02:56:03.484 +07:00 [DBG] Closing connection to database 'capbot_db' on server 'localhost'.
+2025-10-04 02:56:03.484 +07:00 [DBG] Closed connection to database 'capbot_db' on server 'localhost' (0ms).
+2025-10-04 02:56:03.485 +07:00 [DBG] Opening connection to database 'capbot_db' on server 'localhost'.
+2025-10-04 02:56:03.485 +07:00 [DBG] Opened connection to database 'capbot_db' on server 'localhost'.
+2025-10-04 02:56:03.485 +07:00 [DBG] Creating DbCommand for 'ExecuteReader'.
+2025-10-04 02:56:03.485 +07:00 [DBG] Created DbCommand for 'ExecuteReader' (0ms).
+2025-10-04 02:56:03.485 +07:00 [DBG] Initialized DbCommand for 'ExecuteReader' (0ms).
+2025-10-04 02:56:03.485 +07:00 [DBG] Executing DbCommand [Parameters=[@__topicId_0='?' (DbType = Int32)], CommandType='"Text"', CommandTimeout='30']
+SELECT [s].[Id], [s].[AdditionalNotes], [s].[AiCheckDetails], [s].[AiCheckScore], [s].[AiCheckStatus], [s].[CreatedAt], [s].[CreatedBy], [s].[DeletedAt], [s].[DocumentUrl], [s].[IsActive], [s].[LastModifiedAt], [s].[LastModifiedBy], [s].[PhaseId], [s].[Status], [s].[SubmissionRound], [s].[SubmittedAt], [s].[SubmittedBy], [s].[TopicId], [s].[TopicVersionId], [p].[Id], [p].[CreatedAt], [p].[CreatedBy], [p].[DeletedAt], [p].[EndDate], [p].[IsActive], [p].[LastModifiedAt], [p].[LastModifiedBy], [p].[Name], [p].[PhaseTypeId], [p].[SemesterId], [p].[StartDate], [p].[SubmissionDeadline], [u].[Id], [u].[AccessFailedCount], [u].[ConcurrencyStamp], [u].[CreatedAt], [u].[DeletedAt], [u].[Email], [u].[EmailConfirmed], [u].[LastModifiedAt], [u].[LastModifiedBy], [u].[LockoutEnabled], [u].[LockoutEnd], [u].[NormalizedEmail], [u].[NormalizedUserName], [u].[PasswordHash], [u].[PhoneNumber], [u].[PhoneNumberConfirmed], [u].[SecurityStamp], [u].[TwoFactorEnabled], [u].[UserName], [r].[Id], [r].[AssignedAt], [r].[AssignedBy], [r].[AssignmentType], [r].[CompletedAt], [r].[Deadline], [r].[ReviewerId], [r].[SkillMatchScore], [r].[StartedAt], [r].[Status], [r].[SubmissionId]
+FROM [submissions] AS [s]
+INNER JOIN [phases] AS [p] ON [s].[PhaseId] = [p].[Id]
+INNER JOIN [users] AS [u] ON [s].[SubmittedBy] = [u].[Id]
+LEFT JOIN [reviewer_assignments] AS [r] ON [s].[Id] = [r].[SubmissionId]
+WHERE [s].[TopicId] = @__topicId_0 AND [s].[IsActive] = CAST(1 AS bit) AND [s].[DeletedAt] IS NULL
+ORDER BY [s].[Id], [p].[Id], [u].[Id]
+2025-10-04 02:56:03.487 +07:00 [INF] Executed DbCommand (1ms) [Parameters=[@__topicId_0='?' (DbType = Int32)], CommandType='"Text"', CommandTimeout='30']
+SELECT [s].[Id], [s].[AdditionalNotes], [s].[AiCheckDetails], [s].[AiCheckScore], [s].[AiCheckStatus], [s].[CreatedAt], [s].[CreatedBy], [s].[DeletedAt], [s].[DocumentUrl], [s].[IsActive], [s].[LastModifiedAt], [s].[LastModifiedBy], [s].[PhaseId], [s].[Status], [s].[SubmissionRound], [s].[SubmittedAt], [s].[SubmittedBy], [s].[TopicId], [s].[TopicVersionId], [p].[Id], [p].[CreatedAt], [p].[CreatedBy], [p].[DeletedAt], [p].[EndDate], [p].[IsActive], [p].[LastModifiedAt], [p].[LastModifiedBy], [p].[Name], [p].[PhaseTypeId], [p].[SemesterId], [p].[StartDate], [p].[SubmissionDeadline], [u].[Id], [u].[AccessFailedCount], [u].[ConcurrencyStamp], [u].[CreatedAt], [u].[DeletedAt], [u].[Email], [u].[EmailConfirmed], [u].[LastModifiedAt], [u].[LastModifiedBy], [u].[LockoutEnabled], [u].[LockoutEnd], [u].[NormalizedEmail], [u].[NormalizedUserName], [u].[PasswordHash], [u].[PhoneNumber], [u].[PhoneNumberConfirmed], [u].[SecurityStamp], [u].[TwoFactorEnabled], [u].[UserName], [r].[Id], [r].[AssignedAt], [r].[AssignedBy], [r].[AssignmentType], [r].[CompletedAt], [r].[Deadline], [r].[ReviewerId], [r].[SkillMatchScore], [r].[StartedAt], [r].[Status], [r].[SubmissionId]
+FROM [submissions] AS [s]
+INNER JOIN [phases] AS [p] ON [s].[PhaseId] = [p].[Id]
+INNER JOIN [users] AS [u] ON [s].[SubmittedBy] = [u].[Id]
+LEFT JOIN [reviewer_assignments] AS [r] ON [s].[Id] = [r].[SubmissionId]
+WHERE [s].[TopicId] = @__topicId_0 AND [s].[IsActive] = CAST(1 AS bit) AND [s].[DeletedAt] IS NULL
+ORDER BY [s].[Id], [p].[Id], [u].[Id]
+2025-10-04 02:56:03.487 +07:00 [DBG] Closing data reader to 'capbot_db' on server 'localhost'.
+2025-10-04 02:56:03.488 +07:00 [DBG] A data reader for 'capbot_db' on server 'localhost' is being disposed after spending 0ms reading results.
+2025-10-04 02:56:03.488 +07:00 [DBG] Closing connection to database 'capbot_db' on server 'localhost'.
+2025-10-04 02:56:03.488 +07:00 [DBG] Closed connection to database 'capbot_db' on server 'localhost' (0ms).
+2025-10-04 02:56:03.488 +07:00 [DBG] Opening connection to database 'capbot_db' on server 'localhost'.
+2025-10-04 02:56:03.489 +07:00 [DBG] Opened connection to database 'capbot_db' on server 'localhost'.
+2025-10-04 02:56:03.489 +07:00 [DBG] Creating DbCommand for 'ExecuteReader'.
+2025-10-04 02:56:03.489 +07:00 [DBG] Created DbCommand for 'ExecuteReader' (0ms).
+2025-10-04 02:56:03.489 +07:00 [DBG] Initialized DbCommand for 'ExecuteReader' (0ms).
+2025-10-04 02:56:03.489 +07:00 [DBG] Executing DbCommand [Parameters=[@__p_0='?' (DbType = Int64)], CommandType='"Text"', CommandTimeout='30']
+SELECT TOP(1) [e].[Id], [e].[Caption], [e].[CreatedAt], [e].[EntityId], [e].[EntityType], [e].[FileId], [e].[IsPrimary], [f].[Id], [f].[Alt], [f].[Checksum], [f].[CreatedAt], [f].[CreatedBy], [f].[DeletedAt], [f].[FileName], [f].[FilePath], [f].[FileSize], [f].[FileType], [f].[Height], [f].[IsActive], [f].[LastModifiedAt], [f].[LastModifiedBy], [f].[MimeType], [f].[ThumbnailUrl], [f].[Url], [f].[Width]
+FROM [entity_files] AS [e]
+INNER JOIN [files] AS [f] ON [e].[FileId] = [f].[Id]
+WHERE [e].[EntityId] = @__p_0 AND [e].[EntityType] = 1 AND [e].[IsPrimary] = CAST(1 AS bit)
+2025-10-04 02:56:03.493 +07:00 [INF] Executed DbCommand (3ms) [Parameters=[@__p_0='?' (DbType = Int64)], CommandType='"Text"', CommandTimeout='30']
+SELECT TOP(1) [e].[Id], [e].[Caption], [e].[CreatedAt], [e].[EntityId], [e].[EntityType], [e].[FileId], [e].[IsPrimary], [f].[Id], [f].[Alt], [f].[Checksum], [f].[CreatedAt], [f].[CreatedBy], [f].[DeletedAt], [f].[FileName], [f].[FilePath], [f].[FileSize], [f].[FileType], [f].[Height], [f].[IsActive], [f].[LastModifiedAt], [f].[LastModifiedBy], [f].[MimeType], [f].[ThumbnailUrl], [f].[Url], [f].[Width]
+FROM [entity_files] AS [e]
+INNER JOIN [files] AS [f] ON [e].[FileId] = [f].[Id]
+WHERE [e].[EntityId] = @__p_0 AND [e].[EntityType] = 1 AND [e].[IsPrimary] = CAST(1 AS bit)
+2025-10-04 02:56:03.493 +07:00 [DBG] Closing data reader to 'capbot_db' on server 'localhost'.
+2025-10-04 02:56:03.493 +07:00 [DBG] A data reader for 'capbot_db' on server 'localhost' is being disposed after spending 0ms reading results.
+2025-10-04 02:56:03.493 +07:00 [DBG] Closing connection to database 'capbot_db' on server 'localhost'.
+2025-10-04 02:56:03.494 +07:00 [DBG] Closed connection to database 'capbot_db' on server 'localhost' (0ms).
+2025-10-04 02:56:03.494 +07:00 [DBG] List of registered output formatters, in the following order: ["Microsoft.AspNetCore.OData.Formatter.ODataOutputFormatter","Microsoft.AspNetCore.OData.Formatter.ODataOutputFormatter","Microsoft.AspNetCore.OData.Formatter.ODataOutputFormatter","Microsoft.AspNetCore.Mvc.Formatters.HttpNoContentOutputFormatter","Microsoft.AspNetCore.Mvc.Formatters.StringOutputFormatter","Microsoft.AspNetCore.Mvc.Formatters.StreamOutputFormatter","Microsoft.AspNetCore.Mvc.Formatters.SystemTextJsonOutputFormatter"]
+2025-10-04 02:56:03.494 +07:00 [DBG] No information found on request to perform content negotiation.
+2025-10-04 02:56:03.495 +07:00 [DBG] Attempting to select the first output formatter in the output formatters list which supports a content type from the explicitly specified content types '["application/json"]'.
+2025-10-04 02:56:03.495 +07:00 [DBG] Selected output formatter 'Microsoft.AspNetCore.Mvc.Formatters.SystemTextJsonOutputFormatter' and content type 'application/json' to write the response.
+2025-10-04 02:56:03.495 +07:00 [INF] Executing ObjectResult, writing value of type 'FS.Commons.FSResponse'.
+2025-10-04 02:56:03.495 +07:00 [INF] Executed action CapBot.api.Controllers.TopicController.GetDetail (CapBot.api) in 17.6635ms
+2025-10-04 02:56:03.496 +07:00 [INF] Executed endpoint 'CapBot.api.Controllers.TopicController.GetDetail (CapBot.api)'
+2025-10-04 02:56:03.496 +07:00 [DBG] Connection id "0HNG2MQC634J9" completed keep alive response.
+2025-10-04 02:56:03.496 +07:00 [DBG] 'MyDbContext' disposed.
+2025-10-04 02:56:03.496 +07:00 [DBG] Disposing connection to database 'capbot_db' on server 'localhost'.
+2025-10-04 02:56:03.496 +07:00 [DBG] Disposed connection to database '' on server '' (0ms).
+2025-10-04 02:56:03.498 +07:00 [INF] Request finished HTTP/1.1 GET http://localhost:5207/api/topic/detail/104 - 200 null application/json; charset=utf-8 22.4251ms
+2025-10-04 02:56:07.278 +07:00 [DBG] HttpMessageHandler expired after 120000ms for client ''
+2025-10-04 02:56:17.284 +07:00 [DBG] Starting HttpMessageHandler cleanup cycle with 1 items
+2025-10-04 02:56:17.288 +07:00 [DBG] Ending HttpMessageHandler cleanup cycle after 0.2777ms - processed: 0 items - remaining: 1 items
+2025-10-04 02:56:21.995 +07:00 [DBG] Connection id "0HNG2MQC634J9" received FIN.
+2025-10-04 02:56:21.995 +07:00 [DBG] Connection id "0HNG2MQC634J9" sending FIN because: "The Socket transport's send loop completed gracefully."
+2025-10-04 02:56:21.996 +07:00 [DBG] Connection id "0HNG2MQC634J9" disconnecting.
+2025-10-04 02:56:21.998 +07:00 [DBG] Connection id "0HNG2MQC634J9" stopped.
+2025-10-04 02:56:27.292 +07:00 [DBG] Starting HttpMessageHandler cleanup cycle with 1 items
+2025-10-04 02:56:27.292 +07:00 [DBG] Ending HttpMessageHandler cleanup cycle after 0.0071ms - processed: 0 items - remaining: 1 items
+2025-10-04 02:56:37.292 +07:00 [DBG] Starting HttpMessageHandler cleanup cycle with 1 items
+2025-10-04 02:56:37.293 +07:00 [DBG] Ending HttpMessageHandler cleanup cycle after 0.0025ms - processed: 0 items - remaining: 1 items
+2025-10-04 02:56:47.307 +07:00 [DBG] Starting HttpMessageHandler cleanup cycle with 1 items
+2025-10-04 02:56:47.308 +07:00 [DBG] Ending HttpMessageHandler cleanup cycle after 0.0016ms - processed: 0 items - remaining: 1 items
+2025-10-04 02:56:57.324 +07:00 [DBG] Starting HttpMessageHandler cleanup cycle with 1 items
+2025-10-04 02:56:57.324 +07:00 [DBG] Ending HttpMessageHandler cleanup cycle after 0.0046ms - processed: 0 items - remaining: 1 items
+2025-10-04 02:57:07.333 +07:00 [DBG] Starting HttpMessageHandler cleanup cycle with 1 items
+2025-10-04 02:57:07.333 +07:00 [DBG] Ending HttpMessageHandler cleanup cycle after 0.0023ms - processed: 0 items - remaining: 1 items
+2025-10-04 02:57:17.334 +07:00 [DBG] Starting HttpMessageHandler cleanup cycle with 1 items
+2025-10-04 02:57:17.334 +07:00 [DBG] Ending HttpMessageHandler cleanup cycle after 0.0032ms - processed: 0 items - remaining: 1 items
+2025-10-04 02:57:27.350 +07:00 [DBG] Starting HttpMessageHandler cleanup cycle with 1 items
+2025-10-04 02:57:27.350 +07:00 [DBG] Ending HttpMessageHandler cleanup cycle after 0.0037ms - processed: 0 items - remaining: 1 items
+2025-10-04 02:57:37.363 +07:00 [DBG] Starting HttpMessageHandler cleanup cycle with 1 items
+2025-10-04 02:57:37.364 +07:00 [DBG] Ending HttpMessageHandler cleanup cycle after 0.0021ms - processed: 0 items - remaining: 1 items
+2025-10-04 02:57:47.383 +07:00 [DBG] Starting HttpMessageHandler cleanup cycle with 1 items
+2025-10-04 02:57:47.383 +07:00 [DBG] Ending HttpMessageHandler cleanup cycle after 0.0021ms - processed: 0 items - remaining: 1 items
+2025-10-04 02:57:57.389 +07:00 [DBG] Starting HttpMessageHandler cleanup cycle with 1 items
+2025-10-04 02:57:57.389 +07:00 [DBG] Ending HttpMessageHandler cleanup cycle after 0.0045ms - processed: 0 items - remaining: 1 items
+2025-10-04 02:58:07.399 +07:00 [DBG] Starting HttpMessageHandler cleanup cycle with 1 items
+2025-10-04 02:58:07.399 +07:00 [DBG] Ending HttpMessageHandler cleanup cycle after 0.0027ms - processed: 0 items - remaining: 1 items
+2025-10-04 02:58:17.409 +07:00 [DBG] Starting HttpMessageHandler cleanup cycle with 1 items
+2025-10-04 02:58:17.409 +07:00 [DBG] Ending HttpMessageHandler cleanup cycle after 0.0016ms - processed: 0 items - remaining: 1 items
+2025-10-04 02:58:27.424 +07:00 [DBG] Starting HttpMessageHandler cleanup cycle with 1 items
+2025-10-04 02:58:27.424 +07:00 [DBG] Ending HttpMessageHandler cleanup cycle after 0.002ms - processed: 0 items - remaining: 1 items
+2025-10-04 02:58:30.761 +07:00 [DBG] Connection id "0HNG2MQC634JA" accepted.
+2025-10-04 02:58:30.761 +07:00 [DBG] Connection id "0HNG2MQC634JA" started.
+2025-10-04 02:58:30.762 +07:00 [INF] Request starting HTTP/1.1 GET http://localhost:5207/api/topic/detail/117 - null null
+2025-10-04 02:58:30.762 +07:00 [DBG] The request path /api/topic/detail/117 does not match a supported file type
+2025-10-04 02:58:30.763 +07:00 [DBG] The request path /api/topic/detail/117 does not match a supported file type
+2025-10-04 02:58:30.763 +07:00 [DBG] 1 candidate(s) found for the request path '/api/topic/detail/117'
+2025-10-04 02:58:30.763 +07:00 [DBG] Endpoint 'CapBot.api.Controllers.TopicController.GetDetail (CapBot.api)' with route pattern 'api/topic/detail/{topicId}' is valid for the request path '/api/topic/detail/117'
+2025-10-04 02:58:30.763 +07:00 [DBG] Request matched endpoint 'CapBot.api.Controllers.TopicController.GetDetail (CapBot.api)'
+2025-10-04 02:58:30.764 +07:00 [DBG] Successfully validated the token.
+2025-10-04 02:58:30.764 +07:00 [DBG] AuthenticationScheme: Bearer was successfully authenticated.
+2025-10-04 02:58:30.764 +07:00 [INF] Executing endpoint 'CapBot.api.Controllers.TopicController.GetDetail (CapBot.api)'
+2025-10-04 02:58:30.764 +07:00 [INF] Route matched with {action = "GetDetail", controller = "Topic"}. Executing controller action with signature System.Threading.Tasks.Task`1[Microsoft.AspNetCore.Mvc.IActionResult] GetDetail(Int32) on controller CapBot.api.Controllers.TopicController (CapBot.api).
+2025-10-04 02:58:30.764 +07:00 [DBG] Execution plan of authorization filters (in the following order): ["None"]
+2025-10-04 02:58:30.764 +07:00 [DBG] Execution plan of resource filters (in the following order): ["Microsoft.AspNetCore.Mvc.ConsumesAttribute"]
+2025-10-04 02:58:30.764 +07:00 [DBG] Execution plan of action filters (in the following order): ["Microsoft.AspNetCore.Mvc.ModelBinding.UnsupportedContentTypeFilter (Order: -3000)"]
+2025-10-04 02:58:30.765 +07:00 [DBG] Execution plan of exception filters (in the following order): ["None"]
+2025-10-04 02:58:30.765 +07:00 [DBG] Execution plan of result filters (in the following order): ["Microsoft.AspNetCore.Mvc.Infrastructure.ClientErrorResultFilter (Order: -2000)","Microsoft.AspNetCore.Mvc.ProducesAttribute (Order: 0)"]
+2025-10-04 02:58:30.765 +07:00 [DBG] Executing controller factory for controller CapBot.api.Controllers.TopicController (CapBot.api)
+2025-10-04 02:58:30.766 +07:00 [DBG] Executed controller factory for controller CapBot.api.Controllers.TopicController (CapBot.api)
+2025-10-04 02:58:30.767 +07:00 [DBG] Attempting to bind parameter 'topicId' of type 'System.Int32' ...
+2025-10-04 02:58:30.767 +07:00 [DBG] Attempting to bind parameter 'topicId' of type 'System.Int32' using the name 'topicId' in request data ...
+2025-10-04 02:58:30.767 +07:00 [DBG] Done attempting to bind parameter 'topicId' of type 'System.Int32'.
+2025-10-04 02:58:30.767 +07:00 [DBG] Done attempting to bind parameter 'topicId' of type 'System.Int32'.
+2025-10-04 02:58:30.767 +07:00 [DBG] Attempting to validate the bound parameter 'topicId' of type 'System.Int32' ...
+2025-10-04 02:58:30.767 +07:00 [DBG] Done attempting to validate the bound parameter 'topicId' of type 'System.Int32'.
+2025-10-04 02:58:30.790 +07:00 [DBG] Entity Framework Core 8.0.16 initialized 'MyDbContext' using provider 'Microsoft.EntityFrameworkCore.SqlServer:8.0.13' with options: MigrationsAssembly=App.DAL 
+2025-10-04 02:58:30.791 +07:00 [DBG] Creating DbConnection.
+2025-10-04 02:58:30.794 +07:00 [DBG] Created DbConnection. (1ms).
+2025-10-04 02:58:30.795 +07:00 [DBG] Opening connection to database 'capbot_db' on server 'localhost'.
+2025-10-04 02:58:30.795 +07:00 [DBG] Opened connection to database 'capbot_db' on server 'localhost'.
+2025-10-04 02:58:30.795 +07:00 [DBG] Creating DbCommand for 'ExecuteReader'.
+2025-10-04 02:58:30.796 +07:00 [DBG] Created DbCommand for 'ExecuteReader' (0ms).
+2025-10-04 02:58:30.796 +07:00 [DBG] Initialized DbCommand for 'ExecuteReader' (0ms).
+2025-10-04 02:58:30.796 +07:00 [DBG] Executing DbCommand [Parameters=[@__topicId_0='?' (DbType = Int32)], CommandType='"Text"', CommandTimeout='30']
+SELECT [t1].[Id], [t1].[Abbreviation], [t1].[CategoryId], [t1].[Content], [t1].[Context], [t1].[CreatedAt], [t1].[CreatedBy], [t1].[DeletedAt], [t1].[Description], [t1].[EN_Title], [t1].[IsActive], [t1].[IsApproved], [t1].[IsLegacy], [t1].[LastModifiedAt], [t1].[LastModifiedBy], [t1].[MaxStudents], [t1].[Objectives], [t1].[PotentialDuplicate], [t1].[Problem], [t1].[SemesterId], [t1].[SupervisorId], [t1].[VN_title], [t1].[Id0], [t1].[AccessFailedCount], [t1].[ConcurrencyStamp], [t1].[CreatedAt0], [t1].[DeletedAt0], [t1].[Email], [t1].[EmailConfirmed], [t1].[LastModifiedAt0], [t1].[LastModifiedBy0], [t1].[LockoutEnabled], [t1].[LockoutEnd], [t1].[NormalizedEmail], [t1].[NormalizedUserName], [t1].[PasswordHash], [t1].[PhoneNumber], [t1].[PhoneNumberConfirmed], [t1].[SecurityStamp], [t1].[TwoFactorEnabled], [t1].[UserName], [t1].[Id1], [t1].[CreatedAt1], [t1].[CreatedBy0], [t1].[DeletedAt1], [t1].[Description0], [t1].[IsActive0], [t1].[LastModifiedAt1], [t1].[LastModifiedBy1], [t1].[Name], [t1].[Id2], [t1].[CreatedAt2], [t1].[CreatedBy1], [t1].[DeletedAt2], [t1].[Description1], [t1].[EndDate], [t1].[IsActive1], [t1].[LastModifiedAt2], [t1].[LastModifiedBy2], [t1].[Name0], [t1].[StartDate], [t2].[Id], [t2].[Content], [t2].[Context], [t2].[CreatedAt], [t2].[CreatedBy], [t2].[DeletedAt], [t2].[Description], [t2].[DocumentUrl], [t2].[EN_Title], [t2].[ExpectedOutcomes], [t2].[IsActive], [t2].[LastModifiedAt], [t2].[LastModifiedBy], [t2].[Methodology], [t2].[Objectives], [t2].[PotentialDuplicate], [t2].[Problem], [t2].[Requirements], [t2].[Status], [t2].[SubmittedAt], [t2].[SubmittedBy], [t2].[TopicId], [t2].[VN_title], [t2].[VersionNumber]
+FROM (
+    SELECT TOP(1) [t].[Id], [t].[Abbreviation], [t].[CategoryId], [t].[Content], [t].[Context], [t].[CreatedAt], [t].[CreatedBy], [t].[DeletedAt], [t].[Description], [t].[EN_Title], [t].[IsActive], [t].[IsApproved], [t].[IsLegacy], [t].[LastModifiedAt], [t].[LastModifiedBy], [t].[MaxStudents], [t].[Objectives], [t].[PotentialDuplicate], [t].[Problem], [t].[SemesterId], [t].[SupervisorId], [t].[VN_title], [u].[Id] AS [Id0], [u].[AccessFailedCount], [u].[ConcurrencyStamp], [u].[CreatedAt] AS [CreatedAt0], [u].[DeletedAt] AS [DeletedAt0], [u].[Email], [u].[EmailConfirmed], [u].[LastModifiedAt] AS [LastModifiedAt0], [u].[LastModifiedBy] AS [LastModifiedBy0], [u].[LockoutEnabled], [u].[LockoutEnd], [u].[NormalizedEmail], [u].[NormalizedUserName], [u].[PasswordHash], [u].[PhoneNumber], [u].[PhoneNumberConfirmed], [u].[SecurityStamp], [u].[TwoFactorEnabled], [u].[UserName], [t0].[Id] AS [Id1], [t0].[CreatedAt] AS [CreatedAt1], [t0].[CreatedBy] AS [CreatedBy0], [t0].[DeletedAt] AS [DeletedAt1], [t0].[Description] AS [Description0], [t0].[IsActive] AS [IsActive0], [t0].[LastModifiedAt] AS [LastModifiedAt1], [t0].[LastModifiedBy] AS [LastModifiedBy1], [t0].[Name], [s].[Id] AS [Id2], [s].[CreatedAt] AS [CreatedAt2], [s].[CreatedBy] AS [CreatedBy1], [s].[DeletedAt] AS [DeletedAt2], [s].[Description] AS [Description1], [s].[EndDate], [s].[IsActive] AS [IsActive1], [s].[LastModifiedAt] AS [LastModifiedAt2], [s].[LastModifiedBy] AS [LastModifiedBy2], [s].[Name] AS [Name0], [s].[StartDate]
+    FROM [topics] AS [t]
+    INNER JOIN [users] AS [u] ON [t].[SupervisorId] = [u].[Id]
+    LEFT JOIN [topic_categories] AS [t0] ON [t].[CategoryId] = [t0].[Id]
+    INNER JOIN [semesters] AS [s] ON [t].[SemesterId] = [s].[Id]
+    WHERE [t].[Id] = @__topicId_0 AND [t].[IsActive] = CAST(1 AS bit) AND [t].[DeletedAt] IS NULL
+) AS [t1]
+LEFT JOIN [topic_versions] AS [t2] ON [t1].[Id] = [t2].[TopicId]
+ORDER BY [t1].[Id], [t1].[Id0], [t1].[Id1], [t1].[Id2]
+2025-10-04 02:58:30.835 +07:00 [INF] Executed DbCommand (39ms) [Parameters=[@__topicId_0='?' (DbType = Int32)], CommandType='"Text"', CommandTimeout='30']
+SELECT [t1].[Id], [t1].[Abbreviation], [t1].[CategoryId], [t1].[Content], [t1].[Context], [t1].[CreatedAt], [t1].[CreatedBy], [t1].[DeletedAt], [t1].[Description], [t1].[EN_Title], [t1].[IsActive], [t1].[IsApproved], [t1].[IsLegacy], [t1].[LastModifiedAt], [t1].[LastModifiedBy], [t1].[MaxStudents], [t1].[Objectives], [t1].[PotentialDuplicate], [t1].[Problem], [t1].[SemesterId], [t1].[SupervisorId], [t1].[VN_title], [t1].[Id0], [t1].[AccessFailedCount], [t1].[ConcurrencyStamp], [t1].[CreatedAt0], [t1].[DeletedAt0], [t1].[Email], [t1].[EmailConfirmed], [t1].[LastModifiedAt0], [t1].[LastModifiedBy0], [t1].[LockoutEnabled], [t1].[LockoutEnd], [t1].[NormalizedEmail], [t1].[NormalizedUserName], [t1].[PasswordHash], [t1].[PhoneNumber], [t1].[PhoneNumberConfirmed], [t1].[SecurityStamp], [t1].[TwoFactorEnabled], [t1].[UserName], [t1].[Id1], [t1].[CreatedAt1], [t1].[CreatedBy0], [t1].[DeletedAt1], [t1].[Description0], [t1].[IsActive0], [t1].[LastModifiedAt1], [t1].[LastModifiedBy1], [t1].[Name], [t1].[Id2], [t1].[CreatedAt2], [t1].[CreatedBy1], [t1].[DeletedAt2], [t1].[Description1], [t1].[EndDate], [t1].[IsActive1], [t1].[LastModifiedAt2], [t1].[LastModifiedBy2], [t1].[Name0], [t1].[StartDate], [t2].[Id], [t2].[Content], [t2].[Context], [t2].[CreatedAt], [t2].[CreatedBy], [t2].[DeletedAt], [t2].[Description], [t2].[DocumentUrl], [t2].[EN_Title], [t2].[ExpectedOutcomes], [t2].[IsActive], [t2].[LastModifiedAt], [t2].[LastModifiedBy], [t2].[Methodology], [t2].[Objectives], [t2].[PotentialDuplicate], [t2].[Problem], [t2].[Requirements], [t2].[Status], [t2].[SubmittedAt], [t2].[SubmittedBy], [t2].[TopicId], [t2].[VN_title], [t2].[VersionNumber]
+FROM (
+    SELECT TOP(1) [t].[Id], [t].[Abbreviation], [t].[CategoryId], [t].[Content], [t].[Context], [t].[CreatedAt], [t].[CreatedBy], [t].[DeletedAt], [t].[Description], [t].[EN_Title], [t].[IsActive], [t].[IsApproved], [t].[IsLegacy], [t].[LastModifiedAt], [t].[LastModifiedBy], [t].[MaxStudents], [t].[Objectives], [t].[PotentialDuplicate], [t].[Problem], [t].[SemesterId], [t].[SupervisorId], [t].[VN_title], [u].[Id] AS [Id0], [u].[AccessFailedCount], [u].[ConcurrencyStamp], [u].[CreatedAt] AS [CreatedAt0], [u].[DeletedAt] AS [DeletedAt0], [u].[Email], [u].[EmailConfirmed], [u].[LastModifiedAt] AS [LastModifiedAt0], [u].[LastModifiedBy] AS [LastModifiedBy0], [u].[LockoutEnabled], [u].[LockoutEnd], [u].[NormalizedEmail], [u].[NormalizedUserName], [u].[PasswordHash], [u].[PhoneNumber], [u].[PhoneNumberConfirmed], [u].[SecurityStamp], [u].[TwoFactorEnabled], [u].[UserName], [t0].[Id] AS [Id1], [t0].[CreatedAt] AS [CreatedAt1], [t0].[CreatedBy] AS [CreatedBy0], [t0].[DeletedAt] AS [DeletedAt1], [t0].[Description] AS [Description0], [t0].[IsActive] AS [IsActive0], [t0].[LastModifiedAt] AS [LastModifiedAt1], [t0].[LastModifiedBy] AS [LastModifiedBy1], [t0].[Name], [s].[Id] AS [Id2], [s].[CreatedAt] AS [CreatedAt2], [s].[CreatedBy] AS [CreatedBy1], [s].[DeletedAt] AS [DeletedAt2], [s].[Description] AS [Description1], [s].[EndDate], [s].[IsActive] AS [IsActive1], [s].[LastModifiedAt] AS [LastModifiedAt2], [s].[LastModifiedBy] AS [LastModifiedBy2], [s].[Name] AS [Name0], [s].[StartDate]
+    FROM [topics] AS [t]
+    INNER JOIN [users] AS [u] ON [t].[SupervisorId] = [u].[Id]
+    LEFT JOIN [topic_categories] AS [t0] ON [t].[CategoryId] = [t0].[Id]
+    INNER JOIN [semesters] AS [s] ON [t].[SemesterId] = [s].[Id]
+    WHERE [t].[Id] = @__topicId_0 AND [t].[IsActive] = CAST(1 AS bit) AND [t].[DeletedAt] IS NULL
+) AS [t1]
+LEFT JOIN [topic_versions] AS [t2] ON [t1].[Id] = [t2].[TopicId]
+ORDER BY [t1].[Id], [t1].[Id0], [t1].[Id1], [t1].[Id2]
+2025-10-04 02:58:30.840 +07:00 [DBG] Closing data reader to 'capbot_db' on server 'localhost'.
+2025-10-04 02:58:30.840 +07:00 [DBG] A data reader for 'capbot_db' on server 'localhost' is being disposed after spending 4ms reading results.
+2025-10-04 02:58:30.841 +07:00 [DBG] Closing connection to database 'capbot_db' on server 'localhost'.
+2025-10-04 02:58:30.841 +07:00 [DBG] Closed connection to database 'capbot_db' on server 'localhost' (0ms).
+2025-10-04 02:58:30.842 +07:00 [DBG] Opening connection to database 'capbot_db' on server 'localhost'.
+2025-10-04 02:58:30.842 +07:00 [DBG] Opened connection to database 'capbot_db' on server 'localhost'.
+2025-10-04 02:58:30.842 +07:00 [DBG] Creating DbCommand for 'ExecuteReader'.
+2025-10-04 02:58:30.842 +07:00 [DBG] Created DbCommand for 'ExecuteReader' (0ms).
+2025-10-04 02:58:30.842 +07:00 [DBG] Initialized DbCommand for 'ExecuteReader' (0ms).
+2025-10-04 02:58:30.842 +07:00 [DBG] Executing DbCommand [Parameters=[@__topicId_0='?' (DbType = Int32)], CommandType='"Text"', CommandTimeout='30']
+SELECT [s].[Id], [s].[AdditionalNotes], [s].[AiCheckDetails], [s].[AiCheckScore], [s].[AiCheckStatus], [s].[CreatedAt], [s].[CreatedBy], [s].[DeletedAt], [s].[DocumentUrl], [s].[IsActive], [s].[LastModifiedAt], [s].[LastModifiedBy], [s].[PhaseId], [s].[Status], [s].[SubmissionRound], [s].[SubmittedAt], [s].[SubmittedBy], [s].[TopicId], [s].[TopicVersionId], [p].[Id], [p].[CreatedAt], [p].[CreatedBy], [p].[DeletedAt], [p].[EndDate], [p].[IsActive], [p].[LastModifiedAt], [p].[LastModifiedBy], [p].[Name], [p].[PhaseTypeId], [p].[SemesterId], [p].[StartDate], [p].[SubmissionDeadline], [u].[Id], [u].[AccessFailedCount], [u].[ConcurrencyStamp], [u].[CreatedAt], [u].[DeletedAt], [u].[Email], [u].[EmailConfirmed], [u].[LastModifiedAt], [u].[LastModifiedBy], [u].[LockoutEnabled], [u].[LockoutEnd], [u].[NormalizedEmail], [u].[NormalizedUserName], [u].[PasswordHash], [u].[PhoneNumber], [u].[PhoneNumberConfirmed], [u].[SecurityStamp], [u].[TwoFactorEnabled], [u].[UserName], [r].[Id], [r].[AssignedAt], [r].[AssignedBy], [r].[AssignmentType], [r].[CompletedAt], [r].[Deadline], [r].[ReviewerId], [r].[SkillMatchScore], [r].[StartedAt], [r].[Status], [r].[SubmissionId]
+FROM [submissions] AS [s]
+INNER JOIN [phases] AS [p] ON [s].[PhaseId] = [p].[Id]
+INNER JOIN [users] AS [u] ON [s].[SubmittedBy] = [u].[Id]
+LEFT JOIN [reviewer_assignments] AS [r] ON [s].[Id] = [r].[SubmissionId]
+WHERE [s].[TopicId] = @__topicId_0 AND [s].[IsActive] = CAST(1 AS bit) AND [s].[DeletedAt] IS NULL
+ORDER BY [s].[Id], [p].[Id], [u].[Id]
+2025-10-04 02:58:30.854 +07:00 [INF] Executed DbCommand (11ms) [Parameters=[@__topicId_0='?' (DbType = Int32)], CommandType='"Text"', CommandTimeout='30']
+SELECT [s].[Id], [s].[AdditionalNotes], [s].[AiCheckDetails], [s].[AiCheckScore], [s].[AiCheckStatus], [s].[CreatedAt], [s].[CreatedBy], [s].[DeletedAt], [s].[DocumentUrl], [s].[IsActive], [s].[LastModifiedAt], [s].[LastModifiedBy], [s].[PhaseId], [s].[Status], [s].[SubmissionRound], [s].[SubmittedAt], [s].[SubmittedBy], [s].[TopicId], [s].[TopicVersionId], [p].[Id], [p].[CreatedAt], [p].[CreatedBy], [p].[DeletedAt], [p].[EndDate], [p].[IsActive], [p].[LastModifiedAt], [p].[LastModifiedBy], [p].[Name], [p].[PhaseTypeId], [p].[SemesterId], [p].[StartDate], [p].[SubmissionDeadline], [u].[Id], [u].[AccessFailedCount], [u].[ConcurrencyStamp], [u].[CreatedAt], [u].[DeletedAt], [u].[Email], [u].[EmailConfirmed], [u].[LastModifiedAt], [u].[LastModifiedBy], [u].[LockoutEnabled], [u].[LockoutEnd], [u].[NormalizedEmail], [u].[NormalizedUserName], [u].[PasswordHash], [u].[PhoneNumber], [u].[PhoneNumberConfirmed], [u].[SecurityStamp], [u].[TwoFactorEnabled], [u].[UserName], [r].[Id], [r].[AssignedAt], [r].[AssignedBy], [r].[AssignmentType], [r].[CompletedAt], [r].[Deadline], [r].[ReviewerId], [r].[SkillMatchScore], [r].[StartedAt], [r].[Status], [r].[SubmissionId]
+FROM [submissions] AS [s]
+INNER JOIN [phases] AS [p] ON [s].[PhaseId] = [p].[Id]
+INNER JOIN [users] AS [u] ON [s].[SubmittedBy] = [u].[Id]
+LEFT JOIN [reviewer_assignments] AS [r] ON [s].[Id] = [r].[SubmissionId]
+WHERE [s].[TopicId] = @__topicId_0 AND [s].[IsActive] = CAST(1 AS bit) AND [s].[DeletedAt] IS NULL
+ORDER BY [s].[Id], [p].[Id], [u].[Id]
+2025-10-04 02:58:30.857 +07:00 [DBG] Closing data reader to 'capbot_db' on server 'localhost'.
+2025-10-04 02:58:30.858 +07:00 [DBG] A data reader for 'capbot_db' on server 'localhost' is being disposed after spending 3ms reading results.
+2025-10-04 02:58:30.858 +07:00 [DBG] Closing connection to database 'capbot_db' on server 'localhost'.
+2025-10-04 02:58:30.858 +07:00 [DBG] Closed connection to database 'capbot_db' on server 'localhost' (0ms).
+2025-10-04 02:58:30.861 +07:00 [DBG] Compiling query expression: 
+'DbSet<Review>()
+    .AsNoTracking()
+    .Where(r => __assignmentIds_0.Contains(r.AssignmentId) && r.IsActive)'
+2025-10-04 02:58:30.913 +07:00 [DBG] Generated query execution expression: 
+'queryContext => new SingleQueryingEnumerable<Review>(
+    (RelationalQueryContext)queryContext, 
+    RelationalCommandCache.QueryExpression(
+        Projection Mapping:
+            EmptyProjectionMember -> Dictionary<IProperty, int> { [Property: Review.Id (int) Required PK AfterSave:Throw ValueGenerated.OnAdd, 0], [Property: Review.AssignmentId (int) Required FK Index, 1], [Property: Review.CreatedAt (DateTime) Required ValueGenerated.OnAdd, 2], [Property: Review.CreatedBy (string), 3], [Property: Review.DeletedAt (DateTime?), 4], [Property: Review.IsActive (bool) Required, 5], [Property: Review.LastModifiedAt (DateTime?), 6], [Property: Review.LastModifiedBy (string), 7], [Property: Review.OverallComment (string), 8], [Property: Review.OverallScore (decimal?), 9], [Property: Review.Recommendation (ReviewRecommendations) Required Index ValueGenerated.OnAdd, 10], [Property: Review.Status (ReviewStatus) Required Index ValueGenerated.OnAdd, 11], [Property: Review.SubmittedAt (DateTime?) Index, 12], [Property: Review.TimeSpentMinutes (int?), 13] }
+        SELECT r.Id, r.AssignmentId, r.CreatedAt, r.CreatedBy, r.DeletedAt, r.IsActive, r.LastModifiedAt, r.LastModifiedBy, r.OverallComment, r.OverallScore, r.Recommendation, r.Status, r.SubmittedAt, r.TimeSpentMinutes
+        FROM reviews AS r
+        WHERE r.AssignmentId IN (
+            SELECT a.value
+            FROM OPENJSON(@__assignmentIds_0) WITH (value int '') AS a) && r.IsActive), 
+    null, 
+    Func<QueryContext, DbDataReader, ResultContext, SingleQueryResultCoordinator, Review>, 
+    App.DAL.Context.MyDbContext, 
+    False, 
+    False, 
+    True
+)'
+2025-10-04 02:58:30.921 +07:00 [DBG] Opening connection to database 'capbot_db' on server 'localhost'.
+2025-10-04 02:58:30.921 +07:00 [DBG] Opened connection to database 'capbot_db' on server 'localhost'.
+2025-10-04 02:58:30.921 +07:00 [DBG] Creating DbCommand for 'ExecuteReader'.
+2025-10-04 02:58:30.922 +07:00 [DBG] Created DbCommand for 'ExecuteReader' (0ms).
+2025-10-04 02:58:30.927 +07:00 [DBG] Initialized DbCommand for 'ExecuteReader' (5ms).
+2025-10-04 02:58:30.927 +07:00 [DBG] Executing DbCommand [Parameters=[@__assignmentIds_0='?' (Size = 4000)], CommandType='"Text"', CommandTimeout='30']
+SELECT [r].[Id], [r].[AssignmentId], [r].[CreatedAt], [r].[CreatedBy], [r].[DeletedAt], [r].[IsActive], [r].[LastModifiedAt], [r].[LastModifiedBy], [r].[OverallComment], [r].[OverallScore], [r].[Recommendation], [r].[Status], [r].[SubmittedAt], [r].[TimeSpentMinutes]
+FROM [reviews] AS [r]
+WHERE [r].[AssignmentId] IN (
+    SELECT [a].[value]
+    FROM OPENJSON(@__assignmentIds_0) WITH ([value] int '$') AS [a]
+) AND [r].[IsActive] = CAST(1 AS bit)
+2025-10-04 02:58:30.960 +07:00 [INF] Executed DbCommand (33ms) [Parameters=[@__assignmentIds_0='?' (Size = 4000)], CommandType='"Text"', CommandTimeout='30']
+SELECT [r].[Id], [r].[AssignmentId], [r].[CreatedAt], [r].[CreatedBy], [r].[DeletedAt], [r].[IsActive], [r].[LastModifiedAt], [r].[LastModifiedBy], [r].[OverallComment], [r].[OverallScore], [r].[Recommendation], [r].[Status], [r].[SubmittedAt], [r].[TimeSpentMinutes]
+FROM [reviews] AS [r]
+WHERE [r].[AssignmentId] IN (
+    SELECT [a].[value]
+    FROM OPENJSON(@__assignmentIds_0) WITH ([value] int '$') AS [a]
+) AND [r].[IsActive] = CAST(1 AS bit)
+2025-10-04 02:58:30.961 +07:00 [DBG] Closing data reader to 'capbot_db' on server 'localhost'.
+2025-10-04 02:58:30.962 +07:00 [DBG] A data reader for 'capbot_db' on server 'localhost' is being disposed after spending 1ms reading results.
+2025-10-04 02:58:30.962 +07:00 [DBG] Closing connection to database 'capbot_db' on server 'localhost'.
+2025-10-04 02:58:30.962 +07:00 [DBG] Closed connection to database 'capbot_db' on server 'localhost' (0ms).
+2025-10-04 02:58:30.965 +07:00 [DBG] Compiling query expression: 
+'DbSet<User>()
+    .AsNoTracking()
+    .Where(u => __reviewerIds_0.Contains(u.Id))'
+2025-10-04 02:58:30.974 +07:00 [DBG] Generated query execution expression: 
+'queryContext => new SingleQueryingEnumerable<User>(
+    (RelationalQueryContext)queryContext, 
+    RelationalCommandCache.QueryExpression(
+        Projection Mapping:
+            EmptyProjectionMember -> Dictionary<IProperty, int> { [Property: User.Id (int) Required PK AfterSave:Throw ValueGenerated.OnAdd, 0], [Property: User.AccessFailedCount (int) Required, 1], [Property: User.ConcurrencyStamp (string), 2], [Property: User.CreatedAt (DateTime) Required, 3], [Property: User.DeletedAt (DateTime?), 4], [Property: User.Email (string), 5], [Property: User.EmailConfirmed (bool) Required, 6], [Property: User.LastModifiedAt (DateTime) Required, 7], [Property: User.LastModifiedBy (string), 8], [Property: User.LockoutEnabled (bool) Required, 9], [Property: User.LockoutEnd (DateTimeOffset?), 10], [Property: User.NormalizedEmail (string), 11], [Property: User.NormalizedUserName (string), 12], [Property: User.PasswordHash (string), 13], [Property: User.PhoneNumber (string), 14], [Property: User.PhoneNumberConfirmed (bool) Required, 15], [Property: User.SecurityStamp (string), 16], [Property: User.TwoFactorEnabled (bool) Required, 17], [Property: User.UserName (string), 18] }
+        SELECT u.Id, u.AccessFailedCount, u.ConcurrencyStamp, u.CreatedAt, u.DeletedAt, u.Email, u.EmailConfirmed, u.LastModifiedAt, u.LastModifiedBy, u.LockoutEnabled, u.LockoutEnd, u.NormalizedEmail, u.NormalizedUserName, u.PasswordHash, u.PhoneNumber, u.PhoneNumberConfirmed, u.SecurityStamp, u.TwoFactorEnabled, u.UserName
+        FROM users AS u
+        WHERE u.Id IN (
+            SELECT r.value
+            FROM OPENJSON(@__reviewerIds_0) WITH (value int '') AS r)), 
+    null, 
+    Func<QueryContext, DbDataReader, ResultContext, SingleQueryResultCoordinator, User>, 
+    App.DAL.Context.MyDbContext, 
+    False, 
+    False, 
+    True
+)'
+2025-10-04 02:58:30.975 +07:00 [DBG] Opening connection to database 'capbot_db' on server 'localhost'.
+2025-10-04 02:58:30.975 +07:00 [DBG] Opened connection to database 'capbot_db' on server 'localhost'.
+2025-10-04 02:58:30.975 +07:00 [DBG] Creating DbCommand for 'ExecuteReader'.
+2025-10-04 02:58:30.975 +07:00 [DBG] Created DbCommand for 'ExecuteReader' (0ms).
+2025-10-04 02:58:30.976 +07:00 [DBG] Initialized DbCommand for 'ExecuteReader' (0ms).
+2025-10-04 02:58:30.976 +07:00 [DBG] Executing DbCommand [Parameters=[@__reviewerIds_0='?' (Size = 4000)], CommandType='"Text"', CommandTimeout='30']
+SELECT [u].[Id], [u].[AccessFailedCount], [u].[ConcurrencyStamp], [u].[CreatedAt], [u].[DeletedAt], [u].[Email], [u].[EmailConfirmed], [u].[LastModifiedAt], [u].[LastModifiedBy], [u].[LockoutEnabled], [u].[LockoutEnd], [u].[NormalizedEmail], [u].[NormalizedUserName], [u].[PasswordHash], [u].[PhoneNumber], [u].[PhoneNumberConfirmed], [u].[SecurityStamp], [u].[TwoFactorEnabled], [u].[UserName]
+FROM [users] AS [u]
+WHERE [u].[Id] IN (
+    SELECT [r].[value]
+    FROM OPENJSON(@__reviewerIds_0) WITH ([value] int '$') AS [r]
+)
+2025-10-04 02:58:30.985 +07:00 [INF] Executed DbCommand (10ms) [Parameters=[@__reviewerIds_0='?' (Size = 4000)], CommandType='"Text"', CommandTimeout='30']
+SELECT [u].[Id], [u].[AccessFailedCount], [u].[ConcurrencyStamp], [u].[CreatedAt], [u].[DeletedAt], [u].[Email], [u].[EmailConfirmed], [u].[LastModifiedAt], [u].[LastModifiedBy], [u].[LockoutEnabled], [u].[LockoutEnd], [u].[NormalizedEmail], [u].[NormalizedUserName], [u].[PasswordHash], [u].[PhoneNumber], [u].[PhoneNumberConfirmed], [u].[SecurityStamp], [u].[TwoFactorEnabled], [u].[UserName]
+FROM [users] AS [u]
+WHERE [u].[Id] IN (
+    SELECT [r].[value]
+    FROM OPENJSON(@__reviewerIds_0) WITH ([value] int '$') AS [r]
+)
+2025-10-04 02:58:30.986 +07:00 [DBG] Closing data reader to 'capbot_db' on server 'localhost'.
+2025-10-04 02:58:30.987 +07:00 [DBG] A data reader for 'capbot_db' on server 'localhost' is being disposed after spending 1ms reading results.
+2025-10-04 02:58:30.988 +07:00 [DBG] Closing connection to database 'capbot_db' on server 'localhost'.
+2025-10-04 02:58:30.989 +07:00 [DBG] Closed connection to database 'capbot_db' on server 'localhost' (1ms).
+2025-10-04 02:58:30.992 +07:00 [DBG] Opening connection to database 'capbot_db' on server 'localhost'.
+2025-10-04 02:58:30.992 +07:00 [DBG] Opened connection to database 'capbot_db' on server 'localhost'.
+2025-10-04 02:58:30.992 +07:00 [DBG] Creating DbCommand for 'ExecuteReader'.
+2025-10-04 02:58:30.992 +07:00 [DBG] Created DbCommand for 'ExecuteReader' (0ms).
+2025-10-04 02:58:30.992 +07:00 [DBG] Initialized DbCommand for 'ExecuteReader' (0ms).
+2025-10-04 02:58:30.992 +07:00 [DBG] Executing DbCommand [Parameters=[@__p_0='?' (DbType = Int64)], CommandType='"Text"', CommandTimeout='30']
+SELECT TOP(1) [e].[Id], [e].[Caption], [e].[CreatedAt], [e].[EntityId], [e].[EntityType], [e].[FileId], [e].[IsPrimary], [f].[Id], [f].[Alt], [f].[Checksum], [f].[CreatedAt], [f].[CreatedBy], [f].[DeletedAt], [f].[FileName], [f].[FilePath], [f].[FileSize], [f].[FileType], [f].[Height], [f].[IsActive], [f].[LastModifiedAt], [f].[LastModifiedBy], [f].[MimeType], [f].[ThumbnailUrl], [f].[Url], [f].[Width]
+FROM [entity_files] AS [e]
+INNER JOIN [files] AS [f] ON [e].[FileId] = [f].[Id]
+WHERE [e].[EntityId] = @__p_0 AND [e].[EntityType] = 1 AND [e].[IsPrimary] = CAST(1 AS bit)
+2025-10-04 02:58:31.000 +07:00 [INF] Executed DbCommand (8ms) [Parameters=[@__p_0='?' (DbType = Int64)], CommandType='"Text"', CommandTimeout='30']
+SELECT TOP(1) [e].[Id], [e].[Caption], [e].[CreatedAt], [e].[EntityId], [e].[EntityType], [e].[FileId], [e].[IsPrimary], [f].[Id], [f].[Alt], [f].[Checksum], [f].[CreatedAt], [f].[CreatedBy], [f].[DeletedAt], [f].[FileName], [f].[FilePath], [f].[FileSize], [f].[FileType], [f].[Height], [f].[IsActive], [f].[LastModifiedAt], [f].[LastModifiedBy], [f].[MimeType], [f].[ThumbnailUrl], [f].[Url], [f].[Width]
+FROM [entity_files] AS [e]
+INNER JOIN [files] AS [f] ON [e].[FileId] = [f].[Id]
+WHERE [e].[EntityId] = @__p_0 AND [e].[EntityType] = 1 AND [e].[IsPrimary] = CAST(1 AS bit)
+2025-10-04 02:58:31.002 +07:00 [DBG] Closing data reader to 'capbot_db' on server 'localhost'.
+2025-10-04 02:58:31.002 +07:00 [DBG] A data reader for 'capbot_db' on server 'localhost' is being disposed after spending 1ms reading results.
+2025-10-04 02:58:31.002 +07:00 [DBG] Closing connection to database 'capbot_db' on server 'localhost'.
+2025-10-04 02:58:31.002 +07:00 [DBG] Closed connection to database 'capbot_db' on server 'localhost' (0ms).
+2025-10-04 02:58:31.015 +07:00 [DBG] List of registered output formatters, in the following order: ["Microsoft.AspNetCore.OData.Formatter.ODataOutputFormatter","Microsoft.AspNetCore.OData.Formatter.ODataOutputFormatter","Microsoft.AspNetCore.OData.Formatter.ODataOutputFormatter","Microsoft.AspNetCore.Mvc.Formatters.HttpNoContentOutputFormatter","Microsoft.AspNetCore.Mvc.Formatters.StringOutputFormatter","Microsoft.AspNetCore.Mvc.Formatters.StreamOutputFormatter","Microsoft.AspNetCore.Mvc.Formatters.SystemTextJsonOutputFormatter"]
+2025-10-04 02:58:31.015 +07:00 [DBG] No information found on request to perform content negotiation.
+2025-10-04 02:58:31.015 +07:00 [DBG] Attempting to select the first output formatter in the output formatters list which supports a content type from the explicitly specified content types '["application/json"]'.
+2025-10-04 02:58:31.015 +07:00 [DBG] Selected output formatter 'Microsoft.AspNetCore.Mvc.Formatters.SystemTextJsonOutputFormatter' and content type 'application/json' to write the response.
+2025-10-04 02:58:31.015 +07:00 [INF] Executing ObjectResult, writing value of type 'FS.Commons.FSResponse'.
+2025-10-04 02:58:31.028 +07:00 [INF] Executed action CapBot.api.Controllers.TopicController.GetDetail (CapBot.api) in 263.2144ms
+2025-10-04 02:58:31.028 +07:00 [INF] Executed endpoint 'CapBot.api.Controllers.TopicController.GetDetail (CapBot.api)'
+2025-10-04 02:58:31.028 +07:00 [DBG] Connection id "0HNG2MQC634JA" completed keep alive response.
+2025-10-04 02:58:31.029 +07:00 [DBG] 'MyDbContext' disposed.
+2025-10-04 02:58:31.029 +07:00 [DBG] Disposing connection to database 'capbot_db' on server 'localhost'.
+2025-10-04 02:58:31.029 +07:00 [DBG] Disposed connection to database '' on server '' (0ms).
+2025-10-04 02:58:31.030 +07:00 [INF] Request finished HTTP/1.1 GET http://localhost:5207/api/topic/detail/117 - 200 null application/json; charset=utf-8 268.2753ms
+2025-10-04 02:58:37.433 +07:00 [DBG] Starting HttpMessageHandler cleanup cycle with 1 items
+2025-10-04 02:58:37.434 +07:00 [DBG] Ending HttpMessageHandler cleanup cycle after 0.0069ms - processed: 0 items - remaining: 1 items
+2025-10-04 02:58:47.435 +07:00 [DBG] Starting HttpMessageHandler cleanup cycle with 1 items
+2025-10-04 02:58:47.436 +07:00 [DBG] Ending HttpMessageHandler cleanup cycle after 0.0022ms - processed: 0 items - remaining: 1 items
+2025-10-04 02:58:57.455 +07:00 [DBG] Starting HttpMessageHandler cleanup cycle with 1 items
+2025-10-04 02:58:57.457 +07:00 [DBG] Ending HttpMessageHandler cleanup cycle after 0.003ms - processed: 0 items - remaining: 1 items
+2025-10-04 02:59:07.457 +07:00 [DBG] Starting HttpMessageHandler cleanup cycle with 1 items
+2025-10-04 02:59:07.458 +07:00 [DBG] Ending HttpMessageHandler cleanup cycle after 0.0016ms - processed: 0 items - remaining: 1 items
+2025-10-04 02:59:17.461 +07:00 [DBG] Starting HttpMessageHandler cleanup cycle with 1 items
+2025-10-04 02:59:17.461 +07:00 [DBG] Ending HttpMessageHandler cleanup cycle after 0.0047ms - processed: 0 items - remaining: 1 items
+2025-10-04 02:59:27.476 +07:00 [DBG] Starting HttpMessageHandler cleanup cycle with 1 items
+2025-10-04 02:59:27.476 +07:00 [DBG] Ending HttpMessageHandler cleanup cycle after 0.0019ms - processed: 0 items - remaining: 1 items
+2025-10-04 02:59:37.476 +07:00 [DBG] Starting HttpMessageHandler cleanup cycle with 1 items
+2025-10-04 02:59:37.476 +07:00 [DBG] Ending HttpMessageHandler cleanup cycle after 0.0019ms - processed: 0 items - remaining: 1 items
+2025-10-04 02:59:47.477 +07:00 [DBG] Starting HttpMessageHandler cleanup cycle with 1 items
+2025-10-04 02:59:47.478 +07:00 [DBG] Ending HttpMessageHandler cleanup cycle after 0.005ms - processed: 0 items - remaining: 1 items
+2025-10-04 02:59:57.487 +07:00 [DBG] Starting HttpMessageHandler cleanup cycle with 1 items
+2025-10-04 02:59:57.487 +07:00 [DBG] Ending HttpMessageHandler cleanup cycle after 0.0023ms - processed: 0 items - remaining: 1 items
+2025-10-04 03:00:07.486 +07:00 [DBG] Starting HttpMessageHandler cleanup cycle with 1 items
+2025-10-04 03:00:07.486 +07:00 [DBG] Ending HttpMessageHandler cleanup cycle after 0.002ms - processed: 0 items - remaining: 1 items
+2025-10-04 03:00:11.146 +07:00 [INF] Application is shutting down...
+2025-10-04 03:00:11.147 +07:00 [DBG] Hosting stopping
+2025-10-04 03:00:11.153 +07:00 [DBG] Connection id "0HNG2MQC634JA" disconnecting.
+2025-10-04 03:00:11.153 +07:00 [DBG] Connection id "0HNG2MQC634JA" stopped.
+2025-10-04 03:00:11.154 +07:00 [DBG] Connection id "0HNG2MQC634JA" sending FIN because: "The Socket transport's send loop completed gracefully."
+2025-10-04 03:00:11.159 +07:00 [ERR] Lỗi khi kiểm tra deadline notifications
+System.Threading.Tasks.TaskCanceledException: A task was canceled.
+   at CapBot.api.Services.DeadlineNotificationService.ExecuteAsync(CancellationToken stoppingToken) in C:\Users\acer\Downloads\CBAI_API\capbot.api\Services\DeadlineNotificationService.cs:line 41
+2025-10-04 03:00:11.193 +07:00 [DBG] Hosting stopped
+2025-10-04 03:02:15.243 +07:00 [DBG] An 'IServiceProvider' was created for internal use by Entity Framework.
+2025-10-04 03:02:15.351 +07:00 [INF] User profile is available. Using 'C:\Users\acer\AppData\Local\ASP.NET\DataProtection-Keys' as key repository and Windows DPAPI to encrypt keys at rest.
+2025-10-04 03:02:15.636 +07:00 [DBG] No relationship from 'ReviewerAssignment' to 'User' has been configured by convention because there are multiple properties on one entity type - {'AssignedByUser', 'Reviewer'} that could be matched with the properties on the other entity type - {'ReviewerAssignments'}. This message can be disregarded if explicit configuration has been specified in 'OnModelCreating'.
+2025-10-04 03:02:15.664 +07:00 [DBG] No relationship from 'SubmissionWorkflowLog' to 'WorkflowState' has been configured by convention because there are multiple properties on one entity type - {'FromState', 'ToState'} that could be matched with the properties on the other entity type - {'FromStateLogs', 'ToStateLogs'}. This message can be disregarded if explicit configuration has been specified in 'OnModelCreating'.
+2025-10-04 03:02:15.686 +07:00 [DBG] No relationship from 'User' to 'ReviewerAssignment' has been configured by convention because there are multiple properties on one entity type - {'ReviewerAssignments'} that could be matched with the properties on the other entity type - {'AssignedByUser', 'Reviewer'}. This message can be disregarded if explicit configuration has been specified in 'OnModelCreating'.
+2025-10-04 03:02:15.690 +07:00 [DBG] No relationship from 'WorkflowState' to 'SubmissionWorkflowLog' has been configured by convention because there are multiple properties on one entity type - {'FromStateLogs', 'ToStateLogs'} that could be matched with the properties on the other entity type - {'FromState', 'ToState'}. This message can be disregarded if explicit configuration has been specified in 'OnModelCreating'.
+2025-10-04 03:02:15.691 +07:00 [DBG] No relationship from 'WorkflowState' to 'WorkflowTransition' has been configured by convention because there are multiple properties on one entity type - {'FromTransitions', 'ToTransitions'} that could be matched with the properties on the other entity type - {'FromState', 'ToState'}. This message can be disregarded if explicit configuration has been specified in 'OnModelCreating'.
+2025-10-04 03:02:15.692 +07:00 [DBG] No relationship from 'WorkflowTransition' to 'WorkflowState' has been configured by convention because there are multiple properties on one entity type - {'FromState', 'ToState'} that could be matched with the properties on the other entity type - {'FromTransitions', 'ToTransitions'}. This message can be disregarded if explicit configuration has been specified in 'OnModelCreating'.
+2025-10-04 03:02:15.994 +07:00 [DBG] No relationship from 'ReviewerAssignment' to 'User' has been configured by convention because there are multiple properties on one entity type - {'AssignedByUser', 'Reviewer'} that could be matched with the properties on the other entity type - {'ReviewerAssignments'}. This message can be disregarded if explicit configuration has been specified in 'OnModelCreating'.
+2025-10-04 03:02:15.996 +07:00 [DBG] No relationship from 'User' to 'ReviewerAssignment' has been configured by convention because there are multiple properties on one entity type - {'ReviewerAssignments'} that could be matched with the properties on the other entity type - {'AssignedByUser', 'Reviewer'}. This message can be disregarded if explicit configuration has been specified in 'OnModelCreating'.
+2025-10-04 03:02:16.024 +07:00 [DBG] No relationship from 'WorkflowTransition' to 'WorkflowState' has been configured by convention because there are multiple properties on one entity type - {'FromState', 'ToState'} that could be matched with the properties on the other entity type - {'FromTransitions', 'ToTransitions'}. This message can be disregarded if explicit configuration has been specified in 'OnModelCreating'.
+2025-10-04 03:02:16.025 +07:00 [DBG] No relationship from 'WorkflowState' to 'SubmissionWorkflowLog' has been configured by convention because there are multiple properties on one entity type - {'FromStateLogs', 'ToStateLogs'} that could be matched with the properties on the other entity type - {'FromState', 'ToState'}. This message can be disregarded if explicit configuration has been specified in 'OnModelCreating'.
+2025-10-04 03:02:16.025 +07:00 [DBG] No relationship from 'WorkflowState' to 'WorkflowTransition' has been configured by convention because there are multiple properties on one entity type - {'FromTransitions', 'ToTransitions'} that could be matched with the properties on the other entity type - {'FromState', 'ToState'}. This message can be disregarded if explicit configuration has been specified in 'OnModelCreating'.
+2025-10-04 03:02:16.026 +07:00 [DBG] No relationship from 'WorkflowState' to 'SubmissionWorkflowLog' has been configured by convention because there are multiple properties on one entity type - {'FromStateLogs', 'ToStateLogs'} that could be matched with the properties on the other entity type - {'FromState', 'ToState'}. This message can be disregarded if explicit configuration has been specified in 'OnModelCreating'.
+2025-10-04 03:02:16.033 +07:00 [DBG] No relationship from 'SubmissionWorkflowLog' to 'WorkflowState' has been configured by convention because there are multiple properties on one entity type - {'FromState', 'ToState'} that could be matched with the properties on the other entity type - {'FromStateLogs', 'ToStateLogs'}. This message can be disregarded if explicit configuration has been specified in 'OnModelCreating'.
+2025-10-04 03:02:16.033 +07:00 [DBG] No relationship from 'WorkflowState' to 'SubmissionWorkflowLog' has been configured by convention because there are multiple properties on one entity type - {'FromStateLogs', 'ToStateLogs'} that could be matched with the properties on the other entity type - {'FromState', 'ToState'}. This message can be disregarded if explicit configuration has been specified in 'OnModelCreating'.
+2025-10-04 03:02:16.098 +07:00 [DBG] The index {'LecturerId'} was not created on entity type 'LecturerSkill' as the properties are already covered by the index {'LecturerId', 'SkillTag'}.
+2025-10-04 03:02:16.098 +07:00 [DBG] The index {'SemesterId'} was not created on entity type 'Phase' as the properties are already covered by the index {'SemesterId', 'PhaseTypeId'}.
+2025-10-04 03:02:16.098 +07:00 [DBG] The index {'AssignmentId'} was not created on entity type 'Review' as the properties are already covered by the index {'AssignmentId', 'Status'}.
+2025-10-04 03:02:16.099 +07:00 [DBG] The index {'ReviewId'} was not created on entity type 'ReviewComment' as the properties are already covered by the index {'ReviewId', 'SectionName'}.
+2025-10-04 03:02:16.099 +07:00 [DBG] The index {'ReviewId'} was not created on entity type 'ReviewCriteriaScore' as the properties are already covered by the index {'ReviewId', 'CriteriaId'}.
+2025-10-04 03:02:16.099 +07:00 [DBG] The index {'ReviewerId'} was not created on entity type 'ReviewerAssignment' as the properties are already covered by the index {'ReviewerId', 'Status'}.
+2025-10-04 03:02:16.099 +07:00 [DBG] The index {'SubmissionId'} was not created on entity type 'ReviewerAssignment' as the properties are already covered by the index {'SubmissionId', 'ReviewerId'}.
+2025-10-04 03:02:16.099 +07:00 [DBG] The index {'ReviewerId'} was not created on entity type 'ReviewerPerformance' as the properties are already covered by the index {'ReviewerId', 'SemesterId'}.
+2025-10-04 03:02:16.100 +07:00 [DBG] The index {'PhaseId'} was not created on entity type 'Submission' as the properties are already covered by the index {'PhaseId', 'Status'}.
+2025-10-04 03:02:16.100 +07:00 [DBG] The index {'PhaseId'} was not created on entity type 'Submission' as the properties are already covered by the index {'PhaseId', 'Status', 'SubmittedAt'}.
+2025-10-04 03:02:16.100 +07:00 [DBG] The index {'TopicId'} was not created on entity type 'Submission' as the properties are already covered by the index {'TopicId', 'PhaseId', 'SubmissionRound'}.
+2025-10-04 03:02:16.100 +07:00 [DBG] The index {'SubmissionId'} was not created on entity type 'SubmissionWorkflowLog' as the properties are already covered by the index {'SubmissionId', 'CreatedAt'}.
+2025-10-04 03:02:16.100 +07:00 [DBG] The index {'UserId'} was not created on entity type 'SystemNotification' as the properties are already covered by the index {'UserId', 'IsRead', 'CreatedAt'}.
+2025-10-04 03:02:16.100 +07:00 [DBG] The index {'SemesterId'} was not created on entity type 'Topic' as the properties are already covered by the index {'SemesterId', 'IsApproved'}.
+2025-10-04 03:02:16.100 +07:00 [DBG] The index {'SupervisorId'} was not created on entity type 'Topic' as the properties are already covered by the index {'SupervisorId', 'SemesterId'}.
+2025-10-04 03:02:16.101 +07:00 [DBG] The index {'TopicId'} was not created on entity type 'TopicVersion' as the properties are already covered by the index {'TopicId', 'Status'}.
+2025-10-04 03:02:16.101 +07:00 [DBG] The index {'TopicId'} was not created on entity type 'TopicVersion' as the properties are already covered by the index {'TopicId', 'VersionNumber'}.
+2025-10-04 03:02:16.101 +07:00 [DBG] The index {'UserId'} was not created on entity type 'UserRole' as the properties are already covered by the index {'UserId', 'RoleId'}.
+2025-10-04 03:02:16.101 +07:00 [DBG] The index {'UserId'} was not created on entity type 'UserToken' as the properties are already covered by the index {'UserId', 'LoginProvider', 'Name'}.
+2025-10-04 03:02:16.295 +07:00 [WRN] The 'ProficiencyLevels' property 'ProficiencyLevel' on entity type 'LecturerSkill' is configured with a database-generated default, but has no configured sentinel value. The database-generated default will always be used for inserts when the property has the value '0', since this is the CLR default for the 'ProficiencyLevels' type. Consider using a nullable type, using a nullable backing field, or setting the sentinel value for the property to ensure the database default is used when, and only when, appropriate. See https://aka.ms/efcore-docs-default-values for more information.
+2025-10-04 03:02:16.296 +07:00 [WRN] The 'ReviewRecommendations' property 'Recommendation' on entity type 'Review' is configured with a database-generated default, but has no configured sentinel value. The database-generated default will always be used for inserts when the property has the value '0', since this is the CLR default for the 'ReviewRecommendations' type. Consider using a nullable type, using a nullable backing field, or setting the sentinel value for the property to ensure the database default is used when, and only when, appropriate. See https://aka.ms/efcore-docs-default-values for more information.
+2025-10-04 03:02:16.296 +07:00 [WRN] The 'ReviewStatus' property 'Status' on entity type 'Review' is configured with a database-generated default, but has no configured sentinel value. The database-generated default will always be used for inserts when the property has the value '0', since this is the CLR default for the 'ReviewStatus' type. Consider using a nullable type, using a nullable backing field, or setting the sentinel value for the property to ensure the database default is used when, and only when, appropriate. See https://aka.ms/efcore-docs-default-values for more information.
+2025-10-04 03:02:16.296 +07:00 [WRN] The 'CommentTypes' property 'CommentType' on entity type 'ReviewComment' is configured with a database-generated default, but has no configured sentinel value. The database-generated default will always be used for inserts when the property has the value '0', since this is the CLR default for the 'CommentTypes' type. Consider using a nullable type, using a nullable backing field, or setting the sentinel value for the property to ensure the database default is used when, and only when, appropriate. See https://aka.ms/efcore-docs-default-values for more information.
+2025-10-04 03:02:16.296 +07:00 [WRN] The 'PriorityLevels' property 'Priority' on entity type 'ReviewComment' is configured with a database-generated default, but has no configured sentinel value. The database-generated default will always be used for inserts when the property has the value '0', since this is the CLR default for the 'PriorityLevels' type. Consider using a nullable type, using a nullable backing field, or setting the sentinel value for the property to ensure the database default is used when, and only when, appropriate. See https://aka.ms/efcore-docs-default-values for more information.
+2025-10-04 03:02:16.297 +07:00 [WRN] The 'AssignmentTypes' property 'AssignmentType' on entity type 'ReviewerAssignment' is configured with a database-generated default, but has no configured sentinel value. The database-generated default will always be used for inserts when the property has the value '0', since this is the CLR default for the 'AssignmentTypes' type. Consider using a nullable type, using a nullable backing field, or setting the sentinel value for the property to ensure the database default is used when, and only when, appropriate. See https://aka.ms/efcore-docs-default-values for more information.
+2025-10-04 03:02:16.297 +07:00 [WRN] The 'AssignmentStatus' property 'Status' on entity type 'ReviewerAssignment' is configured with a database-generated default, but has no configured sentinel value. The database-generated default will always be used for inserts when the property has the value '0', since this is the CLR default for the 'AssignmentStatus' type. Consider using a nullable type, using a nullable backing field, or setting the sentinel value for the property to ensure the database default is used when, and only when, appropriate. See https://aka.ms/efcore-docs-default-values for more information.
+2025-10-04 03:02:16.297 +07:00 [WRN] The 'AiCheckStatus' property 'AiCheckStatus' on entity type 'Submission' is configured with a database-generated default, but has no configured sentinel value. The database-generated default will always be used for inserts when the property has the value '0', since this is the CLR default for the 'AiCheckStatus' type. Consider using a nullable type, using a nullable backing field, or setting the sentinel value for the property to ensure the database default is used when, and only when, appropriate. See https://aka.ms/efcore-docs-default-values for more information.
+2025-10-04 03:02:16.297 +07:00 [WRN] The 'SubmissionStatus' property 'Status' on entity type 'Submission' is configured with a database-generated default, but has no configured sentinel value. The database-generated default will always be used for inserts when the property has the value '0', since this is the CLR default for the 'SubmissionStatus' type. Consider using a nullable type, using a nullable backing field, or setting the sentinel value for the property to ensure the database default is used when, and only when, appropriate. See https://aka.ms/efcore-docs-default-values for more information.
+2025-10-04 03:02:16.297 +07:00 [WRN] The 'NotificationTypes' property 'Type' on entity type 'SystemNotification' is configured with a database-generated default, but has no configured sentinel value. The database-generated default will always be used for inserts when the property has the value '0', since this is the CLR default for the 'NotificationTypes' type. Consider using a nullable type, using a nullable backing field, or setting the sentinel value for the property to ensure the database default is used when, and only when, appropriate. See https://aka.ms/efcore-docs-default-values for more information.
+2025-10-04 03:02:16.297 +07:00 [WRN] The 'TopicStatus' property 'Status' on entity type 'TopicVersion' is configured with a database-generated default, but has no configured sentinel value. The database-generated default will always be used for inserts when the property has the value '0', since this is the CLR default for the 'TopicStatus' type. Consider using a nullable type, using a nullable backing field, or setting the sentinel value for the property to ensure the database default is used when, and only when, appropriate. See https://aka.ms/efcore-docs-default-values for more information.
+2025-10-04 03:02:16.509 +07:00 [DBG] Entity Framework Core 8.0.16 initialized 'MyDbContext' using provider 'Microsoft.EntityFrameworkCore.SqlServer:8.0.13' with options: MigrationsAssembly=App.DAL 
+2025-10-04 03:02:16.595 +07:00 [DBG] Compiling query expression: 
+'DbSet<Role>()
+    .FirstOrDefault(r => r.NormalizedName == __normalizedName_0)'
+2025-10-04 03:02:16.772 +07:00 [DBG] Generated query execution expression: 
+'queryContext => ShapedQueryCompilingExpressionVisitor.SingleOrDefaultAsync<Role>(
+    asyncEnumerable: new SingleQueryingEnumerable<Role>(
+        (RelationalQueryContext)queryContext, 
+        RelationalCommandCache.QueryExpression(
+            Projection Mapping:
+                EmptyProjectionMember -> Dictionary<IProperty, int> { [Property: Role.Id (int) Required PK AfterSave:Throw ValueGenerated.OnAdd, 0], [Property: Role.ConcurrencyStamp (string), 1], [Property: Role.IsAdmin (bool) Required, 2], [Property: Role.Name (string), 3], [Property: Role.NormalizedName (string), 4] }
+            SELECT TOP(1) r.Id, r.ConcurrencyStamp, r.IsAdmin, r.Name, r.NormalizedName
+            FROM roles AS r
+            WHERE r.NormalizedName == @__normalizedName_0), 
+        null, 
+        Func<QueryContext, DbDataReader, ResultContext, SingleQueryResultCoordinator, Role>, 
+        App.DAL.Context.MyDbContext, 
+        False, 
+        False, 
+        True
+    ), 
+    cancellationToken: queryContext.CancellationToken)'
+2025-10-04 03:02:16.817 +07:00 [DBG] Creating DbConnection.
+2025-10-04 03:02:16.835 +07:00 [DBG] Created DbConnection. (15ms).
+2025-10-04 03:02:16.842 +07:00 [DBG] Opening connection to database 'capbot_db' on server 'localhost'.
+2025-10-04 03:02:17.016 +07:00 [DBG] Opened connection to database 'capbot_db' on server 'localhost'.
+2025-10-04 03:02:17.019 +07:00 [DBG] Creating DbCommand for 'ExecuteReader'.
+2025-10-04 03:02:17.026 +07:00 [DBG] Created DbCommand for 'ExecuteReader' (4ms).
+2025-10-04 03:02:17.033 +07:00 [DBG] Initialized DbCommand for 'ExecuteReader' (13ms).
+2025-10-04 03:02:17.041 +07:00 [DBG] Executing DbCommand [Parameters=[@__normalizedName_0='?' (Size = 4000)], CommandType='"Text"', CommandTimeout='30']
+SELECT TOP(1) [r].[Id], [r].[ConcurrencyStamp], [r].[IsAdmin], [r].[Name], [r].[NormalizedName]
+FROM [roles] AS [r]
+WHERE [r].[NormalizedName] = @__normalizedName_0
+2025-10-04 03:02:17.099 +07:00 [INF] Executed DbCommand (59ms) [Parameters=[@__normalizedName_0='?' (Size = 4000)], CommandType='"Text"', CommandTimeout='30']
+SELECT TOP(1) [r].[Id], [r].[ConcurrencyStamp], [r].[IsAdmin], [r].[Name], [r].[NormalizedName]
+FROM [roles] AS [r]
+WHERE [r].[NormalizedName] = @__normalizedName_0
+2025-10-04 03:02:17.148 +07:00 [DBG] Context 'MyDbContext' started tracking 'Role' entity. Consider using 'DbContextOptionsBuilder.EnableSensitiveDataLogging' to see key values.
+2025-10-04 03:02:17.183 +07:00 [DBG] Closing data reader to 'capbot_db' on server 'localhost'.
+2025-10-04 03:02:17.194 +07:00 [DBG] A data reader for 'capbot_db' on server 'localhost' is being disposed after spending 86ms reading results.
+2025-10-04 03:02:17.197 +07:00 [DBG] Closing connection to database 'capbot_db' on server 'localhost'.
+2025-10-04 03:02:17.201 +07:00 [DBG] Closed connection to database 'capbot_db' on server 'localhost' (4ms).
+2025-10-04 03:02:17.207 +07:00 [DBG] Opening connection to database 'capbot_db' on server 'localhost'.
+2025-10-04 03:02:17.208 +07:00 [DBG] Opened connection to database 'capbot_db' on server 'localhost'.
+2025-10-04 03:02:17.208 +07:00 [DBG] Creating DbCommand for 'ExecuteReader'.
+2025-10-04 03:02:17.208 +07:00 [DBG] Created DbCommand for 'ExecuteReader' (0ms).
+2025-10-04 03:02:17.208 +07:00 [DBG] Initialized DbCommand for 'ExecuteReader' (0ms).
+2025-10-04 03:02:17.208 +07:00 [DBG] Executing DbCommand [Parameters=[@__normalizedName_0='?' (Size = 4000)], CommandType='"Text"', CommandTimeout='30']
+SELECT TOP(1) [r].[Id], [r].[ConcurrencyStamp], [r].[IsAdmin], [r].[Name], [r].[NormalizedName]
+FROM [roles] AS [r]
+WHERE [r].[NormalizedName] = @__normalizedName_0
+2025-10-04 03:02:17.213 +07:00 [INF] Executed DbCommand (4ms) [Parameters=[@__normalizedName_0='?' (Size = 4000)], CommandType='"Text"', CommandTimeout='30']
+SELECT TOP(1) [r].[Id], [r].[ConcurrencyStamp], [r].[IsAdmin], [r].[Name], [r].[NormalizedName]
+FROM [roles] AS [r]
+WHERE [r].[NormalizedName] = @__normalizedName_0
+2025-10-04 03:02:17.213 +07:00 [DBG] Context 'MyDbContext' started tracking 'Role' entity. Consider using 'DbContextOptionsBuilder.EnableSensitiveDataLogging' to see key values.
+2025-10-04 03:02:17.214 +07:00 [DBG] Closing data reader to 'capbot_db' on server 'localhost'.
+2025-10-04 03:02:17.214 +07:00 [DBG] A data reader for 'capbot_db' on server 'localhost' is being disposed after spending 0ms reading results.
+2025-10-04 03:02:17.214 +07:00 [DBG] Closing connection to database 'capbot_db' on server 'localhost'.
+2025-10-04 03:02:17.214 +07:00 [DBG] Closed connection to database 'capbot_db' on server 'localhost' (0ms).
+2025-10-04 03:02:17.215 +07:00 [DBG] Opening connection to database 'capbot_db' on server 'localhost'.
+2025-10-04 03:02:17.215 +07:00 [DBG] Opened connection to database 'capbot_db' on server 'localhost'.
+2025-10-04 03:02:17.215 +07:00 [DBG] Creating DbCommand for 'ExecuteReader'.
+2025-10-04 03:02:17.216 +07:00 [DBG] Created DbCommand for 'ExecuteReader' (0ms).
+2025-10-04 03:02:17.216 +07:00 [DBG] Initialized DbCommand for 'ExecuteReader' (0ms).
+2025-10-04 03:02:17.216 +07:00 [DBG] Executing DbCommand [Parameters=[@__normalizedName_0='?' (Size = 4000)], CommandType='"Text"', CommandTimeout='30']
+SELECT TOP(1) [r].[Id], [r].[ConcurrencyStamp], [r].[IsAdmin], [r].[Name], [r].[NormalizedName]
+FROM [roles] AS [r]
+WHERE [r].[NormalizedName] = @__normalizedName_0
+2025-10-04 03:02:17.217 +07:00 [INF] Executed DbCommand (1ms) [Parameters=[@__normalizedName_0='?' (Size = 4000)], CommandType='"Text"', CommandTimeout='30']
+SELECT TOP(1) [r].[Id], [r].[ConcurrencyStamp], [r].[IsAdmin], [r].[Name], [r].[NormalizedName]
+FROM [roles] AS [r]
+WHERE [r].[NormalizedName] = @__normalizedName_0
+2025-10-04 03:02:17.217 +07:00 [DBG] Context 'MyDbContext' started tracking 'Role' entity. Consider using 'DbContextOptionsBuilder.EnableSensitiveDataLogging' to see key values.
+2025-10-04 03:02:17.217 +07:00 [DBG] Closing data reader to 'capbot_db' on server 'localhost'.
+2025-10-04 03:02:17.217 +07:00 [DBG] A data reader for 'capbot_db' on server 'localhost' is being disposed after spending 0ms reading results.
+2025-10-04 03:02:17.218 +07:00 [DBG] Closing connection to database 'capbot_db' on server 'localhost'.
+2025-10-04 03:02:17.218 +07:00 [DBG] Closed connection to database 'capbot_db' on server 'localhost' (0ms).
+2025-10-04 03:02:17.218 +07:00 [DBG] Opening connection to database 'capbot_db' on server 'localhost'.
+2025-10-04 03:02:17.218 +07:00 [DBG] Opened connection to database 'capbot_db' on server 'localhost'.
+2025-10-04 03:02:17.218 +07:00 [DBG] Creating DbCommand for 'ExecuteReader'.
+2025-10-04 03:02:17.218 +07:00 [DBG] Created DbCommand for 'ExecuteReader' (0ms).
+2025-10-04 03:02:17.218 +07:00 [DBG] Initialized DbCommand for 'ExecuteReader' (0ms).
+2025-10-04 03:02:17.219 +07:00 [DBG] Executing DbCommand [Parameters=[@__normalizedName_0='?' (Size = 4000)], CommandType='"Text"', CommandTimeout='30']
+SELECT TOP(1) [r].[Id], [r].[ConcurrencyStamp], [r].[IsAdmin], [r].[Name], [r].[NormalizedName]
+FROM [roles] AS [r]
+WHERE [r].[NormalizedName] = @__normalizedName_0
+2025-10-04 03:02:17.220 +07:00 [INF] Executed DbCommand (1ms) [Parameters=[@__normalizedName_0='?' (Size = 4000)], CommandType='"Text"', CommandTimeout='30']
+SELECT TOP(1) [r].[Id], [r].[ConcurrencyStamp], [r].[IsAdmin], [r].[Name], [r].[NormalizedName]
+FROM [roles] AS [r]
+WHERE [r].[NormalizedName] = @__normalizedName_0
+2025-10-04 03:02:17.221 +07:00 [DBG] Context 'MyDbContext' started tracking 'Role' entity. Consider using 'DbContextOptionsBuilder.EnableSensitiveDataLogging' to see key values.
+2025-10-04 03:02:17.222 +07:00 [DBG] Closing data reader to 'capbot_db' on server 'localhost'.
+2025-10-04 03:02:17.222 +07:00 [DBG] A data reader for 'capbot_db' on server 'localhost' is being disposed after spending 1ms reading results.
+2025-10-04 03:02:17.223 +07:00 [DBG] Closing connection to database 'capbot_db' on server 'localhost'.
+2025-10-04 03:02:17.224 +07:00 [DBG] Closed connection to database 'capbot_db' on server 'localhost' (0ms).
+2025-10-04 03:02:17.230 +07:00 [DBG] Compiling query expression: 
+'DbSet<User>()
+    .SingleOrDefault(u => u.NormalizedEmail == __normalizedEmail_0)'
+2025-10-04 03:02:17.239 +07:00 [DBG] Generated query execution expression: 
+'queryContext => ShapedQueryCompilingExpressionVisitor.SingleOrDefaultAsync<User>(
+    asyncEnumerable: new SingleQueryingEnumerable<User>(
+        (RelationalQueryContext)queryContext, 
+        RelationalCommandCache.QueryExpression(
+            Projection Mapping:
+                EmptyProjectionMember -> Dictionary<IProperty, int> { [Property: User.Id (int) Required PK AfterSave:Throw ValueGenerated.OnAdd, 0], [Property: User.AccessFailedCount (int) Required, 1], [Property: User.ConcurrencyStamp (string), 2], [Property: User.CreatedAt (DateTime) Required, 3], [Property: User.DeletedAt (DateTime?), 4], [Property: User.Email (string), 5], [Property: User.EmailConfirmed (bool) Required, 6], [Property: User.LastModifiedAt (DateTime) Required, 7], [Property: User.LastModifiedBy (string), 8], [Property: User.LockoutEnabled (bool) Required, 9], [Property: User.LockoutEnd (DateTimeOffset?), 10], [Property: User.NormalizedEmail (string), 11], [Property: User.NormalizedUserName (string), 12], [Property: User.PasswordHash (string), 13], [Property: User.PhoneNumber (string), 14], [Property: User.PhoneNumberConfirmed (bool) Required, 15], [Property: User.SecurityStamp (string), 16], [Property: User.TwoFactorEnabled (bool) Required, 17], [Property: User.UserName (string), 18] }
+            SELECT TOP(2) u.Id, u.AccessFailedCount, u.ConcurrencyStamp, u.CreatedAt, u.DeletedAt, u.Email, u.EmailConfirmed, u.LastModifiedAt, u.LastModifiedBy, u.LockoutEnabled, u.LockoutEnd, u.NormalizedEmail, u.NormalizedUserName, u.PasswordHash, u.PhoneNumber, u.PhoneNumberConfirmed, u.SecurityStamp, u.TwoFactorEnabled, u.UserName
+            FROM users AS u
+            WHERE u.NormalizedEmail == @__normalizedEmail_0), 
+        null, 
+        Func<QueryContext, DbDataReader, ResultContext, SingleQueryResultCoordinator, User>, 
+        App.DAL.Context.MyDbContext, 
+        False, 
+        False, 
+        True
+    ), 
+    cancellationToken: queryContext.CancellationToken)'
+2025-10-04 03:02:17.241 +07:00 [DBG] Opening connection to database 'capbot_db' on server 'localhost'.
+2025-10-04 03:02:17.241 +07:00 [DBG] Opened connection to database 'capbot_db' on server 'localhost'.
+2025-10-04 03:02:17.241 +07:00 [DBG] Creating DbCommand for 'ExecuteReader'.
+2025-10-04 03:02:17.241 +07:00 [DBG] Created DbCommand for 'ExecuteReader' (0ms).
+2025-10-04 03:02:17.242 +07:00 [DBG] Initialized DbCommand for 'ExecuteReader' (0ms).
+2025-10-04 03:02:17.242 +07:00 [DBG] Executing DbCommand [Parameters=[@__normalizedEmail_0='?' (Size = 4000)], CommandType='"Text"', CommandTimeout='30']
+SELECT TOP(2) [u].[Id], [u].[AccessFailedCount], [u].[ConcurrencyStamp], [u].[CreatedAt], [u].[DeletedAt], [u].[Email], [u].[EmailConfirmed], [u].[LastModifiedAt], [u].[LastModifiedBy], [u].[LockoutEnabled], [u].[LockoutEnd], [u].[NormalizedEmail], [u].[NormalizedUserName], [u].[PasswordHash], [u].[PhoneNumber], [u].[PhoneNumberConfirmed], [u].[SecurityStamp], [u].[TwoFactorEnabled], [u].[UserName]
+FROM [users] AS [u]
+WHERE [u].[NormalizedEmail] = @__normalizedEmail_0
+2025-10-04 03:02:17.247 +07:00 [INF] Executed DbCommand (5ms) [Parameters=[@__normalizedEmail_0='?' (Size = 4000)], CommandType='"Text"', CommandTimeout='30']
+SELECT TOP(2) [u].[Id], [u].[AccessFailedCount], [u].[ConcurrencyStamp], [u].[CreatedAt], [u].[DeletedAt], [u].[Email], [u].[EmailConfirmed], [u].[LastModifiedAt], [u].[LastModifiedBy], [u].[LockoutEnabled], [u].[LockoutEnd], [u].[NormalizedEmail], [u].[NormalizedUserName], [u].[PasswordHash], [u].[PhoneNumber], [u].[PhoneNumberConfirmed], [u].[SecurityStamp], [u].[TwoFactorEnabled], [u].[UserName]
+FROM [users] AS [u]
+WHERE [u].[NormalizedEmail] = @__normalizedEmail_0
+2025-10-04 03:02:17.285 +07:00 [DBG] Context 'MyDbContext' started tracking 'User' entity. Consider using 'DbContextOptionsBuilder.EnableSensitiveDataLogging' to see key values.
+2025-10-04 03:02:17.319 +07:00 [DBG] Closing data reader to 'capbot_db' on server 'localhost'.
+2025-10-04 03:02:17.320 +07:00 [DBG] A data reader for 'capbot_db' on server 'localhost' is being disposed after spending 72ms reading results.
+2025-10-04 03:02:17.320 +07:00 [DBG] Closing connection to database 'capbot_db' on server 'localhost'.
+2025-10-04 03:02:17.321 +07:00 [DBG] Closed connection to database 'capbot_db' on server 'localhost' (0ms).
+2025-10-04 03:02:17.325 +07:00 [INF] Admin user 'admin.capbot@gmail.com' already exists
+2025-10-04 03:02:17.328 +07:00 [DBG] Opening connection to database 'capbot_db' on server 'localhost'.
+2025-10-04 03:02:17.329 +07:00 [DBG] Opened connection to database 'capbot_db' on server 'localhost'.
+2025-10-04 03:02:17.329 +07:00 [DBG] Creating DbCommand for 'ExecuteReader'.
+2025-10-04 03:02:17.329 +07:00 [DBG] Created DbCommand for 'ExecuteReader' (0ms).
+2025-10-04 03:02:17.329 +07:00 [DBG] Initialized DbCommand for 'ExecuteReader' (0ms).
+2025-10-04 03:02:17.329 +07:00 [DBG] Executing DbCommand [Parameters=[@__normalizedEmail_0='?' (Size = 4000)], CommandType='"Text"', CommandTimeout='30']
+SELECT TOP(2) [u].[Id], [u].[AccessFailedCount], [u].[ConcurrencyStamp], [u].[CreatedAt], [u].[DeletedAt], [u].[Email], [u].[EmailConfirmed], [u].[LastModifiedAt], [u].[LastModifiedBy], [u].[LockoutEnabled], [u].[LockoutEnd], [u].[NormalizedEmail], [u].[NormalizedUserName], [u].[PasswordHash], [u].[PhoneNumber], [u].[PhoneNumberConfirmed], [u].[SecurityStamp], [u].[TwoFactorEnabled], [u].[UserName]
+FROM [users] AS [u]
+WHERE [u].[NormalizedEmail] = @__normalizedEmail_0
+2025-10-04 03:02:17.330 +07:00 [INF] Executed DbCommand (1ms) [Parameters=[@__normalizedEmail_0='?' (Size = 4000)], CommandType='"Text"', CommandTimeout='30']
+SELECT TOP(2) [u].[Id], [u].[AccessFailedCount], [u].[ConcurrencyStamp], [u].[CreatedAt], [u].[DeletedAt], [u].[Email], [u].[EmailConfirmed], [u].[LastModifiedAt], [u].[LastModifiedBy], [u].[LockoutEnabled], [u].[LockoutEnd], [u].[NormalizedEmail], [u].[NormalizedUserName], [u].[PasswordHash], [u].[PhoneNumber], [u].[PhoneNumberConfirmed], [u].[SecurityStamp], [u].[TwoFactorEnabled], [u].[UserName]
+FROM [users] AS [u]
+WHERE [u].[NormalizedEmail] = @__normalizedEmail_0
+2025-10-04 03:02:17.330 +07:00 [DBG] Context 'MyDbContext' started tracking 'User' entity. Consider using 'DbContextOptionsBuilder.EnableSensitiveDataLogging' to see key values.
+2025-10-04 03:02:17.331 +07:00 [DBG] Closing data reader to 'capbot_db' on server 'localhost'.
+2025-10-04 03:02:17.331 +07:00 [DBG] A data reader for 'capbot_db' on server 'localhost' is being disposed after spending 0ms reading results.
+2025-10-04 03:02:17.331 +07:00 [DBG] Closing connection to database 'capbot_db' on server 'localhost'.
+2025-10-04 03:02:17.331 +07:00 [DBG] Closed connection to database 'capbot_db' on server 'localhost' (0ms).
+2025-10-04 03:02:17.331 +07:00 [INF] Sample moderator 'moderator@example.com' already exists
+2025-10-04 03:02:17.331 +07:00 [DBG] Opening connection to database 'capbot_db' on server 'localhost'.
+2025-10-04 03:02:17.332 +07:00 [DBG] Opened connection to database 'capbot_db' on server 'localhost'.
+2025-10-04 03:02:17.332 +07:00 [DBG] Creating DbCommand for 'ExecuteReader'.
+2025-10-04 03:02:17.332 +07:00 [DBG] Created DbCommand for 'ExecuteReader' (0ms).
+2025-10-04 03:02:17.332 +07:00 [DBG] Initialized DbCommand for 'ExecuteReader' (0ms).
+2025-10-04 03:02:17.332 +07:00 [DBG] Executing DbCommand [Parameters=[@__normalizedEmail_0='?' (Size = 4000)], CommandType='"Text"', CommandTimeout='30']
+SELECT TOP(2) [u].[Id], [u].[AccessFailedCount], [u].[ConcurrencyStamp], [u].[CreatedAt], [u].[DeletedAt], [u].[Email], [u].[EmailConfirmed], [u].[LastModifiedAt], [u].[LastModifiedBy], [u].[LockoutEnabled], [u].[LockoutEnd], [u].[NormalizedEmail], [u].[NormalizedUserName], [u].[PasswordHash], [u].[PhoneNumber], [u].[PhoneNumberConfirmed], [u].[SecurityStamp], [u].[TwoFactorEnabled], [u].[UserName]
+FROM [users] AS [u]
+WHERE [u].[NormalizedEmail] = @__normalizedEmail_0
+2025-10-04 03:02:17.333 +07:00 [INF] Executed DbCommand (1ms) [Parameters=[@__normalizedEmail_0='?' (Size = 4000)], CommandType='"Text"', CommandTimeout='30']
+SELECT TOP(2) [u].[Id], [u].[AccessFailedCount], [u].[ConcurrencyStamp], [u].[CreatedAt], [u].[DeletedAt], [u].[Email], [u].[EmailConfirmed], [u].[LastModifiedAt], [u].[LastModifiedBy], [u].[LockoutEnabled], [u].[LockoutEnd], [u].[NormalizedEmail], [u].[NormalizedUserName], [u].[PasswordHash], [u].[PhoneNumber], [u].[PhoneNumberConfirmed], [u].[SecurityStamp], [u].[TwoFactorEnabled], [u].[UserName]
+FROM [users] AS [u]
+WHERE [u].[NormalizedEmail] = @__normalizedEmail_0
+2025-10-04 03:02:17.333 +07:00 [DBG] Context 'MyDbContext' started tracking 'User' entity. Consider using 'DbContextOptionsBuilder.EnableSensitiveDataLogging' to see key values.
+2025-10-04 03:02:17.334 +07:00 [DBG] Closing data reader to 'capbot_db' on server 'localhost'.
+2025-10-04 03:02:17.334 +07:00 [DBG] A data reader for 'capbot_db' on server 'localhost' is being disposed after spending 0ms reading results.
+2025-10-04 03:02:17.334 +07:00 [DBG] Closing connection to database 'capbot_db' on server 'localhost'.
+2025-10-04 03:02:17.334 +07:00 [DBG] Closed connection to database 'capbot_db' on server 'localhost' (0ms).
+2025-10-04 03:02:17.335 +07:00 [DBG] Opening connection to database 'capbot_db' on server 'localhost'.
+2025-10-04 03:02:17.335 +07:00 [DBG] Opened connection to database 'capbot_db' on server 'localhost'.
+2025-10-04 03:02:17.335 +07:00 [DBG] Creating DbCommand for 'ExecuteReader'.
+2025-10-04 03:02:17.335 +07:00 [DBG] Created DbCommand for 'ExecuteReader' (0ms).
+2025-10-04 03:02:17.335 +07:00 [DBG] Initialized DbCommand for 'ExecuteReader' (0ms).
+2025-10-04 03:02:17.335 +07:00 [DBG] Executing DbCommand [Parameters=[@__normalizedEmail_0='?' (Size = 4000)], CommandType='"Text"', CommandTimeout='30']
+SELECT TOP(2) [u].[Id], [u].[AccessFailedCount], [u].[ConcurrencyStamp], [u].[CreatedAt], [u].[DeletedAt], [u].[Email], [u].[EmailConfirmed], [u].[LastModifiedAt], [u].[LastModifiedBy], [u].[LockoutEnabled], [u].[LockoutEnd], [u].[NormalizedEmail], [u].[NormalizedUserName], [u].[PasswordHash], [u].[PhoneNumber], [u].[PhoneNumberConfirmed], [u].[SecurityStamp], [u].[TwoFactorEnabled], [u].[UserName]
+FROM [users] AS [u]
+WHERE [u].[NormalizedEmail] = @__normalizedEmail_0
+2025-10-04 03:02:17.338 +07:00 [INF] Executed DbCommand (2ms) [Parameters=[@__normalizedEmail_0='?' (Size = 4000)], CommandType='"Text"', CommandTimeout='30']
+SELECT TOP(2) [u].[Id], [u].[AccessFailedCount], [u].[ConcurrencyStamp], [u].[CreatedAt], [u].[DeletedAt], [u].[Email], [u].[EmailConfirmed], [u].[LastModifiedAt], [u].[LastModifiedBy], [u].[LockoutEnabled], [u].[LockoutEnd], [u].[NormalizedEmail], [u].[NormalizedUserName], [u].[PasswordHash], [u].[PhoneNumber], [u].[PhoneNumberConfirmed], [u].[SecurityStamp], [u].[TwoFactorEnabled], [u].[UserName]
+FROM [users] AS [u]
+WHERE [u].[NormalizedEmail] = @__normalizedEmail_0
+2025-10-04 03:02:17.339 +07:00 [DBG] Context 'MyDbContext' started tracking 'User' entity. Consider using 'DbContextOptionsBuilder.EnableSensitiveDataLogging' to see key values.
+2025-10-04 03:02:17.339 +07:00 [DBG] Closing data reader to 'capbot_db' on server 'localhost'.
+2025-10-04 03:02:17.340 +07:00 [DBG] A data reader for 'capbot_db' on server 'localhost' is being disposed after spending 1ms reading results.
+2025-10-04 03:02:17.340 +07:00 [DBG] Closing connection to database 'capbot_db' on server 'localhost'.
+2025-10-04 03:02:17.340 +07:00 [DBG] Closed connection to database 'capbot_db' on server 'localhost' (0ms).
+2025-10-04 03:02:17.340 +07:00 [INF] Data seeding completed successfully
+2025-10-04 03:02:17.342 +07:00 [DBG] 'MyDbContext' disposed.
+2025-10-04 03:02:17.343 +07:00 [DBG] Disposing connection to database 'capbot_db' on server 'localhost'.
+2025-10-04 03:02:17.345 +07:00 [DBG] Disposed connection to database '' on server '' (0ms).
+2025-10-04 03:02:17.365 +07:00 [DBG] Registered SignalR Protocol: json, implemented by Microsoft.AspNetCore.SignalR.Protocol.JsonHubProtocol.
+2025-10-04 03:02:17.560 +07:00 [DBG] Registered model binder providers, in the following order: ["Microsoft.AspNetCore.Mvc.ModelBinding.Binders.BinderTypeModelBinderProvider","Microsoft.AspNetCore.Mvc.ModelBinding.Binders.ServicesModelBinderProvider","Microsoft.AspNetCore.Mvc.ModelBinding.Binders.BodyModelBinderProvider","Microsoft.AspNetCore.Mvc.ModelBinding.Binders.HeaderModelBinderProvider","Microsoft.AspNetCore.Mvc.ModelBinding.Binders.FloatingPointTypeModelBinderProvider","Microsoft.AspNetCore.Mvc.ModelBinding.Binders.EnumTypeModelBinderProvider","Microsoft.AspNetCore.Mvc.ModelBinding.Binders.DateTimeModelBinderProvider","Microsoft.AspNetCore.Mvc.ModelBinding.Binders.SimpleTypeModelBinderProvider","Microsoft.AspNetCore.Mvc.ModelBinding.Binders.TryParseModelBinderProvider","Microsoft.AspNetCore.Mvc.ModelBinding.Binders.CancellationTokenModelBinderProvider"]
+2025-10-04 03:02:17.696 +07:00 [DBG] Hosting starting
+2025-10-04 03:02:17.708 +07:00 [DBG] Reading data from file 'C:\Users\acer\AppData\Local\ASP.NET\DataProtection-Keys\key-30a711c8-7ddc-4a0d-8c07-4439effde9db.xml'.
+2025-10-04 03:02:17.714 +07:00 [DBG] Reading data from file 'C:\Users\acer\AppData\Local\ASP.NET\DataProtection-Keys\key-732ee668-a56c-4fc9-b9d2-4188dc372919.xml'.
+2025-10-04 03:02:17.715 +07:00 [DBG] Reading data from file 'C:\Users\acer\AppData\Local\ASP.NET\DataProtection-Keys\key-ad0e504d-5eaf-4fbc-adde-d8f26319af02.xml'.
+2025-10-04 03:02:17.719 +07:00 [DBG] Found key {30a711c8-7ddc-4a0d-8c07-4439effde9db}.
+2025-10-04 03:02:17.724 +07:00 [DBG] Found key {732ee668-a56c-4fc9-b9d2-4188dc372919}.
+2025-10-04 03:02:17.724 +07:00 [DBG] Found key {ad0e504d-5eaf-4fbc-adde-d8f26319af02}.
+2025-10-04 03:02:17.730 +07:00 [DBG] Considering key {30a711c8-7ddc-4a0d-8c07-4439effde9db} with expiration date 2025-11-11 18:32:26Z as default key.
+2025-10-04 03:02:17.734 +07:00 [DBG] Forwarded activator type request from Microsoft.AspNetCore.DataProtection.XmlEncryption.DpapiXmlDecryptor, Microsoft.AspNetCore.DataProtection, Version=8.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60 to Microsoft.AspNetCore.DataProtection.XmlEncryption.DpapiXmlDecryptor, Microsoft.AspNetCore.DataProtection, Culture=neutral, PublicKeyToken=adb9793829ddae60
+2025-10-04 03:02:17.734 +07:00 [DBG] Decrypting secret element using Windows DPAPI.
+2025-10-04 03:02:17.736 +07:00 [DBG] Forwarded activator type request from Microsoft.AspNetCore.DataProtection.AuthenticatedEncryption.ConfigurationModel.AuthenticatedEncryptorDescriptorDeserializer, Microsoft.AspNetCore.DataProtection, Version=8.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60 to Microsoft.AspNetCore.DataProtection.AuthenticatedEncryption.ConfigurationModel.AuthenticatedEncryptorDescriptorDeserializer, Microsoft.AspNetCore.DataProtection, Culture=neutral, PublicKeyToken=adb9793829ddae60
+2025-10-04 03:02:17.738 +07:00 [DBG] Opening CNG algorithm 'AES' from provider 'null' with chaining mode CBC.
+2025-10-04 03:02:17.741 +07:00 [DBG] Opening CNG algorithm 'SHA256' from provider 'null' with HMAC.
+2025-10-04 03:02:17.745 +07:00 [DBG] Using key {30a711c8-7ddc-4a0d-8c07-4439effde9db} as the default key.
+2025-10-04 03:02:17.745 +07:00 [DBG] Key ring with default key {30a711c8-7ddc-4a0d-8c07-4439effde9db} was loaded during application startup.
+2025-10-04 03:02:17.802 +07:00 [INF] Now listening on: http://localhost:5207
+2025-10-04 03:02:17.803 +07:00 [DBG] Loaded hosting startup assembly CapBot.api
+2025-10-04 03:02:17.804 +07:00 [DBG] Loaded hosting startup assembly Microsoft.AspNetCore.Watch.BrowserRefresh
+2025-10-04 03:02:17.805 +07:00 [INF] Application started. Press Ctrl+C to shut down.
+2025-10-04 03:02:17.805 +07:00 [INF] Hosting environment: Development
+2025-10-04 03:02:17.805 +07:00 [INF] Content root path: C:\Users\acer\Downloads\CBAI_API\capbot.api
+2025-10-04 03:02:17.807 +07:00 [DBG] Hosting started
+2025-10-04 03:02:17.979 +07:00 [DBG] Connection id "0HNG2MV0M178S" accepted.
+2025-10-04 03:02:17.981 +07:00 [DBG] Connection id "0HNG2MV0M178S" started.
+2025-10-04 03:02:18.210 +07:00 [DBG] Connection id "0HNG2MV0M178T" accepted.
+2025-10-04 03:02:18.211 +07:00 [DBG] Connection id "0HNG2MV0M178T" started.
+2025-10-04 03:02:18.395 +07:00 [INF] Request starting HTTP/1.1 GET http://localhost:5207/index.html - null null
+2025-10-04 03:02:18.481 +07:00 [DBG] Wildcard detected, all requests with hosts will be allowed.
+2025-10-04 03:02:18.685 +07:00 [DBG] Response markup is scheduled to include browser refresh script injection.
+2025-10-04 03:02:18.706 +07:00 [DBG] Response markup was updated to include browser refresh script injection.
+2025-10-04 03:02:18.706 +07:00 [DBG] Connection id "0HNG2MV0M178S" completed keep alive response.
+2025-10-04 03:02:18.709 +07:00 [INF] Request finished HTTP/1.1 GET http://localhost:5207/index.html - 200 null text/html;charset=utf-8 375.1191ms
+2025-10-04 03:02:18.747 +07:00 [INF] Request starting HTTP/1.1 GET http://localhost:5207/_framework/aspnetcore-browser-refresh.js - null null
+2025-10-04 03:02:18.760 +07:00 [DBG] Connection id "0HNG2MV0M178S" completed keep alive response.
+2025-10-04 03:02:18.763 +07:00 [INF] Request finished HTTP/1.1 GET http://localhost:5207/_framework/aspnetcore-browser-refresh.js - 200 13732 application/javascript; charset=utf-8 13.7023ms
+2025-10-04 03:02:18.919 +07:00 [INF] Request starting HTTP/1.1 GET http://localhost:5207/swagger/v1/swagger.json - null null
+2025-10-04 03:02:19.582 +07:00 [DBG] Connection id "0HNG2MV0M178S" completed keep alive response.
+2025-10-04 03:02:19.583 +07:00 [INF] Request finished HTTP/1.1 GET http://localhost:5207/swagger/v1/swagger.json - 200 null application/json;charset=utf-8 663.2865ms
+2025-10-04 03:02:41.769 +07:00 [INF] Application is shutting down...
+2025-10-04 03:02:41.770 +07:00 [DBG] Hosting stopping
+2025-10-04 03:02:41.779 +07:00 [DBG] Connection id "0HNG2MV0M178T" disconnecting.
+2025-10-04 03:02:41.779 +07:00 [DBG] Connection id "0HNG2MV0M178S" disconnecting.
+2025-10-04 03:02:41.781 +07:00 [DBG] Connection id "0HNG2MV0M178S" stopped.
+2025-10-04 03:02:41.781 +07:00 [DBG] Connection id "0HNG2MV0M178T" stopped.
+2025-10-04 03:02:41.783 +07:00 [DBG] Connection id "0HNG2MV0M178S" sending FIN because: "The Socket transport's send loop completed gracefully."
+2025-10-04 03:02:41.783 +07:00 [DBG] Connection id "0HNG2MV0M178T" sending FIN because: "The Socket transport's send loop completed gracefully."
+2025-10-04 03:02:41.789 +07:00 [ERR] Lỗi khi kiểm tra deadline notifications
+System.Threading.Tasks.TaskCanceledException: A task was canceled.
+   at CapBot.api.Services.DeadlineNotificationService.ExecuteAsync(CancellationToken stoppingToken) in C:\Users\acer\Downloads\CBAI_API\capbot.api\Services\DeadlineNotificationService.cs:line 41
+2025-10-04 03:02:41.800 +07:00 [DBG] Hosting stopped


### PR DESCRIPTION
This pull request updates the logic for determining the latest submission information in the `TopicDetailDTO` constructor to more accurately represent the current topic version's state. The main change ensures that, when available, submission data for the current topic version is preferred, with a fallback to the latest submission across all versions if necessary.

**Improvements to submission status logic:**

* The constructor now prioritizes finding the latest submission date and status (`LatestSubmittedAt` and `LatestSubmissionStatus`) for the current topic version, if one exists. If no submissions exist for the current version, it falls back to the latest submission for the topic overall. This ensures the DTO reflects the most relevant submission state for the topic version being viewed.… logic